### PR TITLE
feat(config): allow partial source init with summary

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -37,6 +37,14 @@ Before you begin, ensure you have the following:
     go run .
     ```
 
+    * **Allowing Partial Startup:** During local development or active configuration, you can pass the `--allow-partial-startup` flag to prevent the server from crashing if some sources, tools, or prompts fail to initialize:
+
+        ```bash
+        go run . --allow-partial-startup
+        ```
+
+        Failure summaries will be logged in console warnings, allowing you to debug individual connection/configuration issues while keeping the rest of the server active.
+
 1. **Testing the Endpoint:** Verify the server is running by sending a request
    to the endpoint:
 

--- a/cmd/internal/flags.go
+++ b/cmd/internal/flags.go
@@ -67,6 +67,7 @@ func ServeFlags(flags *pflag.FlagSet, opts *ToolboxOptions) {
 	flags.BoolVar(&opts.Cfg.Stdio, "stdio", false, "Listens via MCP STDIO instead of acting as a remote HTTP server.")
 	flags.BoolVar(&opts.Cfg.UI, "ui", false, "Launches the Toolbox UI web server.")
 	flags.BoolVar(&opts.Cfg.EnableAPI, "enable-api", false, "Enable the /api endpoint.")
+	flags.BoolVar(&opts.Cfg.AllowPartialStartup, "allow-partial-startup", false, "Continue startup when some sources, tools or prompts fail to initialize; failures are logged in a summary.")
 	flags.StringVar(&opts.Cfg.ToolboxUrl, "toolbox-url", "", "Specifies the Toolbox URL. Used as the resource field in the MCP PRM file when MCP Auth is enabled. Falls back to TOOLBOX_URL environment variable.")
 	flags.StringVar(&opts.Cfg.McpPrmFile, "mcp-prm-file", "", "Path to a manual Protected Resource Metadata (PRM) JSON file. If provided, overrides auto-generation.")
 	flags.StringSliceVar(&opts.Cfg.AllowedOrigins, "allowed-origins", []string{"*"}, "Specifies a list of origins permitted to access this server. Defaults to '*'.")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -138,7 +138,7 @@ func handleDynamicReload(ctx context.Context, toolsFile internal.Config, s *serv
 		panic(err)
 	}
 
-	sourcesMap, authServicesMap, embeddingModelsMap, toolsMap, toolsetsMap, promptsMap, promptsetsMap, err := validateReloadEdits(ctx, toolsFile)
+	sourcesMap, authServicesMap, embeddingModelsMap, toolsMap, toolsetsMap, promptsMap, promptsetsMap, err := validateReloadEdits(ctx, toolsFile, s.AllowPartialStartup())
 	if err != nil {
 		errMsg := fmt.Errorf("unable to validate reloaded edits: %w", err)
 		logger.WarnContext(ctx, errMsg.Error())
@@ -152,7 +152,7 @@ func handleDynamicReload(ctx context.Context, toolsFile internal.Config, s *serv
 
 // validateReloadEdits checks that the reloaded config configs can initialized without failing
 func validateReloadEdits(
-	ctx context.Context, toolsFile internal.Config,
+	ctx context.Context, toolsFile internal.Config, allowPartial bool,
 ) (map[string]sources.Source, map[string]auth.AuthService, map[string]embeddingmodels.EmbeddingModel, map[string]tools.Tool, map[string]tools.Toolset, map[string]prompts.Prompt, map[string]prompts.Promptset, error,
 ) {
 	logger, err := util.LoggerFromContext(ctx)
@@ -178,6 +178,7 @@ func validateReloadEdits(
 		ToolConfigs:           toolsFile.Tools,
 		ToolsetConfigs:        toolsFile.Toolsets,
 		PromptConfigs:         toolsFile.Prompts,
+		AllowPartialStartup:   allowPartial,
 	}
 
 	sourcesMap, authServicesMap, embeddingModelsMap, toolsMap, toolsetsMap, promptsMap, promptsetsMap, err := server.InitializeConfigs(ctx, reloadedConfig)

--- a/internal/prompts/promptsets.go
+++ b/internal/prompts/promptsets.go
@@ -52,7 +52,7 @@ type PromptsetManifest struct {
 	PromptsManifest map[string]Manifest `json:"prompts"`
 }
 
-func (p PromptsetConfig) Initialize(serverVersion string, promptsMap map[string]Prompt) (Promptset, error) {
+func (p PromptsetConfig) Initialize(serverVersion string, promptsMap map[string]Prompt, allowPartial bool) (Promptset, []string, error) {
 	// Check each declared prompt name exists
 	promptset := Promptset{
 		PromptsetConfig: p,
@@ -64,17 +64,22 @@ func (p PromptsetConfig) Initialize(serverVersion string, promptsMap map[string]
 		PromptNameSet: make(map[string]struct{}, len(p.PromptNames)),
 	}
 	if !tools.IsValidName(promptset.Name) {
-		return promptset, fmt.Errorf("invalid promptset name: %s", promptset.Name)
+		return promptset, nil, fmt.Errorf("invalid promptset name: %s", promptset.Name)
 	}
+	var missing []string
 	for _, promptName := range p.PromptNames {
 		prompt, ok := promptsMap[promptName]
 		if !ok {
-			return promptset, fmt.Errorf("prompt does not exist: %s", promptName)
+			if allowPartial {
+				missing = append(missing, promptName)
+				continue
+			}
+			return promptset, nil, fmt.Errorf("prompt does not exist: %s", promptName)
 		}
 		promptset.Prompts = append(promptset.Prompts, &prompt)
 		promptset.Manifest.PromptsManifest[promptName] = prompt.Manifest()
 		promptset.PromptNameSet[promptName] = struct{}{}
 	}
 
-	return promptset, nil
+	return promptset, missing, nil
 }

--- a/internal/prompts/promptsets_test.go
+++ b/internal/prompts/promptsets_test.go
@@ -234,7 +234,7 @@ func TestPromptsetConfig_Initialize(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := tc.config.Initialize(serverVersion, promptsMap)
+			got, _, err := tc.config.Initialize(serverVersion, promptsMap, false)
 
 			if tc.wantErr != "" {
 				if err == nil {
@@ -261,5 +261,32 @@ func TestPromptsetConfig_Initialize(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestPromptsetConfig_Initialize_Partial verifies allowPartial=true skips missing
+// prompts and surfaces them in the returned missing slice.
+func TestPromptsetConfig_Initialize_Partial(t *testing.T) {
+	t.Parallel()
+
+	promptsMap := map[string]prompts.Prompt{
+		"prompt1": testutils.NewMockPrompt("prompt1", "First test prompt", prompts.Arguments{}),
+	}
+	serverVersion := "v1.0.0"
+
+	cfg := prompts.PromptsetConfig{
+		Name:        "partial-set",
+		PromptNames: []string{"prompt1", "ghost-prompt"},
+	}
+
+	got, missing, err := cfg.Initialize(serverVersion, promptsMap, true)
+	if err != nil {
+		t.Fatalf("Initialize() with allowPartial=true returned unexpected error: %v", err)
+	}
+	if len(missing) != 1 || missing[0] != "ghost-prompt" {
+		t.Errorf("missing slice = %v, want [ghost-prompt]", missing)
+	}
+	if len(got.Prompts) != 1 {
+		t.Errorf("got %d prompts, want 1 (only the valid one)", len(got.Prompts))
 	}
 }

--- a/internal/server/common_test.go
+++ b/internal/server/common_test.go
@@ -84,7 +84,7 @@ func setUpResources(t *testing.T, mockTools []testutils.MockTool, mockPrompts []
 		"tool2_only": {allTools[1]},
 	} {
 		tc := tools.ToolsetConfig{Name: name, ToolNames: l}
-		m, err := tc.Initialize(fakeVersionString, toolsMap)
+		m, _, err := tc.Initialize(fakeVersionString, toolsMap, false)
 		if err != nil {
 			t.Fatalf("unable to initialize toolset %q: %s", name, err)
 		}
@@ -101,7 +101,7 @@ func setUpResources(t *testing.T, mockTools []testutils.MockTool, mockPrompts []
 	promptsets := make(map[string]prompts.Promptset)
 	if len(allPrompts) > 0 {
 		psc := prompts.PromptsetConfig{Name: "", PromptNames: allPrompts}
-		ps, err := psc.Initialize(fakeVersionString, promptsMap)
+		ps, _, err := psc.Initialize(fakeVersionString, promptsMap, false)
 		if err != nil {
 			t.Fatalf("unable to initialize default promptset: %s", err)
 		}

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -74,6 +74,8 @@ type ServerConfig struct {
 	Stdio bool
 	// DisableReload indicates if the user has disabled dynamic reloading for Toolbox.
 	DisableReload bool
+	// AllowPartialStartup indicates whether initialization should continue when some components fail.
+	AllowPartialStartup bool
 	// UI indicates if Toolbox UI endpoints (/ui) are available.
 	UI bool
 	// EnableAPI indicates if the /api endpoint is enabled.

--- a/internal/server/mcp/v20241105/manifests_test.go
+++ b/internal/server/mcp/v20241105/manifests_test.go
@@ -124,7 +124,7 @@ func TestGenerateListToolsResult(t *testing.T) {
 		Name:      "test-toolset",
 		ToolNames: []string{"no_params", "some_params"},
 	}
-	toolset, err := tc.Initialize("test-version", toolsMap)
+	toolset, _, err := tc.Initialize("test-version", toolsMap, false)
 	if err != nil {
 		t.Fatalf("unable to initialize toolset %q: %s", "test-toolset", err)
 	}
@@ -237,7 +237,7 @@ func TestGenerateListPromptsResult(t *testing.T) {
 		Name:        "test-promptset",
 		PromptNames: []string{"prompt1", "prompt2"},
 	}
-	promptset, err := pc.Initialize("test-version", promptsMap)
+	promptset, _, err := pc.Initialize("test-version", promptsMap, false)
 	if err != nil {
 		t.Fatalf("unable to initialize promptset %q: %s", "test-promptset", err)
 	}

--- a/internal/server/mcp/v20250326/manifests_test.go
+++ b/internal/server/mcp/v20250326/manifests_test.go
@@ -197,7 +197,7 @@ func TestGenerateListToolsResult(t *testing.T) {
 		Name:      "test-toolset",
 		ToolNames: []string{"no_params", "some_params"},
 	}
-	toolset, err := tc.Initialize("test-version", toolsMap)
+	toolset, _, err := tc.Initialize("test-version", toolsMap, false)
 	if err != nil {
 		t.Fatalf("unable to initialize toolset %q: %s", "test-toolset", err)
 	}
@@ -310,7 +310,7 @@ func TestGenerateListPromptsResult(t *testing.T) {
 		Name:        "test-promptset",
 		PromptNames: []string{"prompt1", "prompt2"},
 	}
-	promptset, err := pc.Initialize("test-version", promptsMap)
+	promptset, _, err := pc.Initialize("test-version", promptsMap, false)
 	if err != nil {
 		t.Fatalf("unable to initialize promptset %q: %s", "test-promptset", err)
 	}

--- a/internal/server/mcp/v20250618/manifests_test.go
+++ b/internal/server/mcp/v20250618/manifests_test.go
@@ -224,7 +224,7 @@ func TestGenerateListToolsResult(t *testing.T) {
 		Name:      "test-toolset",
 		ToolNames: []string{"no_params", "some_params"},
 	}
-	toolset, err := tc.Initialize("test-version", toolsMap)
+	toolset, _, err := tc.Initialize("test-version", toolsMap, false)
 	if err != nil {
 		t.Fatalf("unable to initialize toolset %q: %s", "test-toolset", err)
 	}
@@ -337,7 +337,7 @@ func TestGenerateListPromptsResult(t *testing.T) {
 		Name:        "test-promptset",
 		PromptNames: []string{"prompt1", "prompt2"},
 	}
-	promptset, err := pc.Initialize("test-version", promptsMap)
+	promptset, _, err := pc.Initialize("test-version", promptsMap, false)
 	if err != nil {
 		t.Fatalf("unable to initialize promptset %q: %s", "test-promptset", err)
 	}

--- a/internal/server/mcp/v20251125/manifests_test.go
+++ b/internal/server/mcp/v20251125/manifests_test.go
@@ -224,7 +224,7 @@ func TestGenerateListToolsResult(t *testing.T) {
 		Name:      "test-toolset",
 		ToolNames: []string{"no_params", "some_params"},
 	}
-	toolset, err := tc.Initialize("test-version", toolsMap)
+	toolset, _, err := tc.Initialize("test-version", toolsMap, false)
 	if err != nil {
 		t.Fatalf("unable to initialize toolset %q: %s", "test-toolset", err)
 	}
@@ -337,7 +337,7 @@ func TestGenerateListPromptsResult(t *testing.T) {
 		Name:        "test-promptset",
 		PromptNames: []string{"prompt1", "prompt2"},
 	}
-	promptset, err := pc.Initialize("test-version", promptsMap)
+	promptset, _, err := pc.Initialize("test-version", promptsMap, false)
 	if err != nil {
 		t.Fatalf("unable to initialize promptset %q: %s", "test-promptset", err)
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -54,6 +54,7 @@ type Server struct {
 	version             string
 	sqlCommenterEnabled bool
 	toolboxUrl          string
+	allowPartialStartup bool
 	srv                 *http.Server
 	listener            net.Listener
 	root                chi.Router
@@ -91,6 +92,7 @@ func InitializeConfigs(ctx context.Context, cfg ServerConfig) (
 
 	// initialize and validate the sources from configs
 	sourcesMap := make(map[string]sources.Source)
+	var sourceInitErrors []string
 	for name, sc := range cfg.SourceConfigs {
 		s, err := func() (sources.Source, error) {
 			childCtx, span := instrumentation.Tracer.Start(
@@ -107,9 +109,16 @@ func InitializeConfigs(ctx context.Context, cfg ServerConfig) (
 			return s, nil
 		}()
 		if err != nil {
+			if cfg.AllowPartialStartup {
+				sourceInitErrors = append(sourceInitErrors, err.Error())
+				continue
+			}
 			return nil, nil, nil, nil, nil, nil, nil, err
 		}
 		sourcesMap[name] = s
+	}
+	if cfg.AllowPartialStartup && len(sourceInitErrors) > 0 {
+		l.WarnContext(ctx, fmt.Sprintf("Initialized %d sources with %d failures:\n- %s", len(sourcesMap), len(sourceInitErrors), strings.Join(sourceInitErrors, "\n- ")))
 	}
 	sourceNames := make([]string, 0, len(sourcesMap))
 	for name := range sourcesMap {
@@ -175,6 +184,7 @@ func InitializeConfigs(ctx context.Context, cfg ServerConfig) (
 
 	// initialize and validate the tools from configs
 	toolsMap := make(map[string]tools.Tool)
+	var toolInitErrors []string
 	for name, tc := range cfg.ToolConfigs {
 		t, err := func() (tools.Tool, error) {
 			_, span := instrumentation.Tracer.Start(
@@ -191,9 +201,16 @@ func InitializeConfigs(ctx context.Context, cfg ServerConfig) (
 			return t, nil
 		}()
 		if err != nil {
+			if cfg.AllowPartialStartup {
+				toolInitErrors = append(toolInitErrors, err.Error())
+				continue
+			}
 			return nil, nil, nil, nil, nil, nil, nil, err
 		}
 		toolsMap[name] = t
+	}
+	if cfg.AllowPartialStartup && len(toolInitErrors) > 0 {
+		l.WarnContext(ctx, fmt.Sprintf("Initialized %d tools with %d failures:\n- %s", len(toolsMap), len(toolInitErrors), strings.Join(toolInitErrors, "\n- ")))
 	}
 	toolNames := make([]string, 0, len(toolsMap))
 	for name := range toolsMap {
@@ -213,6 +230,7 @@ func InitializeConfigs(ctx context.Context, cfg ServerConfig) (
 
 	// initialize and validate the toolsets from configs
 	toolsetsMap := make(map[string]tools.Toolset)
+	var toolsetInitErrors []string
 	for name, tc := range cfg.ToolsetConfigs {
 		t, err := func() (tools.Toolset, error) {
 			_, span := instrumentation.Tracer.Start(
@@ -221,16 +239,26 @@ func InitializeConfigs(ctx context.Context, cfg ServerConfig) (
 				trace.WithAttributes(attribute.String("toolset.name", name)),
 			)
 			defer span.End()
-			t, err := tc.Initialize(cfg.Version, toolsMap)
+			t, missing, err := tc.Initialize(cfg.Version, toolsMap, cfg.AllowPartialStartup)
+			if len(missing) > 0 {
+				toolsetInitErrors = append(toolsetInitErrors, fmt.Sprintf("in toolset %q: missing tools %v", name, missing))
+			}
 			if err != nil {
 				return tools.Toolset{}, fmt.Errorf("unable to initialize toolset %q: %w", name, err)
 			}
 			return t, err
 		}()
 		if err != nil {
+			if cfg.AllowPartialStartup {
+				toolsetInitErrors = append(toolsetInitErrors, err.Error())
+				continue
+			}
 			return nil, nil, nil, nil, nil, nil, nil, err
 		}
 		toolsetsMap[name] = t
+	}
+	if cfg.AllowPartialStartup && len(toolsetInitErrors) > 0 {
+		l.WarnContext(ctx, fmt.Sprintf("Initialized %d toolsets with %d failures:\n- %s", len(toolsetsMap), len(toolsetInitErrors), strings.Join(toolsetInitErrors, "\n- ")))
 	}
 	toolsetNames := make([]string, 0, len(toolsetsMap))
 	for name := range toolsetsMap {
@@ -244,6 +272,7 @@ func InitializeConfigs(ctx context.Context, cfg ServerConfig) (
 
 	// initialize and validate the prompts from configs
 	promptsMap := make(map[string]prompts.Prompt)
+	var promptInitErrors []string
 	for name, pc := range cfg.PromptConfigs {
 		p, err := func() (prompts.Prompt, error) {
 			_, span := instrumentation.Tracer.Start(
@@ -260,9 +289,16 @@ func InitializeConfigs(ctx context.Context, cfg ServerConfig) (
 			return p, nil
 		}()
 		if err != nil {
+			if cfg.AllowPartialStartup {
+				promptInitErrors = append(promptInitErrors, err.Error())
+				continue
+			}
 			return nil, nil, nil, nil, nil, nil, nil, err
 		}
 		promptsMap[name] = p
+	}
+	if cfg.AllowPartialStartup && len(promptInitErrors) > 0 {
+		l.WarnContext(ctx, fmt.Sprintf("Initialized %d prompts with %d failures:\n- %s", len(promptsMap), len(promptInitErrors), strings.Join(promptInitErrors, "\n- ")))
 	}
 	promptNames := make([]string, 0, len(promptsMap))
 	for name := range promptsMap {
@@ -282,6 +318,7 @@ func InitializeConfigs(ctx context.Context, cfg ServerConfig) (
 
 	// initialize and validate the promptsets from configs
 	promptsetsMap := make(map[string]prompts.Promptset)
+	var promptsetInitErrors []string
 	for name, pc := range cfg.PromptsetConfigs {
 		p, err := func() (prompts.Promptset, error) {
 			_, span := instrumentation.Tracer.Start(
@@ -290,16 +327,26 @@ func InitializeConfigs(ctx context.Context, cfg ServerConfig) (
 				trace.WithAttributes(attribute.String("prompset_name", name)),
 			)
 			defer span.End()
-			p, err := pc.Initialize(cfg.Version, promptsMap)
+			p, missing, err := pc.Initialize(cfg.Version, promptsMap, cfg.AllowPartialStartup)
+			if len(missing) > 0 {
+				promptsetInitErrors = append(promptsetInitErrors, fmt.Sprintf("in promptset %q: missing prompts %v", name, missing))
+			}
 			if err != nil {
 				return prompts.Promptset{}, fmt.Errorf("unable to initialize promptset %q: %w", name, err)
 			}
 			return p, err
 		}()
 		if err != nil {
+			if cfg.AllowPartialStartup {
+				promptsetInitErrors = append(promptsetInitErrors, err.Error())
+				continue
+			}
 			return nil, nil, nil, nil, nil, nil, nil, err
 		}
 		promptsetsMap[name] = p
+	}
+	if cfg.AllowPartialStartup && len(promptsetInitErrors) > 0 {
+		l.WarnContext(ctx, fmt.Sprintf("Initialized %d promptsets with %d failures:\n- %s", len(promptsetsMap), len(promptsetInitErrors), strings.Join(promptsetInitErrors, "\n- ")))
 	}
 	promptsetNames := make([]string, 0, len(promptsetsMap))
 	for name := range promptsetsMap {
@@ -391,6 +438,7 @@ func NewServer(ctx context.Context, cfg ServerConfig) (*Server, error) {
 		ResourceMgr:         resourceManager,
 		toolboxUrl:          cfg.ToolboxUrl,
 		mcpPrmFile:          cfg.McpPrmFile,
+		allowPartialStartup: cfg.AllowPartialStartup,
 	}
 
 	// cors
@@ -602,4 +650,8 @@ func (s *Server) Shutdown(ctx context.Context) error {
 
 func (s *Server) Addr() string {
 	return s.listener.Addr().String()
+}
+
+func (s *Server) AllowPartialStartup() bool {
+	return s.allowPartialStartup
 }

--- a/internal/tools/toolsets.go
+++ b/internal/tools/toolsets.go
@@ -56,7 +56,7 @@ type ToolsetManifest struct {
 	ToolsManifest map[string]Manifest `json:"tools"`
 }
 
-func (t ToolsetConfig) Initialize(serverVersion string, toolsMap map[string]Tool) (Toolset, error) {
+func (t ToolsetConfig) Initialize(serverVersion string, toolsMap map[string]Tool, allowPartial bool) (Toolset, []string, error) {
 	// finish toolset setup
 	// Check each declared tool name exists
 	toolset := Toolset{
@@ -69,18 +69,24 @@ func (t ToolsetConfig) Initialize(serverVersion string, toolsMap map[string]Tool
 		toolNameSet: make(map[string]struct{}, len(t.ToolNames)),
 	}
 	if !IsValidName(toolset.Name) {
-		return toolset, fmt.Errorf("invalid toolset name: %s", toolset.Name)
+		return toolset, nil, fmt.Errorf("invalid toolset name: %s", toolset.Name)
 	}
+	var missing []string
 	for _, toolName := range t.ToolNames {
 		tool, ok := toolsMap[toolName]
 		if !ok {
-			return toolset, fmt.Errorf("tool does not exist: %s", toolName)
+			if allowPartial {
+				missing = append(missing, toolName)
+				continue
+			}
+			return toolset, nil, fmt.Errorf("tool does not exist: %s", toolName)
 		}
 		toolset.Tools = append(toolset.Tools, &tool)
 		toolset.Manifest.ToolsManifest[toolName] = tool.Manifest()
 		toolset.toolNameSet[toolName] = struct{}{}
 	}
-	return toolset, nil
+
+	return toolset, missing, nil
 }
 
 var validName = regexp.MustCompile(`^[a-zA-Z0-9_-]*$`)

--- a/internal/tools/toolsets_test.go
+++ b/internal/tools/toolsets_test.go
@@ -169,7 +169,7 @@ func TestToolsetConfig_Initialize(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := tc.config.Initialize(serverVersion, toolsMap)
+			got, _, err := tc.config.Initialize(serverVersion, toolsMap, false)
 
 			if tc.wantErr != "" {
 				if err == nil {


### PR DESCRIPTION
  ## Description                                                                                                                                            
   Allow Toolbox to start with partial sources when `--allow-partial-sources` is enabled.Source initialization continues on failures and logs a summary of all failed sources so operators can see every misconfigured source at once.                                                                                 
                                                                                                                                                             
   ## PR Checklist                                                                                                                                           
   - [x] Make sure you reviewed CONTRIBUTING.md                                                                                                              
   - [x] Make sure to open an issue as a bug/issue before writing your code                                                                                  
   - [x] Ensure the tests and linter pass                                                                                                                    
   - [x] Code coverage does not decrease (if any source code was changed)                                                                                    
   - [x] Appropriate docs were updated (if necessary)                                                                                                        
   - [x] Make sure to add `!` if this involve a breaking change                                                                                              
                                                                                                                                                             
Fixes #2925  