### PR TITLE
feat(mcp): add secure parameter support for current MCP versions

### DIFF
--- a/internal/server/common_test.go
+++ b/internal/server/common_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/googleapis/mcp-toolbox/internal/telemetry"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 
+	mcputil "github.com/googleapis/mcp-toolbox/internal/server/mcp/util"
 	"github.com/googleapis/mcp-toolbox/internal/testutils"
 )
 
@@ -67,6 +68,7 @@ func setUpServer(t *testing.T, router string, tools map[string]tools.Tool, tools
 		instrumentation: instrumentation,
 		sseManager:      sseManager,
 		ResourceMgr:     resourceManager,
+		httpSessions:    make(map[string]*mcputil.SessionState),
 	}
 
 	var r chi.Router

--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -49,11 +49,12 @@ import (
 )
 
 type sseSession struct {
-	writer     http.ResponseWriter
-	flusher    http.Flusher
-	done       chan struct{}
-	eventQueue chan string
-	lastActive time.Time
+	writer       http.ResponseWriter
+	flusher      http.Flusher
+	done         chan struct{}
+	eventQueue   chan string
+	lastActive   time.Time
+	sessionState *mcputil.SessionState
 }
 
 // sseManager manages and control access to sse sessions
@@ -124,10 +125,11 @@ func (m *sseManager) cleanupRoutine(ctx context.Context) {
 }
 
 type stdioSession struct {
-	protocol string
-	server   *Server
-	reader   *bufio.Reader
-	writer   io.Writer
+	protocol     string
+	server       *Server
+	reader       *bufio.Reader
+	writer       io.Writer
+	sessionState *mcputil.SessionState
 }
 
 // traceContextCarrier implements propagation.TextMapCarrier for extracting trace context from _meta
