### PR TITLE
chore: remove oldest docs from cloudflare

### DIFF
--- a/.hugo/hugo.cloudflare.toml
+++ b/.hugo/hugo.cloudflare.toml
@@ -116,10 +116,6 @@ ignoreFiles = ["quickstart/shared", "quickstart/python", "quickstart/js", "quick
   version = "v0.28.0"
   url = "https://mcp-toolbox.dev/v0.28.0/"
 
-[[params.versions]]
-  version = "v0.27.0"
-  url = "https://mcp-toolbox.dev/v0.27.0/"
-
 [[menu.main]]
   name = "GitHub"
   weight = 50


### PR DESCRIPTION
The latest merge sync failed to run due to cloudflare docsite exceeding the number of files. Removing the oldest version to fix this.