### PR TITLE
feat(cli/invoke): add support for direct tool invocation from CLI

### DIFF
--- a/cmd/invoke_tool_test.go
+++ b/cmd/invoke_tool_test.go
@@ -1,0 +1,131 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInvokeTool(t *testing.T) {
+	// Create a temporary tools file
+	tmpDir := t.TempDir()
+
+	toolsFileContent := `
+sources:
+  my-sqlite:
+    kind: sqlite
+    database: test.db
+tools:
+  hello-sqlite:
+    kind: sqlite-sql
+    source: my-sqlite
+    description: "hello tool"
+    statement: "SELECT 'hello' as greeting"
+  echo-tool:
+    kind: sqlite-sql
+    source: my-sqlite
+    description: "echo tool"
+    statement: "SELECT ? as msg"
+    parameters:
+      - name: message
+        type: string
+        description: message to echo
+`
+
+	toolsFilePath := filepath.Join(tmpDir, "tools.yaml")
+	if err := os.WriteFile(toolsFilePath, []byte(toolsFileContent), 0644); err != nil {
+		t.Fatalf("failed to write tools file: %v", err)
+	}
+
+	tcs := []struct {
+		desc    string
+		args    []string
+		want    string
+		wantErr bool
+		errStr  string
+	}{
+		{
+			desc: "success - basic tool call",
+			args: []string{"invoke", "hello-sqlite", "--tools-file", toolsFilePath},
+			want: `"greeting": "hello"`,
+		},
+		{
+			desc: "success - tool call with parameters",
+			args: []string{"invoke", "echo-tool", `{"message": "world"}`, "--tools-file", toolsFilePath},
+			want: `"msg": "world"`,
+		},
+		{
+			desc:    "error - tool not found",
+			args:    []string{"invoke", "non-existent", "--tools-file", toolsFilePath},
+			wantErr: true,
+			errStr:  `tool "non-existent" not found`,
+		},
+		{
+			desc:    "error - invalid JSON params",
+			args:    []string{"invoke", "echo-tool", `invalid-json`, "--tools-file", toolsFilePath},
+			wantErr: true,
+			errStr:  `params must be a valid JSON string`,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			_, got, err := invokeCommandWithContext(context.Background(), tc.args)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("got error %v, wantErr %v", err, tc.wantErr)
+			}
+			if tc.wantErr && !strings.Contains(err.Error(), tc.errStr) {
+				t.Fatalf("got error %v, want error containing %q", err, tc.errStr)
+			}
+			if !tc.wantErr && !strings.Contains(got, tc.want) {
+				t.Fatalf("got %q, want it to contain %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestInvokeTool_AuthUnsupported(t *testing.T) {
+	tmpDir := t.TempDir()
+	toolsFileContent := `
+sources:
+  my-bq:
+    kind: bigquery
+    project: my-project
+    useClientOAuth: true
+tools:
+  bq-tool:
+    kind: bigquery-sql
+    source: my-bq
+    description: "bq tool"
+    statement: "SELECT 1"
+`
+	toolsFilePath := filepath.Join(tmpDir, "auth_tools.yaml")
+	if err := os.WriteFile(toolsFilePath, []byte(toolsFileContent), 0644); err != nil {
+		t.Fatalf("failed to write tools file: %v", err)
+	}
+
+	args := []string{"invoke", "bq-tool", "--tools-file", toolsFilePath}
+	_, _, err := invokeCommandWithContext(context.Background(), args)
+	if err == nil {
+		t.Fatal("expected error for tool requiring client auth, but got nil")
+	}
+	if !strings.Contains(err.Error(), "client authorization is not supported") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+}

--- a/docs/en/how-to/invoke_tool.md
+++ b/docs/en/how-to/invoke_tool.md
@@ -1,0 +1,74 @@
+---
+title: "Invoke Tools via CLI"
+type: docs
+weight: 10
+description: >
+  Learn how to invoke your tools directly from the command line using the `invoke` command.
+---
+
+The `invoke` command allows you to invoke tools defined in your configuration directly from the CLI. This is useful for:
+
+- **Ephemeral Invocation:** Executing a tool without spinning up a full MCP server/client.
+- **Debugging:** Isolating tool execution logic and testing with various parameter combinations.
+
+{{< notice tip >}}
+**Keep configurations minimal:** The `invoke` command initializes *all* resources (sources, tools, etc.) defined in your configuration files during execution. To ensure fast response times, consider using a minimal configuration file containing only the tools you need for the specific invocation.
+{{< notice tip >}}
+
+## Prerequisites
+
+- You have the `toolbox` binary installed or built.
+- You have a valid tool configuration file (e.g., `tools.yaml`).
+
+## Basic Usage
+
+The basic syntax for the command is:
+
+```bash
+toolbox [--tools-file <path> | --prebuilt <name>] invoke <tool-name> [params]
+```
+
+- `<tool-name>`: The name of the tool you want to call. This must match the name defined in your `tools.yaml`.
+- `[params]`: (Optional) A JSON string representing the arguments for the tool.
+
+## Examples
+
+### 1. Calling a Tool without Parameters
+
+If your tool takes no parameters, simply provide the tool name:
+
+```bash
+toolbox  --tools-file tools.yaml invoke my-simple-tool
+```
+
+### 2. Calling a Tool with Parameters
+
+For tools that require arguments, pass them as a JSON string. Ensure you escape quotes correctly for your shell.
+
+**Example: A tool that takes parameters**
+
+Assuming a tool named `mytool` taking `a` and `b`:
+
+```bash
+toolbox --tools-file tools.yaml invoke mytool '{"a": 10, "b": 20}' 
+```
+
+**Example: A tool that queries a database**
+
+```bash
+toolbox  --tools-file tools.yaml invoke db-query '{"sql": "SELECT * FROM users LIMIT 5"}'
+```
+
+### 3. Using Prebuilt Configurations
+
+You can also use the `--prebuilt` flag to load prebuilt toolsets.
+
+```bash
+toolbox --prebuilt cloudsql-postgres invoke cloudsql-postgres-list-instances
+```
+
+## Troubleshooting
+
+- **Tool not found:** Ensure the `<tool-name>` matches exactly what is in your YAML file and that the file is correctly loaded via `--tools-file`.
+- **Invalid parameters:** Double-check your JSON syntax. The error message will usually indicate if the JSON parsing failed or if the parameters didn't match the tool's schema.
+- **Auth errors:** The `invoke` command currently does not support flows requiring client-side authorization (like OAuth flow initiation via the CLI). It works best for tools using service-side authentication (e.g., Application Default Credentials).

--- a/docs/en/reference/cli.md
+++ b/docs/en/reference/cli.md
@@ -30,6 +30,21 @@ description: >
 |              | `--user-agent-metadata`    | Appends additional metadata to the User-Agent.                                                                                                                                   |             |
 | `-v`         | `--version`                | version for toolbox                                                                                                                                                              |             |
 
+## Sub Commands
+
+### `invoke`
+
+Executes a tool directly with the provided parameters. This is useful for testing tool configurations and parameters without needing a full client setup.
+
+**Syntax:**
+
+```bash
+toolbox invoke <tool-name> [params]
+```
+
+- `<tool-name>`: The name of the tool to execute (as defined in your configuration).
+- `[params]`: (Optional) A JSON string containing the parameters for the tool.
+
 ## Examples
 
 ### Transport Configuration

--- a/internal/cli/invoke/command.go
+++ b/internal/cli/invoke/command.go
@@ -1,0 +1,161 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package invoke
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/googleapis/genai-toolbox/internal/log"
+	"github.com/googleapis/genai-toolbox/internal/server"
+	"github.com/googleapis/genai-toolbox/internal/server/resources"
+	"github.com/googleapis/genai-toolbox/internal/util/parameters"
+	"github.com/spf13/cobra"
+)
+
+// RootCommand defines the interface for required by invoke subcommand.
+// This allows subcommands to access shared resources and functionality without
+// direct coupling to the root command's implementation.
+type RootCommand interface {
+	// Config returns a copy of the current server configuration.
+	Config() server.ServerConfig
+
+	// Out returns the writer used for standard output.
+	Out() io.Writer
+
+	// LoadConfig loads and merges the configuration from files, folders, and prebuilts.
+	LoadConfig(ctx context.Context) error
+
+	// Setup initializes the runtime environment, including logging and telemetry.
+	// It returns the updated context and a shutdown function to be called when finished.
+	Setup(ctx context.Context) (context.Context, func(context.Context) error, error)
+
+	// Logger returns the logger instance.
+	Logger() log.Logger
+}
+
+func NewCommand(rootCmd RootCommand) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "invoke <tool-name> [params]",
+		Short: "Execute a tool directly",
+		Long: `Execute a tool directly with parameters.
+Params must be a JSON string.
+Example:
+  toolbox invoke my-tool '{"param1": "value1"}'`,
+		Args: cobra.MinimumNArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			return runInvoke(c, args, rootCmd)
+		},
+	}
+	return cmd
+}
+
+func runInvoke(cmd *cobra.Command, args []string, rootCmd RootCommand) error {
+	ctx, cancel := context.WithCancel(cmd.Context())
+	defer cancel()
+
+	ctx, shutdown, err := rootCmd.Setup(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = shutdown(ctx)
+	}()
+
+	// Load and merge tool configurations
+	if err := rootCmd.LoadConfig(ctx); err != nil {
+		return err
+	}
+
+	// Initialize Resources
+	sourcesMap, authServicesMap, embeddingModelsMap, toolsMap, toolsetsMap, promptsMap, promptsetsMap, err := server.InitializeConfigs(ctx, rootCmd.Config())
+	if err != nil {
+		errMsg := fmt.Errorf("failed to initialize resources: %w", err)
+		rootCmd.Logger().ErrorContext(ctx, errMsg.Error())
+		return errMsg
+	}
+
+	resourceMgr := resources.NewResourceManager(sourcesMap, authServicesMap, embeddingModelsMap, toolsMap, toolsetsMap, promptsMap, promptsetsMap)
+
+	// Execute Tool
+	toolName := args[0]
+	tool, ok := resourceMgr.GetTool(toolName)
+	if !ok {
+		errMsg := fmt.Errorf("tool %q not found", toolName)
+		rootCmd.Logger().ErrorContext(ctx, errMsg.Error())
+		return errMsg
+	}
+
+	var paramsInput string
+	if len(args) > 1 {
+		paramsInput = args[1]
+	}
+
+	params := make(map[string]any)
+	if paramsInput != "" {
+		if err := json.Unmarshal([]byte(paramsInput), &params); err != nil {
+			errMsg := fmt.Errorf("params must be a valid JSON string: %w", err)
+			rootCmd.Logger().ErrorContext(ctx, errMsg.Error())
+			return errMsg
+		}
+	}
+
+	parsedParams, err := parameters.ParseParams(tool.GetParameters(), params, nil)
+	if err != nil {
+		errMsg := fmt.Errorf("invalid parameters: %w", err)
+		rootCmd.Logger().ErrorContext(ctx, errMsg.Error())
+		return errMsg
+	}
+
+	parsedParams, err = tool.EmbedParams(ctx, parsedParams, resourceMgr.GetEmbeddingModelMap())
+	if err != nil {
+		errMsg := fmt.Errorf("error embedding parameters: %w", err)
+		rootCmd.Logger().ErrorContext(ctx, errMsg.Error())
+		return errMsg
+	}
+
+	// Client Auth not supported for ephemeral CLI call
+	requiresAuth, err := tool.RequiresClientAuthorization(resourceMgr)
+	if err != nil {
+		errMsg := fmt.Errorf("failed to check auth requirements: %w", err)
+		rootCmd.Logger().ErrorContext(ctx, errMsg.Error())
+		return errMsg
+	}
+	if requiresAuth {
+		errMsg := fmt.Errorf("client authorization is not supported")
+		rootCmd.Logger().ErrorContext(ctx, errMsg.Error())
+		return errMsg
+	}
+
+	result, err := tool.Invoke(ctx, resourceMgr, parsedParams, "")
+	if err != nil {
+		errMsg := fmt.Errorf("tool execution failed: %w", err)
+		rootCmd.Logger().ErrorContext(ctx, errMsg.Error())
+		return errMsg
+	}
+
+	// Print Result
+	output, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		errMsg := fmt.Errorf("failed to marshal result: %w", err)
+		rootCmd.Logger().ErrorContext(ctx, errMsg.Error())
+		return errMsg
+	}
+	fmt.Fprintln(rootCmd.Out(), string(output))
+
+	return nil
+}

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -22,6 +22,18 @@ import (
 	"strings"
 )
 
+// NewLogger creates a new logger based on the provided format and level.
+func NewLogger(format, level string, out, err io.Writer) (Logger, error) {
+	switch strings.ToLower(format) {
+	case "json":
+		return NewStructuredLogger(out, err, level)
+	case "standard":
+		return NewStdLogger(out, err, level)
+	default:
+		return nil, fmt.Errorf("logging format invalid: %s", format)
+	}
+}
+
 // StdLogger is the standard logger
 type StdLogger struct {
 	outLogger *slog.Logger


### PR DESCRIPTION
## Description

This PR introduces a new subcommand, invoke, to the toolbox CLI. This feature allows developers to execute tools defined in their configuration directly from the command line.

- New Subcommand: Implemented invoke as subcommand, which handles tool lookup, parameter unmarshaling from JSON, and invocation.
- Persistent Configuration Flags: Updated cmd/root.go to make flags like --tools-file, --tools-folder, and --prebuilt persistent, allowing them to be used with subcommands.
- Testing: Added unit tests for various scenarios
- Documentation: Created a new "how-to" guide for CLI tool testing and updated the CLI reference documentation.