@@ -194,9 +196,10 @@ func extractMeta(ctx context.Context, body []byte) context.Context {
 
 func NewStdioSession(s *Server, stdin io.Reader, stdout io.Writer) *stdioSession {
 	stdioSession := &stdioSession{
-		server: s,
-		reader: bufio.NewReader(stdin),
-		writer: stdout,
+		server:       s,
+		reader:       bufio.NewReader(stdin),
+		writer:       stdout,
+		sessionState: &mcputil.SessionState{},
 	}
 	return stdioSession
 }
@@ -258,6 +261,7 @@ func (s *stdioSession) readInputStream(ctx context.Context) error {
 		if err := func() error {
 			// This ensures the transport span becomes a child of the client span
 			msgCtx := extractMeta(ctx, []byte(line))
+			msgCtx = mcputil.WithSessionState(msgCtx, s.sessionState)
 
 			// Create span for STDIO transport
 			msgCtx, span := s.server.instrumentation.Tracer.Start(msgCtx, "toolbox/server/mcp/stdio",
@@ -431,10 +435,11 @@ func sseHandler(s *Server, w http.ResponseWriter, r *http.Request) {
 		_ = render.Render(w, r, newErrResponse(err, http.StatusInternalServerError))
 	}
 	session := &sseSession{
-		writer:     w,
-		flusher:    flusher,
-		done:       make(chan struct{}),
-		eventQueue: make(chan string, 100),
+		writer:       w,
+		flusher:      flusher,
+		done:         make(chan struct{}),
+		eventQueue:   make(chan string, 100),
+		sessionState: &mcputil.SessionState{},
 	}
 	s.sseManager.add(sessionId, session)
 	defer s.sseManager.remove(sessionId)
@@ -529,13 +534,32 @@ func httpHandler(s *Server, w http.ResponseWriter, r *http.Request) {
 			_ = render.Render(w, r, newErrResponse(err, http.StatusBadRequest))
 			return
 		}
+		ctx = mcputil.WithSessionState(ctx, session.sessionState)
+		r = r.WithContext(ctx)
 	}
 
 	// check if client have `Mcp-Session-Id` header
 	// `Mcp-Session-Id` is only set for v2025-03-26 in Toolbox
 	headerSessionId := r.Header.Get("Mcp-Session-Id")
+	var httpSessionState *mcputil.SessionState
 	if headerSessionId != "" {
 		protocolVersion = v20250326.PROTOCOL_VERSION
+		s.httpSessionsMu.Lock()
+		state, exists := s.httpSessions[headerSessionId]
+		if exists {
+			httpSessionState = state
+		}
+		s.httpSessionsMu.Unlock()
+	}
+
+	if httpSessionState != nil {
+		ctx = mcputil.WithSessionState(ctx, httpSessionState)
+		r = r.WithContext(ctx)
+	} else if headerSessionId == "" && paramSessionId == "" {
+		// New HTTP session (e.g. initialize request)
+		httpSessionState = &mcputil.SessionState{}
+		ctx = mcputil.WithSessionState(ctx, httpSessionState)
+		r = r.WithContext(ctx)
 	}
 
 	// check if client have `MCP-Protocol-Version` header
@@ -581,6 +605,11 @@ func httpHandler(s *Server, w http.ResponseWriter, r *http.Request) {
 	if v == v20250326.PROTOCOL_VERSION {
 		sessionId = uuid.New().String()
 		w.Header().Set("Mcp-Session-Id", sessionId)
+		if httpSessionState != nil {
+			s.httpSessionsMu.Lock()
+			s.httpSessions[sessionId] = httpSessionState
+			s.httpSessionsMu.Unlock()
+		}
 	}
 
 	if session != nil {

--- a/internal/server/mcp/util/util.go
+++ b/internal/server/mcp/util/util.go
@@ -14,6 +14,10 @@
 
 package util
 
+import (
+	"context"
+)
+
 const (
 	VERSION_20241105 = "2024-11-05"
 	VERSION_20250326 = "2025-03-26"
@@ -31,4 +35,24 @@ var SUPPORTED_PROTOCOL_VERSIONS = []string{
 	VERSION_20250326,
 	VERSION_20250618,
 	VERSION_20251125,
+}
+
+type contextKey string
+
+const sessionStateKey contextKey = "sessionState"
+
+// SessionState represents the stateful information associated with an MCP session.
+type SessionState struct {
+	SupportsSecureParams bool
+}
+
+// WithSessionState returns a new context with the given SessionState.
+func WithSessionState(ctx context.Context, state *SessionState) context.Context {
+	return context.WithValue(ctx, sessionStateKey, state)
+}
+
+// SessionStateFromContext retrieves the SessionState from the context.
+func SessionStateFromContext(ctx context.Context) (*SessionState, bool) {
+	state, ok := ctx.Value(sessionStateKey).(*SessionState)
+	return state, ok
 }

--- a/internal/server/mcp/v20241105/manifests.go
+++ b/internal/server/mcp/v20241105/manifests.go
@@ -23,8 +23,20 @@ import (
 )
 
 // generateToolManifest generates Tool for list tools result
-func generateToolManifest(name, desc string, authInvoke []string, params parameters.Parameters, annotations *tools.ToolAnnotations) Tool {
-	inputSchema, authParams := generateParamManifest(params)
+func generateToolManifest(name, desc string, authInvoke []string, params parameters.Parameters, annotations *tools.ToolAnnotations, supportsSecureParams bool) (Tool, bool) {
+	stdSchema, secureSchema, authParams := generateParamManifests(params, supportsSecureParams)
+
+	// If the tool has secure parameters, and the client does NOT support secure parameters, omit this tool.
+	hasSecureParams := false
+	for _, p := range params {
+		if p.GetSecure() {
+			hasSecureParams = true
+			break
+		}
+	}
+	if hasSecureParams && !supportsSecureParams {
+		return Tool{}, false
+	}
 
 	var toolAnnotations *ToolAnnotations
 	if annotations != nil {
@@ -38,9 +50,13 @@ func generateToolManifest(name, desc string, authInvoke []string, params paramet
 	mcpManifest := Tool{
 		Name:            name,
 		Description:     desc,
-		ToolInputSchema: inputSchema,
+		ToolInputSchema: stdSchema,
 		Annotations:     toolAnnotations,
 	}
+	if secureSchema != nil {
+		mcpManifest.SecureInputSchema = secureSchema
+	}
+
 	metadata := make(map[string]any)
 	if len(authInvoke) > 0 {
 		metadata["toolbox/authInvoke"] = authInvoke
@@ -51,13 +67,17 @@ func generateToolManifest(name, desc string, authInvoke []string, params paramet
 	if len(metadata) > 0 {
 		mcpManifest.Metadata = metadata
 	}
-	return mcpManifest
+	return mcpManifest, true
 }
 
-// generateParamManifest generates the input schema and get authParam
-func generateParamManifest(ps parameters.Parameters) (InputSchema, map[string][]string) {
-	properties := make(map[string]parameters.ParameterMcpManifest)
-	required := make([]string, 0)
+// generateParamManifests splits parameters into standard and secure manifests.
+func generateParamManifests(ps parameters.Parameters, supportsSecureParams bool) (InputSchema, *InputSchema, map[string][]string) {
+	stdProps := make(map[string]parameters.ParameterMcpManifest)
+	stdReq := make([]string, 0)
+
+	secProps := make(map[string]parameters.ParameterMcpManifest)
+	secReq := make([]string, 0)
+
 	authParam := make(map[string][]string)
 
 	for _, p := range ps {
@@ -72,31 +92,54 @@ func generateParamManifest(ps parameters.Parameters) (InputSchema, map[string][]
 		if defaultV != nil {
 			paramManifest.Default = defaultV
 		}
-		properties[name] = paramManifest
-		// parameters that doesn't have a default value are added to the required field
-		if parameters.CheckParamRequired(p.GetRequired(), defaultV) {
-			required = append(required, name)
-		}
+
 		if len(authParamList) > 0 {
 			authParam[name] = authParamList
 		}
+
+		if p.GetSecure() {
+			if supportsSecureParams {
+				secProps[name] = paramManifest
+				if parameters.CheckParamRequired(p.GetRequired(), defaultV) {
+					secReq = append(secReq, name)
+				}
+			}
+		} else {
+			stdProps[name] = paramManifest
+			if parameters.CheckParamRequired(p.GetRequired(), defaultV) {
+				stdReq = append(stdReq, name)
+			}
+		}
 	}
+
+	var secureSchema *InputSchema
+	if supportsSecureParams && len(secProps) > 0 {
+		secureSchema = &InputSchema{
+			Type:       "object",
+			Properties: secProps,
+			Required:   secReq,
+		}
+	}
+
 	return InputSchema{
 		Type:       "object",
-		Properties: properties,
-		Required:   required,
-	}, authParam
+		Properties: stdProps,
+		Required:   stdReq,
+	}, secureSchema, authParam
 }
 
 // GenerateListToolsResult generates tools/list method result according to mcp schema
-func GenerateListToolsResult(t tools.Toolset, toolsMap map[string]tools.Tool) (ListToolsResult, error) {
+func GenerateListToolsResult(t tools.Toolset, toolsMap map[string]tools.Tool, supportsSecureParams bool) (ListToolsResult, error) {
 	mcpManifest := make([]Tool, 0, len(t.ToolNames))
 	for _, toolName := range t.ToolNames {
 		tool, ok := toolsMap[toolName]
 		if !ok {
 			return ListToolsResult{}, fmt.Errorf("tool does not exist: %s", toolName)
 		}
-		toolManifest := generateToolManifest(toolName, tool.GetDescription(), tool.GetAuthRequired(), tool.GetParameters(), tool.GetAnnotations())
+		toolManifest, ok := generateToolManifest(toolName, tool.GetDescription(), tool.GetAuthRequired(), tool.GetParameters(), tool.GetAnnotations(), supportsSecureParams)
+		if !ok {
+			continue
+		}
 		mcpManifest = append(mcpManifest, toolManifest)
 	}
 	return ListToolsResult{Tools: mcpManifest}, nil

--- a/internal/server/mcp/v20241105/manifests_test.go
+++ b/internal/server/mcp/v20241105/manifests_test.go
@@ -107,8 +107,8 @@ func TestGenerateToolManifest(t *testing.T) {
 		},
 	}
 	for _, tc := range tcs {
-		t.Run(tc.name, func(t *testing.T) {
-			got := generateToolManifest(tc.name, tc.description, tc.authInvoke, tc.params, tc.annotations)
+		t.Run(tc.desc, func(t *testing.T) {
+			got, _ := generateToolManifest(tc.name, tc.description, tc.authInvoke, tc.params, tc.annotations, true)
 			gotM := got.Metadata
 			if diff := cmp.Diff(tc.wantMetadata, gotM); diff != "" {
 				t.Fatalf("unexpected metadata (-want +got):\n%s", diff)
@@ -188,7 +188,7 @@ func TestParamManifest(t *testing.T) {
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			gotSchema, gotAuthParam := generateParamManifest(tc.in)
+			gotSchema, _, gotAuthParam := generateParamManifests(tc.in, true)
 			if diff := cmp.Diff(tc.wantSchema, gotSchema); diff != "" {
 				t.Fatalf("unexpected manifest (-want +got):\n%s", diff)
 			}
@@ -230,7 +230,7 @@ func TestGenerateListToolsResult(t *testing.T) {
 		t.Fatalf("unable to initialize toolset %q: %s", "test-toolset", err)
 	}
 
-	got, err := GenerateListToolsResult(toolset, toolsMap)
+	got, err := GenerateListToolsResult(toolset, toolsMap, true)
 	if err != nil {
 		t.Fatalf("unable to generate list tools result: %s", err)
 	}

--- a/internal/server/mcp/v20241105/method.go
+++ b/internal/server/mcp/v20241105/method.go
@@ -44,7 +44,7 @@ func ProcessMethod(ctx context.Context, id jsonrpc.RequestId, method string, too
 	case PING:
 		return pingHandler(id)
 	case TOOLS_LIST:
-		return toolsListHandler(id, resourceMgr, toolset, body)
+		return toolsListHandler(ctx, id, resourceMgr, toolset, body)
 	case TOOLS_CALL:
 		return toolsCallHandler(ctx, id, toolset, resourceMgr, body, header)
 	case PROMPTS_LIST:
@@ -70,6 +70,12 @@ func initializeHandler(ctx context.Context, id jsonrpc.RequestId, body []byte) (
 	if err := json.Unmarshal(body, &req); err != nil {
 		err = fmt.Errorf("invalid mcp initialize request: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
+	}
+
+	if state, ok := mcputil.SessionStateFromContext(ctx); ok {
+		if req.Params.Capabilities.SecureParams != nil || (req.Params.Capabilities.Experimental != nil && req.Params.Capabilities.Experimental["toolbox/secure-params"] != nil) {
+			state.SupportsSecureParams = true
+		}
 	}
 
 	toolsListChanged := false
@@ -109,15 +115,20 @@ func pingHandler(id jsonrpc.RequestId) (any, error) {
 	}, nil
 }
 
-func toolsListHandler(id jsonrpc.RequestId, resourceMgr *resources.ResourceManager, toolset tools.Toolset, body []byte) (any, error) {
+func toolsListHandler(ctx context.Context, id jsonrpc.RequestId, resourceMgr *resources.ResourceManager, toolset tools.Toolset, body []byte) (any, error) {
 	var req ListToolsRequest
 	if err := json.Unmarshal(body, &req); err != nil {
 		err = fmt.Errorf("invalid mcp tools list request: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
 	}
 
+	supportsSecureParams := false
+	if state, ok := mcputil.SessionStateFromContext(ctx); ok {
+		supportsSecureParams = state.SupportsSecureParams
+	}
+
 	toolsMap := resourceMgr.GetToolsMap()
-	listToolsResult, err := GenerateListToolsResult(toolset, toolsMap)
+	listToolsResult, err := GenerateListToolsResult(toolset, toolsMap, supportsSecureParams)
 	if err != nil {
 		err = fmt.Errorf("error generating manifest: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err

--- a/internal/server/mcp/v20241105/method_test.go
+++ b/internal/server/mcp/v20241105/method_test.go
@@ -221,7 +221,7 @@ func TestToolsListHandler(t *testing.T) {
 					t.Fatalf("unexpected error during marshaling")
 				}
 			}
-			got, err := toolsListHandler(dummyID, resourceMgr, tt.toolset, body)
+			got, err := toolsListHandler(context.Background(), dummyID, resourceMgr, tt.toolset, body)
 
 			if tt.wantErr {
 				if err == nil {
@@ -281,8 +281,9 @@ func TestToolsCallHandler(t *testing.T) {
 					Method: "tools/call",
 				},
 				Params: struct {
-					Name      string         `json:"name"`
-					Arguments map[string]any `json:"arguments,omitempty"`
+					Name            string         `json:"name"`
+					Arguments       map[string]any `json:"arguments,omitempty"`
+					SecureArguments map[string]any `json:"secureArguments,omitempty"`
 				}{
 					Name: "no_params",
 				},
@@ -298,8 +299,9 @@ func TestToolsCallHandler(t *testing.T) {
 					Method: "tools/call",
 				},
 				Params: struct {
-					Name      string         `json:"name"`
-					Arguments map[string]any `json:"arguments,omitempty"`
+					Name            string         `json:"name"`
+					Arguments       map[string]any `json:"arguments,omitempty"`
+					SecureArguments map[string]any `json:"secureArguments,omitempty"`
 				}{
 					Name: "unknown_tool",
 				},
@@ -315,8 +317,9 @@ func TestToolsCallHandler(t *testing.T) {
 					Method: "tools/call",
 				},
 				Params: struct {
-					Name      string         `json:"name"`
-					Arguments map[string]any `json:"arguments,omitempty"`
+					Name            string         `json:"name"`
+					Arguments       map[string]any `json:"arguments,omitempty"`
+					SecureArguments map[string]any `json:"secureArguments,omitempty"`
 				}{
 					Name: "require_client_auth_tool",
 				},
@@ -332,8 +335,9 @@ func TestToolsCallHandler(t *testing.T) {
 					Method: "tools/call",
 				},
 				Params: struct {
-					Name      string         `json:"name"`
-					Arguments map[string]any `json:"arguments,omitempty"`
+					Name            string         `json:"name"`
+					Arguments       map[string]any `json:"arguments,omitempty"`
+					SecureArguments map[string]any `json:"secureArguments,omitempty"`
 				}{
 					Name: "no_params",
 				},

--- a/internal/server/mcp/v20241105/types.go
+++ b/internal/server/mcp/v20241105/types.go
@@ -92,7 +92,8 @@ type ClientCapabilities struct {
 	// Present if the client supports listing roots.
 	Roots *ListChanged `json:"roots,omitempty"`
 	// Present if the client supports sampling from an LLM.
-	Sampling struct{} `json:"sampling,omitempty"`
+	Sampling     struct{}       `json:"sampling,omitempty"`
+	SecureParams map[string]any `json:"toolbox/secure-params,omitempty"`
 }
 
 // ServerCapabilities represents capabilities that a server may support. Known
@@ -168,7 +169,8 @@ type Tool struct {
 	// A human-readable description of the tool.
 	Description string `json:"description,omitempty"`
 	// A JSON Schema object defining the expected parameters for the tool.
-	ToolInputSchema InputSchema `json:"inputSchema,omitempty"`
+	ToolInputSchema   InputSchema  `json:"inputSchema,omitempty"`
+	SecureInputSchema *InputSchema `json:"secureInputSchema,omitempty"`
 	// Extension of the schema: This was not in the original schema for this version.
 	Annotations *ToolAnnotations `json:"annotations,omitempty"`
 	// Extension of the schema: This was not in the original schema for this version.
@@ -185,8 +187,9 @@ type InputSchema struct {
 type CallToolRequest struct {
 	jsonrpc.Request
 	Params struct {
-		Name      string         `json:"name"`
-		Arguments map[string]any `json:"arguments,omitempty"`
+		Name            string         `json:"name"`
+		Arguments       map[string]any `json:"arguments,omitempty"`
+		SecureArguments map[string]any `json:"secureArguments,omitempty"`
 	} `json:"params,omitempty"`
 }
 

--- a/internal/server/mcp/v20250326/manifests.go
+++ b/internal/server/mcp/v20250326/manifests.go
@@ -23,8 +23,22 @@ import (
 )
 
 // generateToolManifest generates Tool for list tools result
-func generateToolManifest(name, desc string, authInvoke []string, params parameters.Parameters, annotations *tools.ToolAnnotations) Tool {
-	inputSchema, authParams := generateParamManifest(params)
+func generateToolManifest(name, desc string, authInvoke []string, params parameters.Parameters, annotations *tools.ToolAnnotations, supportsSecureParams bool) (Tool, bool) {
+	stdSchema, secureSchema, authParams := generateParamManifests(params, supportsSecureParams)
+
+	// If the tool has secure parameters, and the client does NOT support secure parameters,
+	// we should omit this tool entirely.
+	hasSecureParams := false
+	for _, p := range params {
+		if p.GetSecure() {
+			hasSecureParams = true
+			break
+		}
+	}
+	if hasSecureParams && !supportsSecureParams {
+		return Tool{}, false
+	}
+
 	var toolAnnotations *ToolAnnotations
 	if annotations != nil {
 		toolAnnotations = &ToolAnnotations{
@@ -37,9 +51,13 @@ func generateToolManifest(name, desc string, authInvoke []string, params paramet
 	mcpManifest := Tool{
 		Name:            name,
 		Description:     desc,
-		ToolInputSchema: inputSchema,
+		ToolInputSchema: stdSchema,
 		Annotations:     toolAnnotations,
 	}
+	if secureSchema != nil {
+		mcpManifest.SecureInputSchema = secureSchema
+	}
+
 	metadata := make(map[string]any)
 	if len(authInvoke) > 0 {
 		metadata["toolbox/authInvoke"] = authInvoke
@@ -50,13 +68,17 @@ func generateToolManifest(name, desc string, authInvoke []string, params paramet
 	if len(metadata) > 0 {
 		mcpManifest.Metadata = metadata
 	}
-	return mcpManifest
+	return mcpManifest, true
 }
 
-// generateParamManifest generates the input schema and get authParam
-func generateParamManifest(ps parameters.Parameters) (InputSchema, map[string][]string) {
-	properties := make(map[string]parameters.ParameterMcpManifest)
-	required := make([]string, 0)
+// generateParamManifests splits parameters into standard and secure manifests.
+func generateParamManifests(ps parameters.Parameters, supportsSecureParams bool) (InputSchema, *InputSchema, map[string][]string) {
+	stdProps := make(map[string]parameters.ParameterMcpManifest)
+	stdReq := make([]string, 0)
+
+	secProps := make(map[string]parameters.ParameterMcpManifest)
+	secReq := make([]string, 0)
+
 	authParam := make(map[string][]string)
 
 	for _, p := range ps {
@@ -71,31 +93,54 @@ func generateParamManifest(ps parameters.Parameters) (InputSchema, map[string][]
 		if defaultV != nil {
 			paramManifest.Default = defaultV
 		}
-		properties[name] = paramManifest
-		// parameters that doesn't have a default value are added to the required field
-		if parameters.CheckParamRequired(p.GetRequired(), defaultV) {
-			required = append(required, name)
-		}
+
 		if len(authParamList) > 0 {
 			authParam[name] = authParamList
 		}
+
+		if p.GetSecure() {
+			if supportsSecureParams {
+				secProps[name] = paramManifest
+				if parameters.CheckParamRequired(p.GetRequired(), defaultV) {
+					secReq = append(secReq, name)
+				}
+			}
+		} else {
+			stdProps[name] = paramManifest
+			if parameters.CheckParamRequired(p.GetRequired(), defaultV) {
+				stdReq = append(stdReq, name)
+			}
+		}
 	}
+
+	var secureSchema *InputSchema
+	if supportsSecureParams && len(secProps) > 0 {
+		secureSchema = &InputSchema{
+			Type:       "object",
+			Properties: secProps,
+			Required:   secReq,
+		}
+	}
+
 	return InputSchema{
 		Type:       "object",
-		Properties: properties,
-		Required:   required,
-	}, authParam
+		Properties: stdProps,
+		Required:   stdReq,
+	}, secureSchema, authParam
 }
 
 // GenerateListToolsResult generates tools/list method result according to mcp schema
-func GenerateListToolsResult(t tools.Toolset, toolsMap map[string]tools.Tool) (ListToolsResult, error) {
+func GenerateListToolsResult(t tools.Toolset, toolsMap map[string]tools.Tool, supportsSecureParams bool) (ListToolsResult, error) {
 	mcpManifest := make([]Tool, 0, len(t.ToolNames))
 	for _, toolName := range t.ToolNames {
 		tool, ok := toolsMap[toolName]
 		if !ok {
 			return ListToolsResult{}, fmt.Errorf("tool does not exist: %s", toolName)
 		}
-		toolManifest := generateToolManifest(toolName, tool.GetDescription(), tool.GetAuthRequired(), tool.GetParameters(), tool.GetAnnotations())
+		toolManifest, ok := generateToolManifest(toolName, tool.GetDescription(), tool.GetAuthRequired(), tool.GetParameters(), tool.GetAnnotations(), supportsSecureParams)
+		if !ok {
+			continue
+		}
 		mcpManifest = append(mcpManifest, toolManifest)
 	}
 	return ListToolsResult{Tools: mcpManifest}, nil

--- a/internal/server/mcp/v20250326/manifests_test.go
+++ b/internal/server/mcp/v20250326/manifests_test.go
@@ -107,8 +107,8 @@ func TestGenerateToolManifest(t *testing.T) {
 		},
 	}
 	for _, tc := range tcs {
-		t.Run(tc.name, func(t *testing.T) {
-			got := generateToolManifest(tc.name, tc.description, tc.authInvoke, tc.params, tc.annotations)
+		t.Run(tc.desc, func(t *testing.T) {
+			got, _ := generateToolManifest(tc.name, tc.description, tc.authInvoke, tc.params, tc.annotations, true)
 			gotM := got.Metadata
 			if diff := cmp.Diff(tc.wantMetadata, gotM); diff != "" {
 				t.Fatalf("unexpected metadata (-want +got):\n%s", diff)
@@ -188,7 +188,7 @@ func TestParamManifest(t *testing.T) {
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			gotSchema, gotAuthParam := generateParamManifest(tc.in)
+			gotSchema, _, gotAuthParam := generateParamManifests(tc.in, true)
 			if diff := cmp.Diff(tc.wantSchema, gotSchema); diff != "" {
 				t.Fatalf("unexpected manifest (-want +got):\n%s", diff)
 			}
@@ -230,7 +230,7 @@ func TestGenerateListToolsResult(t *testing.T) {
 		t.Fatalf("unable to initialize toolset %q: %s", "test-toolset", err)
 	}
 
-	got, err := GenerateListToolsResult(toolset, toolsMap)
+	got, err := GenerateListToolsResult(toolset, toolsMap, true)
 	if err != nil {
 		t.Fatalf("unable to generate list tools result: %s", err)
 	}

--- a/internal/server/mcp/v20250326/method.go
+++ b/internal/server/mcp/v20250326/method.go
@@ -44,7 +44,7 @@ func ProcessMethod(ctx context.Context, id jsonrpc.RequestId, method string, too
 	case PING:
 		return pingHandler(id)
 	case TOOLS_LIST:
-		return toolsListHandler(id, resourceMgr, toolset, body)
+		return toolsListHandler(ctx, id, resourceMgr, toolset, body)
 	case TOOLS_CALL:
 		return toolsCallHandler(ctx, id, toolset, resourceMgr, body, header)
 	case PROMPTS_LIST:
@@ -70,6 +70,12 @@ func initializeHandler(ctx context.Context, id jsonrpc.RequestId, body []byte) (
 	if err := json.Unmarshal(body, &req); err != nil {
 		err = fmt.Errorf("invalid mcp initialize request: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
+	}
+
+	if state, ok := mcputil.SessionStateFromContext(ctx); ok {
+		if req.Params.Capabilities.SecureParams != nil || (req.Params.Capabilities.Experimental != nil && req.Params.Capabilities.Experimental["toolbox/secure-params"] != nil) {
+			state.SupportsSecureParams = true
+		}
 	}
 
 	toolsListChanged := false
@@ -109,15 +115,20 @@ func pingHandler(id jsonrpc.RequestId) (any, error) {
 	}, nil
 }
 
-func toolsListHandler(id jsonrpc.RequestId, resourceMgr *resources.ResourceManager, toolset tools.Toolset, body []byte) (any, error) {
+func toolsListHandler(ctx context.Context, id jsonrpc.RequestId, resourceMgr *resources.ResourceManager, toolset tools.Toolset, body []byte) (any, error) {
 	var req ListToolsRequest
 	if err := json.Unmarshal(body, &req); err != nil {
 		err = fmt.Errorf("invalid mcp tools list request: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
 	}
 
+	supportsSecureParams := false
+	if state, ok := mcputil.SessionStateFromContext(ctx); ok {
+		supportsSecureParams = state.SupportsSecureParams
+	}
+
 	toolsMap := resourceMgr.GetToolsMap()
-	listToolsResult, err := GenerateListToolsResult(toolset, toolsMap)
+	listToolsResult, err := GenerateListToolsResult(toolset, toolsMap, supportsSecureParams)
 	if err != nil {
 		err = fmt.Errorf("error generating manifest: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err

--- a/internal/server/mcp/v20250326/method_test.go
+++ b/internal/server/mcp/v20250326/method_test.go
@@ -221,7 +221,7 @@ func TestToolsListHandler(t *testing.T) {
 					t.Fatalf("unexpected error during marshaling")
 				}
 			}
-			got, err := toolsListHandler(dummyID, resourceMgr, tt.toolset, body)
+			got, err := toolsListHandler(context.Background(), dummyID, resourceMgr, tt.toolset, body)
 
 			if tt.wantErr {
 				if err == nil {
@@ -281,8 +281,9 @@ func TestToolsCallHandler(t *testing.T) {
 					Method: "tools/call",
 				},
 				Params: struct {
-					Name      string         `json:"name"`
-					Arguments map[string]any `json:"arguments,omitempty"`
+					Name            string         `json:"name"`
+					Arguments       map[string]any `json:"arguments,omitempty"`
+					SecureArguments map[string]any `json:"secureArguments,omitempty"`
 				}{
 					Name: "no_params",
 				},
@@ -298,8 +299,9 @@ func TestToolsCallHandler(t *testing.T) {
 					Method: "tools/call",
 				},
 				Params: struct {
-					Name      string         `json:"name"`
-					Arguments map[string]any `json:"arguments,omitempty"`
+					Name            string         `json:"name"`
+					Arguments       map[string]any `json:"arguments,omitempty"`
+					SecureArguments map[string]any `json:"secureArguments,omitempty"`
 				}{
 					Name: "unknown_tool",
 				},
@@ -315,8 +317,9 @@ func TestToolsCallHandler(t *testing.T) {
 					Method: "tools/call",
 				},
 				Params: struct {
-					Name      string         `json:"name"`
-					Arguments map[string]any `json:"arguments,omitempty"`
+					Name            string         `json:"name"`
+					Arguments       map[string]any `json:"arguments,omitempty"`
+					SecureArguments map[string]any `json:"secureArguments,omitempty"`
 				}{
 					Name: "require_client_auth_tool",
 				},
@@ -332,8 +335,9 @@ func TestToolsCallHandler(t *testing.T) {
 					Method: "tools/call",
 				},
 				Params: struct {
-					Name      string         `json:"name"`
-					Arguments map[string]any `json:"arguments,omitempty"`
+					Name            string         `json:"name"`
+					Arguments       map[string]any `json:"arguments,omitempty"`
+					SecureArguments map[string]any `json:"secureArguments,omitempty"`
 				}{
 					Name: "no_params",
 				},

--- a/internal/server/mcp/v20250326/types.go
+++ b/internal/server/mcp/v20250326/types.go
@@ -92,7 +92,8 @@ type ClientCapabilities struct {
 	// Present if the client supports listing roots.
 	Roots *ListChanged `json:"roots,omitempty"`
 	// Present if the client supports sampling from an LLM.
-	Sampling struct{} `json:"sampling,omitempty"`
+	Sampling     struct{}       `json:"sampling,omitempty"`
+	SecureParams map[string]any `json:"toolbox/secure-params,omitempty"`
 }
 
 // ServerCapabilities represents capabilities that a server may support. Known
@@ -168,7 +169,8 @@ type Tool struct {
 	// A human-readable description of the tool.
 	Description string `json:"description,omitempty"`
 	// A JSON Schema object defining the expected parameters for the tool.
-	ToolInputSchema InputSchema `json:"inputSchema,omitempty"`
+	ToolInputSchema   InputSchema  `json:"inputSchema,omitempty"`
+	SecureInputSchema *InputSchema `json:"secureInputSchema,omitempty"`
 	// Optional additional tool information.
 	Annotations *ToolAnnotations `json:"annotations,omitempty"`
 	// Extension of the schema: This was not in the original schema for this version.
@@ -185,8 +187,9 @@ type InputSchema struct {
 type CallToolRequest struct {
 	jsonrpc.Request
 	Params struct {
-		Name      string         `json:"name"`
-		Arguments map[string]any `json:"arguments,omitempty"`
+		Name            string         `json:"name"`
+		Arguments       map[string]any `json:"arguments,omitempty"`
+		SecureArguments map[string]any `json:"secureArguments,omitempty"`
 	} `json:"params,omitempty"`
 }
 

--- a/internal/server/mcp/v20250618/manifests.go
+++ b/internal/server/mcp/v20250618/manifests.go
@@ -23,8 +23,22 @@ import (
 )
 
 // generateToolManifest generates Tool for list tools result
-func generateToolManifest(name, desc string, authInvoke []string, params parameters.Parameters, annotations *tools.ToolAnnotations) Tool {
-	inputSchema, authParams := generateParamManifest(params)
+func generateToolManifest(name, desc string, authInvoke []string, params parameters.Parameters, annotations *tools.ToolAnnotations, supportsSecureParams bool) (Tool, bool) {
+	stdSchema, secureSchema, authParams := generateParamManifests(params, supportsSecureParams)
+
+	// If the tool has secure parameters, and the client does NOT support secure parameters,
+	// we should omit this tool entirely.
+	hasSecureParams := false
+	for _, p := range params {
+		if p.GetSecure() {
+			hasSecureParams = true
+			break
+		}
+	}
+	if hasSecureParams && !supportsSecureParams {
+		return Tool{}, false
+	}
+
 	var toolAnnotations *ToolAnnotations
 	if annotations != nil {
 		toolAnnotations = &ToolAnnotations{
@@ -39,9 +53,13 @@ func generateToolManifest(name, desc string, authInvoke []string, params paramet
 			Name: name,
 		},
 		Description:     desc,
-		ToolInputSchema: inputSchema,
+		ToolInputSchema: stdSchema,
 		Annotations:     toolAnnotations,
 	}
+	if secureSchema != nil {
+		mcpManifest.SecureInputSchema = secureSchema
+	}
+
 	metadata := make(map[string]any)
 	if len(authInvoke) > 0 {
 		metadata["toolbox/authInvoke"] = authInvoke
@@ -52,13 +70,17 @@ func generateToolManifest(name, desc string, authInvoke []string, params paramet
 	if len(metadata) > 0 {
 		mcpManifest.Metadata = metadata
 	}
-	return mcpManifest
+	return mcpManifest, true
 }
 
-// generateParamManifest generates the input schema and get authParam
-func generateParamManifest(ps parameters.Parameters) (InputSchema, map[string][]string) {
-	properties := make(map[string]parameters.ParameterMcpManifest)
-	required := make([]string, 0)
+// generateParamManifests splits parameters into standard and secure manifests.
+func generateParamManifests(ps parameters.Parameters, supportsSecureParams bool) (InputSchema, *InputSchema, map[string][]string) {
+	stdProps := make(map[string]parameters.ParameterMcpManifest)
+	stdReq := make([]string, 0)
+
+	secProps := make(map[string]parameters.ParameterMcpManifest)
+	secReq := make([]string, 0)
+
 	authParam := make(map[string][]string)
 
 	for _, p := range ps {
@@ -73,31 +95,54 @@ func generateParamManifest(ps parameters.Parameters) (InputSchema, map[string][]
 		if defaultV != nil {
 			paramManifest.Default = defaultV
 		}
-		properties[name] = paramManifest
-		// parameters that doesn't have a default value are added to the required field
-		if parameters.CheckParamRequired(p.GetRequired(), defaultV) {
-			required = append(required, name)
-		}
+
 		if len(authParamList) > 0 {
 			authParam[name] = authParamList
 		}
+
+		if p.GetSecure() {
+			if supportsSecureParams {
+				secProps[name] = paramManifest
+				if parameters.CheckParamRequired(p.GetRequired(), defaultV) {
+					secReq = append(secReq, name)
+				}
+			}
+		} else {
+			stdProps[name] = paramManifest
+			if parameters.CheckParamRequired(p.GetRequired(), defaultV) {
+				stdReq = append(stdReq, name)
+			}
+		}
 	}
+
+	var secureSchema *InputSchema
+	if supportsSecureParams && len(secProps) > 0 {
+		secureSchema = &InputSchema{
+			Type:       "object",
+			Properties: secProps,
+			Required:   secReq,
+		}
+	}
+
 	return InputSchema{
 		Type:       "object",
-		Properties: properties,
-		Required:   required,
-	}, authParam
+		Properties: stdProps,
+		Required:   stdReq,
+	}, secureSchema, authParam
 }
 
 // GenerateListToolsResult generates tools/list method result according to mcp schema
-func GenerateListToolsResult(t tools.Toolset, toolsMap map[string]tools.Tool) (ListToolsResult, error) {
+func GenerateListToolsResult(t tools.Toolset, toolsMap map[string]tools.Tool, supportsSecureParams bool) (ListToolsResult, error) {
 	mcpManifest := make([]Tool, 0, len(t.ToolNames))
 	for _, toolName := range t.ToolNames {
 		tool, ok := toolsMap[toolName]
 		if !ok {
 			return ListToolsResult{}, fmt.Errorf("tool does not exist: %s", toolName)
 		}
-		toolManifest := generateToolManifest(toolName, tool.GetDescription(), tool.GetAuthRequired(), tool.GetParameters(), tool.GetAnnotations())
+		toolManifest, ok := generateToolManifest(toolName, tool.GetDescription(), tool.GetAuthRequired(), tool.GetParameters(), tool.GetAnnotations(), supportsSecureParams)
+		if !ok {
+			continue
+		}
 		mcpManifest = append(mcpManifest, toolManifest)
 	}
 	return ListToolsResult{Tools: mcpManifest}, nil

--- a/internal/server/mcp/v20250618/manifests_test.go
+++ b/internal/server/mcp/v20250618/manifests_test.go
@@ -107,8 +107,8 @@ func TestGenerateToolManifest(t *testing.T) {
 		},
 	}
 	for _, tc := range tcs {
-		t.Run(tc.name, func(t *testing.T) {
-			got := generateToolManifest(tc.name, tc.description, tc.authInvoke, tc.params, tc.annotations)
+		t.Run(tc.desc, func(t *testing.T) {
+			got, _ := generateToolManifest(tc.name, tc.description, tc.authInvoke, tc.params, tc.annotations, true)
 			gotM := got.Metadata
 			if diff := cmp.Diff(tc.wantMetadata, gotM); diff != "" {
 				t.Fatalf("unexpected metadata (-want +got):\n%s", diff)
@@ -188,7 +188,7 @@ func TestParamManifest(t *testing.T) {
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			gotSchema, gotAuthParam := generateParamManifest(tc.in)
+			gotSchema, _, gotAuthParam := generateParamManifests(tc.in, true)
 			if diff := cmp.Diff(tc.wantSchema, gotSchema); diff != "" {
 				t.Fatalf("unexpected manifest (-want +got):\n%s", diff)
 			}
@@ -230,7 +230,7 @@ func TestGenerateListToolsResult(t *testing.T) {
 		t.Fatalf("unable to initialize toolset %q: %s", "test-toolset", err)
 	}
 
-	got, err := GenerateListToolsResult(toolset, toolsMap)
+	got, err := GenerateListToolsResult(toolset, toolsMap, true)
 	if err != nil {
 		t.Fatalf("unable to generate list tools result: %s", err)
 	}

--- a/internal/server/mcp/v20250618/method.go
+++ b/internal/server/mcp/v20250618/method.go
@@ -44,7 +44,7 @@ func ProcessMethod(ctx context.Context, id jsonrpc.RequestId, method string, too
 	case PING:
 		return pingHandler(id)
 	case TOOLS_LIST:
-		return toolsListHandler(id, resourceMgr, toolset, body)
+		return toolsListHandler(ctx, id, resourceMgr, toolset, body)
 	case TOOLS_CALL:
 		return toolsCallHandler(ctx, id, toolset, resourceMgr, body, header)
 	case PROMPTS_LIST:
@@ -70,6 +70,12 @@ func initializeHandler(ctx context.Context, id jsonrpc.RequestId, body []byte) (
 	if err := json.Unmarshal(body, &req); err != nil {
 		err = fmt.Errorf("invalid mcp initialize request: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
+	}
+
+	if state, ok := mcputil.SessionStateFromContext(ctx); ok {
+		if req.Params.Capabilities.SecureParams != nil || (req.Params.Capabilities.Experimental != nil && req.Params.Capabilities.Experimental["toolbox/secure-params"] != nil) {
+			state.SupportsSecureParams = true
+		}
 	}
 
 	toolsListChanged := false
@@ -109,15 +115,20 @@ func pingHandler(id jsonrpc.RequestId) (any, error) {
 	}, nil
 }
 
-func toolsListHandler(id jsonrpc.RequestId, resourceMgr *resources.ResourceManager, toolset tools.Toolset, body []byte) (any, error) {
+func toolsListHandler(ctx context.Context, id jsonrpc.RequestId, resourceMgr *resources.ResourceManager, toolset tools.Toolset, body []byte) (any, error) {
 	var req ListToolsRequest
 	if err := json.Unmarshal(body, &req); err != nil {
 		err = fmt.Errorf("invalid mcp tools list request: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
 	}
 
+	supportsSecureParams := false
+	if state, ok := mcputil.SessionStateFromContext(ctx); ok {
+		supportsSecureParams = state.SupportsSecureParams
+	}
+
 	toolsMap := resourceMgr.GetToolsMap()
-	listToolsResult, err := GenerateListToolsResult(toolset, toolsMap)
+	listToolsResult, err := GenerateListToolsResult(toolset, toolsMap, supportsSecureParams)
 	if err != nil {
 		err = fmt.Errorf("error generating manifest: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err

--- a/internal/server/mcp/v20250618/method_test.go
+++ b/internal/server/mcp/v20250618/method_test.go
@@ -221,7 +221,7 @@ func TestToolsListHandler(t *testing.T) {
 					t.Fatalf("unexpected error during marshaling")
 				}
 			}
-			got, err := toolsListHandler(dummyID, resourceMgr, tt.toolset, body)
+			got, err := toolsListHandler(context.Background(), dummyID, resourceMgr, tt.toolset, body)
 
 			if tt.wantErr {
 				if err == nil {
@@ -281,8 +281,9 @@ func TestToolsCallHandler(t *testing.T) {
 					Method: "tools/call",
 				},
 				Params: struct {
-					Name      string         `json:"name"`
-					Arguments map[string]any `json:"arguments,omitempty"`
+					Name            string         `json:"name"`
+					Arguments       map[string]any `json:"arguments,omitempty"`
+					SecureArguments map[string]any `json:"secureArguments,omitempty"`
 				}{
 					Name: "no_params",
 				},
@@ -298,8 +299,9 @@ func TestToolsCallHandler(t *testing.T) {
 					Method: "tools/call",
 				},
 				Params: struct {
-					Name      string         `json:"name"`
-					Arguments map[string]any `json:"arguments,omitempty"`
+					Name            string         `json:"name"`
+					Arguments       map[string]any `json:"arguments,omitempty"`
+					SecureArguments map[string]any `json:"secureArguments,omitempty"`
 				}{
 					Name: "unknown_tool",
 				},
@@ -315,8 +317,9 @@ func TestToolsCallHandler(t *testing.T) {
 					Method: "tools/call",
 				},
 				Params: struct {
-					Name      string         `json:"name"`
-					Arguments map[string]any `json:"arguments,omitempty"`
+					Name            string         `json:"name"`
+					Arguments       map[string]any `json:"arguments,omitempty"`
+					SecureArguments map[string]any `json:"secureArguments,omitempty"`
 				}{
 					Name: "require_client_auth_tool",
 				},
@@ -332,8 +335,9 @@ func TestToolsCallHandler(t *testing.T) {
 					Method: "tools/call",
 				},
 				Params: struct {
-					Name      string         `json:"name"`
-					Arguments map[string]any `json:"arguments,omitempty"`
+					Name            string         `json:"name"`
+					Arguments       map[string]any `json:"arguments,omitempty"`
+					SecureArguments map[string]any `json:"secureArguments,omitempty"`
 				}{
 					Name: "no_params",
 				},

--- a/internal/server/mcp/v20250618/types.go
+++ b/internal/server/mcp/v20250618/types.go
@@ -92,7 +92,8 @@ type ClientCapabilities struct {
 	// Present if the client supports listing roots.
 	Roots *ListChanged `json:"roots,omitempty"`
 	// Present if the client supports sampling from an LLM.
-	Sampling struct{} `json:"sampling,omitempty"`
+	Sampling     struct{}       `json:"sampling,omitempty"`
+	SecureParams map[string]any `json:"toolbox/secure-params,omitempty"`
 }
 
 // ServerCapabilities represents capabilities that a server may support. Known
@@ -167,7 +168,8 @@ type Tool struct {
 	// A human-readable description of the tool.
 	Description string `json:"description,omitempty"`
 	// A JSON Schema object defining the expected parameters for the tool.
-	ToolInputSchema InputSchema `json:"inputSchema,omitempty"`
+	ToolInputSchema   InputSchema  `json:"inputSchema,omitempty"`
+	SecureInputSchema *InputSchema `json:"secureInputSchema,omitempty"`
 	// Optional additional tool information.
 	Annotations *ToolAnnotations `json:"annotations,omitempty"`
 	// See [General fields: `_meta`](/specification/2025-06-18/basic/index#_meta) for notes on `_meta` usage.
@@ -184,8 +186,9 @@ type InputSchema struct {
 type CallToolRequest struct {
 	jsonrpc.Request
 	Params struct {
-		Name      string         `json:"name"`
-		Arguments map[string]any `json:"arguments,omitempty"`
+		Name            string         `json:"name"`
+		Arguments       map[string]any `json:"arguments,omitempty"`
+		SecureArguments map[string]any `json:"secureArguments,omitempty"`
 	} `json:"params,omitempty"`
 }
 

--- a/internal/server/mcp/v20251125/manifests.go
+++ b/internal/server/mcp/v20251125/manifests.go
@@ -23,8 +23,22 @@ import (
 )
 
 // generateToolManifest generates Tool for list tools result
-func generateToolManifest(name, desc string, authInvoke []string, params parameters.Parameters, annotations *tools.ToolAnnotations) Tool {
-	inputSchema, authParams := generateParamManifest(params)
+func generateToolManifest(name, desc string, authInvoke []string, params parameters.Parameters, annotations *tools.ToolAnnotations, supportsSecureParams bool) (Tool, bool) {
+	stdSchema, secureSchema, authParams := generateParamManifests(params, supportsSecureParams)
+
+	// If the tool has secure parameters, and the client does NOT support secure parameters,
+	// we should omit this tool entirely.
+	hasSecureParams := false
+	for _, p := range params {
+		if p.GetSecure() {
+			hasSecureParams = true
+			break
+		}
+	}
+	if hasSecureParams && !supportsSecureParams {
+		return Tool{}, false
+	}
+
 	var toolAnnotations *ToolAnnotations
 	if annotations != nil {
 		toolAnnotations = &ToolAnnotations{
@@ -39,9 +53,13 @@ func generateToolManifest(name, desc string, authInvoke []string, params paramet
 			Name: name,
 		},
 		Description:     desc,
-		ToolInputSchema: inputSchema,
+		ToolInputSchema: stdSchema,
 		Annotations:     toolAnnotations,
 	}
+	if secureSchema != nil {
+		mcpManifest.SecureInputSchema = secureSchema
+	}
+
 	metadata := make(map[string]any)
 	if len(authInvoke) > 0 {
 		metadata["toolbox/authInvoke"] = authInvoke
@@ -52,13 +70,17 @@ func generateToolManifest(name, desc string, authInvoke []string, params paramet
 	if len(metadata) > 0 {
 		mcpManifest.Metadata = metadata
 	}
-	return mcpManifest
+	return mcpManifest, true
 }
 
-// generateParamManifest generates the input schema and get authParam
-func generateParamManifest(ps parameters.Parameters) (InputSchema, map[string][]string) {
-	properties := make(map[string]parameters.ParameterMcpManifest)
-	required := make([]string, 0)
+// generateParamManifests splits parameters into standard and secure manifests.
+func generateParamManifests(ps parameters.Parameters, supportsSecureParams bool) (InputSchema, *InputSchema, map[string][]string) {
+	stdProps := make(map[string]parameters.ParameterMcpManifest)
+	stdReq := make([]string, 0)
+
+	secProps := make(map[string]parameters.ParameterMcpManifest)
+	secReq := make([]string, 0)
+
 	authParam := make(map[string][]string)
 
 	for _, p := range ps {
@@ -73,31 +95,54 @@ func generateParamManifest(ps parameters.Parameters) (InputSchema, map[string][]
 		if defaultV != nil {
 			paramManifest.Default = defaultV
 		}
-		properties[name] = paramManifest
-		// parameters that doesn't have a default value are added to the required field
-		if parameters.CheckParamRequired(p.GetRequired(), defaultV) {
-			required = append(required, name)
-		}
+
 		if len(authParamList) > 0 {
 			authParam[name] = authParamList
 		}
+
+		if p.GetSecure() {
+			if supportsSecureParams {
+				secProps[name] = paramManifest
+				if parameters.CheckParamRequired(p.GetRequired(), defaultV) {
+					secReq = append(secReq, name)
+				}
+			}
+		} else {
+			stdProps[name] = paramManifest
+			if parameters.CheckParamRequired(p.GetRequired(), defaultV) {
+				stdReq = append(stdReq, name)
+			}
+		}
 	}
+
+	var secureSchema *InputSchema
+	if supportsSecureParams && len(secProps) > 0 {
+		secureSchema = &InputSchema{
+			Type:       "object",
+			Properties: secProps,
+			Required:   secReq,
+		}
+	}
+
 	return InputSchema{
 		Type:       "object",
-		Properties: properties,
-		Required:   required,
-	}, authParam
+		Properties: stdProps,
+		Required:   stdReq,
+	}, secureSchema, authParam
 }
 
 // GenerateListToolsResult generates tools/list method result according to mcp schema
-func GenerateListToolsResult(t tools.Toolset, toolsMap map[string]tools.Tool) (ListToolsResult, error) {
+func GenerateListToolsResult(t tools.Toolset, toolsMap map[string]tools.Tool, supportsSecureParams bool) (ListToolsResult, error) {
 	mcpManifest := make([]Tool, 0, len(t.ToolNames))
 	for _, toolName := range t.ToolNames {
 		tool, ok := toolsMap[toolName]
 		if !ok {
 			return ListToolsResult{}, fmt.Errorf("tool does not exist: %s", toolName)
 		}
-		toolManifest := generateToolManifest(toolName, tool.GetDescription(), tool.GetAuthRequired(), tool.GetParameters(), tool.GetAnnotations())
+		toolManifest, ok := generateToolManifest(toolName, tool.GetDescription(), tool.GetAuthRequired(), tool.GetParameters(), tool.GetAnnotations(), supportsSecureParams)
+		if !ok {
+			continue
+		}
 		mcpManifest = append(mcpManifest, toolManifest)
 	}
 	return ListToolsResult{Tools: mcpManifest}, nil

--- a/internal/server/mcp/v20251125/manifests_test.go
+++ b/internal/server/mcp/v20251125/manifests_test.go
@@ -107,8 +107,8 @@ func TestGenerateToolManifest(t *testing.T) {
 		},
 	}
 	for _, tc := range tcs {
-		t.Run(tc.name, func(t *testing.T) {
-			got := generateToolManifest(tc.name, tc.description, tc.authInvoke, tc.params, tc.annotations)
+		t.Run(tc.desc, func(t *testing.T) {
+			got, _ := generateToolManifest(tc.name, tc.description, tc.authInvoke, tc.params, tc.annotations, true)
 			gotM := got.Metadata
 			if diff := cmp.Diff(tc.wantMetadata, gotM); diff != "" {
 				t.Fatalf("unexpected metadata (-want +got):\n%s", diff)
@@ -188,7 +188,7 @@ func TestParamManifest(t *testing.T) {
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			gotSchema, gotAuthParam := generateParamManifest(tc.in)
+			gotSchema, _, gotAuthParam := generateParamManifests(tc.in, true)
 			if diff := cmp.Diff(tc.wantSchema, gotSchema); diff != "" {
 				t.Fatalf("unexpected manifest (-want +got):\n%s", diff)
 			}
@@ -230,7 +230,7 @@ func TestGenerateListToolsResult(t *testing.T) {
 		t.Fatalf("unable to initialize toolset %q: %s", "test-toolset", err)
 	}
 
-	got, err := GenerateListToolsResult(toolset, toolsMap)
+	got, err := GenerateListToolsResult(toolset, toolsMap, true)
 	if err != nil {
 		t.Fatalf("unable to generate list tools result: %s", err)
 	}

--- a/internal/server/mcp/v20251125/method.go
+++ b/internal/server/mcp/v20251125/method.go
@@ -44,7 +44,7 @@ func ProcessMethod(ctx context.Context, id jsonrpc.RequestId, method string, too
 	case PING:
 		return pingHandler(id)
 	case TOOLS_LIST:
-		return toolsListHandler(id, resourceMgr, toolset, body)
+		return toolsListHandler(ctx, id, resourceMgr, toolset, body)
 	case TOOLS_CALL:
 		return toolsCallHandler(ctx, id, toolset, resourceMgr, body, header)
 	case PROMPTS_LIST:
@@ -70,6 +70,12 @@ func initializeHandler(ctx context.Context, id jsonrpc.RequestId, body []byte) (
 	if err := json.Unmarshal(body, &req); err != nil {
 		err = fmt.Errorf("invalid mcp initialize request: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
+	}
+
+	if state, ok := mcputil.SessionStateFromContext(ctx); ok {
+		if req.Params.Capabilities.SecureParams != nil || (req.Params.Capabilities.Experimental != nil && req.Params.Capabilities.Experimental["toolbox/secure-params"] != nil) {
+			state.SupportsSecureParams = true
+		}
 	}
 
 	toolsListChanged := false
@@ -109,15 +115,20 @@ func pingHandler(id jsonrpc.RequestId) (any, error) {
 	}, nil
 }
 
-func toolsListHandler(id jsonrpc.RequestId, resourceMgr *resources.ResourceManager, toolset tools.Toolset, body []byte) (any, error) {
+func toolsListHandler(ctx context.Context, id jsonrpc.RequestId, resourceMgr *resources.ResourceManager, toolset tools.Toolset, body []byte) (any, error) {
 	var req ListToolsRequest
 	if err := json.Unmarshal(body, &req); err != nil {
 		err = fmt.Errorf("invalid mcp tools list request: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
 	}
 
+	supportsSecureParams := false
+	if state, ok := mcputil.SessionStateFromContext(ctx); ok {
+		supportsSecureParams = state.SupportsSecureParams
+	}
+
 	toolsMap := resourceMgr.GetToolsMap()
-	listToolsResult, err := GenerateListToolsResult(toolset, toolsMap)
+	listToolsResult, err := GenerateListToolsResult(toolset, toolsMap, supportsSecureParams)
 	if err != nil {
 		err = fmt.Errorf("error generating manifest: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err

--- a/internal/server/mcp/v20251125/method_test.go
+++ b/internal/server/mcp/v20251125/method_test.go
@@ -221,7 +221,7 @@ func TestToolsListHandler(t *testing.T) {
 					t.Fatalf("unexpected error during marshaling")
 				}
 			}
-			got, err := toolsListHandler(dummyID, resourceMgr, tt.toolset, body)
+			got, err := toolsListHandler(context.Background(), dummyID, resourceMgr, tt.toolset, body)
 
 			if tt.wantErr {
 				if err == nil {
@@ -281,8 +281,9 @@ func TestToolsCallHandler(t *testing.T) {
 					Method: "tools/call",
 				},
 				Params: struct {
-					Name      string         `json:"name"`
-					Arguments map[string]any `json:"arguments,omitempty"`
+					Name            string         `json:"name"`
+					Arguments       map[string]any `json:"arguments,omitempty"`
+					SecureArguments map[string]any `json:"secureArguments,omitempty"`
 				}{
 					Name: "no_params",
 				},
@@ -298,8 +299,9 @@ func TestToolsCallHandler(t *testing.T) {
 					Method: "tools/call",
 				},
 				Params: struct {
-					Name      string         `json:"name"`
-					Arguments map[string]any `json:"arguments,omitempty"`
+					Name            string         `json:"name"`
+					Arguments       map[string]any `json:"arguments,omitempty"`
+					SecureArguments map[string]any `json:"secureArguments,omitempty"`
 				}{
 					Name: "unknown_tool",
 				},
@@ -315,8 +317,9 @@ func TestToolsCallHandler(t *testing.T) {
 					Method: "tools/call",
 				},
 				Params: struct {
-					Name      string         `json:"name"`
-					Arguments map[string]any `json:"arguments,omitempty"`
+					Name            string         `json:"name"`
+					Arguments       map[string]any `json:"arguments,omitempty"`
+					SecureArguments map[string]any `json:"secureArguments,omitempty"`
 				}{
 					Name: "require_client_auth_tool",
 				},
@@ -332,8 +335,9 @@ func TestToolsCallHandler(t *testing.T) {
 					Method: "tools/call",
 				},
 				Params: struct {
-					Name      string         `json:"name"`
-					Arguments map[string]any `json:"arguments,omitempty"`
+					Name            string         `json:"name"`
+					Arguments       map[string]any `json:"arguments,omitempty"`
+					SecureArguments map[string]any `json:"secureArguments,omitempty"`
 				}{
 					Name: "no_params",
 				},

--- a/internal/server/mcp/v20251125/types.go
+++ b/internal/server/mcp/v20251125/types.go
@@ -92,7 +92,8 @@ type ClientCapabilities struct {
 	// Present if the client supports listing roots.
 	Roots *ListChanged `json:"roots,omitempty"`
 	// Present if the client supports sampling from an LLM.
-	Sampling struct{} `json:"sampling,omitempty"`
+	Sampling     struct{}       `json:"sampling,omitempty"`
+	SecureParams map[string]any `json:"toolbox/secure-params,omitempty"`
 }
 
 // ServerCapabilities represents capabilities that a server may support. Known
@@ -171,7 +172,8 @@ type Tool struct {
 	 */
 	Description string `json:"description,omitempty"`
 	// A JSON Schema object defining the expected parameters for the tool.
-	ToolInputSchema InputSchema `json:"inputSchema,omitempty"`
+	ToolInputSchema   InputSchema  `json:"inputSchema,omitempty"`
+	SecureInputSchema *InputSchema `json:"secureInputSchema,omitempty"`
 	// Optional additional tool information.
 	Annotations *ToolAnnotations `json:"annotations,omitempty"`
 	// See [General fields: `_meta`](/specification/2025-11-25/basic/index#_meta) for notes on `_meta` usage.
@@ -188,8 +190,9 @@ type InputSchema struct {
 type CallToolRequest struct {
 	jsonrpc.Request
 	Params struct {
-		Name      string         `json:"name"`
-		Arguments map[string]any `json:"arguments,omitempty"`
+		Name            string         `json:"name"`
+		Arguments       map[string]any `json:"arguments,omitempty"`
+		SecureArguments map[string]any `json:"secureArguments,omitempty"`
 	} `json:"params,omitempty"`
 }
 

--- a/internal/server/mcp_test.go
+++ b/internal/server/mcp_test.go
@@ -36,6 +36,7 @@ import (
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 
+	mcputil "github.com/googleapis/mcp-toolbox/internal/server/mcp/util"
 	"github.com/googleapis/mcp-toolbox/internal/testutils"
 )
 
@@ -1131,6 +1132,7 @@ func TestStdioSession(t *testing.T) {
 		instrumentation: instrumentation,
 		sseManager:      sseManager,
 		ResourceMgr:     resourceManager,
+		httpSessions:    make(map[string]*mcputil.SessionState),
 	}
 
 	in := bufio.NewReader(pr)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -27,6 +27,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -39,8 +40,10 @@ import (
 	"github.com/googleapis/mcp-toolbox/internal/log"
 	"github.com/googleapis/mcp-toolbox/internal/prompts"
 	"github.com/googleapis/mcp-toolbox/internal/server/mcp/jsonrpc"
+	mcputil "github.com/googleapis/mcp-toolbox/internal/server/mcp/util"
 	"github.com/googleapis/mcp-toolbox/internal/server/resources"
 	"github.com/googleapis/mcp-toolbox/internal/sources"
+
 	"github.com/googleapis/mcp-toolbox/internal/telemetry"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -59,6 +62,8 @@ type Server struct {
 	logger              log.Logger
 	instrumentation     *telemetry.Instrumentation
 	sseManager          *sseManager
+	httpSessions        map[string]*mcputil.SessionState
+	httpSessionsMu      sync.Mutex
 	ResourceMgr         *resources.ResourceManager
 	mcpPrmFile          string
 }
@@ -400,6 +405,7 @@ func NewServer(ctx context.Context, cfg ServerConfig) (*Server, error) {
 		logger:              l,
 		instrumentation:     instrumentation,
 		sseManager:          sseManager,
+		httpSessions:        make(map[string]*mcputil.SessionState),
 		ResourceMgr:         resourceManager,
 		toolboxUrl:          cfg.ToolboxUrl,
 		mcpPrmFile:          cfg.McpPrmFile,

--- a/internal/util/parameters/parameters.go
+++ b/internal/util/parameters/parameters.go
@@ -329,6 +329,8 @@ type Parameter interface {
 	Parse(any) (any, error)
 	Manifest() ParameterManifest
 	McpManifest() (ParameterMcpManifest, []string)
+	// GetSecure returns whether the parameter is secure.
+	GetSecure() bool
 }
 
 // Parameters is a type used to allow unmarshal a list of parameters
@@ -474,6 +476,7 @@ type CommonParameter struct {
 	AuthServices   []ParamAuthService `yaml:"authServices"`
 	EmbeddedBy     string             `yaml:"embeddedBy"`
 	ValueFromParam string             `yaml:"valueFromParam"`
+	Secure         bool               `yaml:"secure"`
 }
 
 // GetName returns the name specified for the Parameter.
@@ -498,6 +501,11 @@ func (p *CommonParameter) GetRequired() bool {
 		return true
 	}
 	return *p.Required
+}
+
+// GetSecure returns whether the parameter is secure.
+func (p *CommonParameter) GetSecure() bool {
+	return p.Secure
 }
 
 // GetAllowedValues returns the allowed values for the Parameter.
@@ -714,13 +722,17 @@ func (p *StringParameter) Parse(v any) (any, error) {
 func applyEscape(escape, v string) (any, error) {
 	switch escape {
 	case escapeBackticks:
-		return fmt.Sprintf("`%s`", v), nil
+		escaped := strings.ReplaceAll(v, "`", "``")
+		return fmt.Sprintf("`%s`", escaped), nil
 	case escapeDoubleQuotes:
-		return fmt.Sprintf(`"%s"`, v), nil
+		escaped := strings.ReplaceAll(v, `"`, `""`)
+		return fmt.Sprintf(`"%s"`, escaped), nil
 	case escapeSingleQuotes:
-		return fmt.Sprintf(`'%s'`, v), nil
+		escaped := strings.ReplaceAll(v, `'`, `''`)
+		return fmt.Sprintf(`'%s'`, escaped), nil
 	case escapeSquareBrackets:
-		return fmt.Sprintf("[%s]", v), nil
+		escaped := strings.ReplaceAll(v, "]", "]]")
+		return fmt.Sprintf("[%s]", escaped), nil
 	default:
 		return nil, fmt.Errorf("%s is not an allowed escaping delimiter", escape)
 	}


### PR DESCRIPTION
Add all the stateful MCP protocol integrations (v20241105, v20250326, v20250618, v20251125) for secure parameters.