### PR TITLE
feat: core agent-level suppression for read-only tools

### DIFF
--- a/docs/en/integrations/alloydb-admin/source.md
+++ b/docs/en/integrations/alloydb-admin/source.md
@@ -46,3 +46,4 @@ useClientOAuth: true
 | type           |  string  |     true     | Must be "alloydb-admin".                                                                                                                       |
 | defaultProject |  string  |     false    | The Google Cloud project ID to use for AlloyDB infrastructure tools.                                                                           |
 | useClientOAuth |  boolean |     false    | If true, the source will use client-side OAuth for authorization. Otherwise, it will use Application Default Credentials. Defaults to `false`. |
+| readOnly       |  boolean |     false    | When set to `true`, suppresses write-capable admin tools. Default: `false`.                                                                    |

--- a/docs/en/integrations/cloud-sql-admin/source.md
+++ b/docs/en/integrations/cloud-sql-admin/source.md
@@ -46,3 +46,4 @@ useClientOAuth: true
 | type           |  string  |     true     | Must be "cloud-sql-admin".                                                                                                                     |
 | defaultProject |  string  |     false    | The Google Cloud project ID to use for Cloud SQL infrastructure tools.                                                                         |
 | useClientOAuth |  boolean |     false    | If true, the source will use client-side OAuth for authorization. Otherwise, it will use Application Default Credentials. Defaults to `false`. |
+| readOnly       |  boolean |     false    | When set to `true`, suppresses write-capable admin tools. Default: `false`.                                                                    |

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -274,6 +274,7 @@ func InitializeOfflineConfigs(ctx context.Context, cfg ServerConfig) (
 func initializeTools(ctx context.Context, cfg ServerConfig, sourcesMap map[string]sources.Source, instrumentation *telemetry.Instrumentation, l log.Logger) (map[string]tools.Tool, error) {
 	toolsMap := make(map[string]tools.Tool)
 	for name, tc := range cfg.ToolConfigs {
+		var src sources.Source
 		t, err := func() (tools.Tool, error) {
 			_, span := instrumentation.Tracer.Start(
 				ctx,
@@ -286,16 +287,16 @@ func initializeTools(ctx context.Context, cfg ServerConfig, sourcesMap map[strin
 			if err != nil {
 				return nil, fmt.Errorf("unable to initialize tool %q: %w", name, err)
 			}
-			if !cfg.SkipSourceValidation {
-				srcName := t.GetSourceName()
-				var src sources.Source
+
+			if srcName := t.GetSourceName(); srcName != "" && sourcesMap != nil {
 				var ok bool
-				if srcName != "" {
-					src, ok = sourcesMap[srcName]
-					if !ok {
-						return nil, fmt.Errorf("unable to retrieve source %s for tool %s", srcName, name)
-					}
+				src, ok = sourcesMap[srcName]
+				if !ok && !cfg.SkipSourceValidation {
+					return nil, fmt.Errorf("unable to retrieve source %q for tool %q", srcName, name)
 				}
+			}
+
+			if !cfg.SkipSourceValidation {
 				err = t.ValidateSource(src)
 				if err != nil {
 					return nil, err
@@ -306,6 +307,11 @@ func initializeTools(ctx context.Context, cfg ServerConfig, sourcesMap map[strin
 		if err != nil {
 			return nil, err
 		}
+
+		if t.ShouldSuppress(ctx, src) {
+			continue
+		}
+
 		toolsMap[name] = t
 	}
 	toolNames := make([]string, 0, len(toolsMap))
@@ -351,17 +357,20 @@ func initializeGroups(ctx context.Context, cfg ServerConfig, toolsMap map[string
 
 	groupsMap := make(map[string]group.Group)
 	for name, gc := range groupConfigs {
-		if cfg.IgnoreUnknownTools {
-			filteredToolNames := make([]string, 0, len(gc.ToolNames))
-			for _, tn := range gc.ToolNames {
-				if _, ok := toolsMap[tn]; ok {
-					filteredToolNames = append(filteredToolNames, tn)
-				} else {
-					l.WarnContext(ctx, fmt.Sprintf("Skipping missing tool %q in group %q", tn, name))
-				}
+		filteredToolNames := make([]string, 0, len(gc.ToolNames))
+		for _, tn := range gc.ToolNames {
+			if _, ok := toolsMap[tn]; ok {
+				filteredToolNames = append(filteredToolNames, tn)
+			} else if _, isTool := cfg.ToolConfigs[tn]; isTool {
+				l.InfoContext(ctx, fmt.Sprintf("Removing suppressed tool %q from group %q", tn, name))
+			} else if cfg.IgnoreUnknownTools {
+				l.WarnContext(ctx, fmt.Sprintf("Skipping missing tool %q in group %q", tn, name))
+			} else {
+				// Keep it so that Initialize returns the expected error
+				filteredToolNames = append(filteredToolNames, tn)
 			}
-			gc.ToolNames = filteredToolNames
 		}
+		gc.ToolNames = filteredToolNames
 
 		g, err := func() (group.Group, error) {
 			_, span := instrumentation.Tracer.Start(

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -50,10 +50,14 @@ import (
 	v20260728 "github.com/googleapis/mcp-toolbox/internal/server/mcp/v20260728"
 	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/sources/alloydbpg"
+	_ "github.com/googleapis/mcp-toolbox/internal/sources/postgres"
+	_ "github.com/googleapis/mcp-toolbox/internal/sources/sqlite"
 	"github.com/googleapis/mcp-toolbox/internal/telemetry"
 	"github.com/googleapis/mcp-toolbox/internal/testutils"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	_ "github.com/googleapis/mcp-toolbox/internal/tools/http"
+	"github.com/googleapis/mcp-toolbox/internal/tools/mysql/mysqlexecutesql"
+	"github.com/googleapis/mcp-toolbox/internal/tools/postgres/postgresexecutesql"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 )
 
@@ -2096,4 +2100,269 @@ func TestNewServer_Extensions(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestShouldSuppressTool(t *testing.T) {
+	ctx, err := testutils.ContextWithNewLogger()
+	if err != nil {
+		t.Fatalf("error setting up logger: %s", err)
+	}
+
+	readOnlySource := &testutils.MockSource{MockSourceConfig: testutils.MockSourceConfig{Name: "readonly-db", ReadOnly: true}}
+	readWriteSource := &testutils.MockSource{MockSourceConfig: testutils.MockSourceConfig{Name: "readwrite-db", ReadOnly: false}}
+
+	boolPtr := func(b bool) *bool { return &b }
+
+	initTool := func(cfg testutils.MockToolConfig) tools.Tool {
+		t, err := cfg.Initialize(ctx)
+		if err != nil {
+			panic(err)
+		}
+		return t
+	}
+
+	testCases := []struct {
+		desc   string
+		source sources.Source
+		tool   tools.Tool
+		want   bool
+	}{
+		{
+			desc:   "nil source -> not suppressed",
+			source: nil,
+			tool:   initTool(testutils.MockToolConfig{ConfigBase: tools.ConfigBase{Name: "some-tool"}, Source: "readonly-db"}),
+			want:   false,
+		},
+		{
+			desc:   "nil tool -> not suppressed",
+			source: readOnlySource,
+			tool:   nil,
+			want:   false,
+		},
+		{
+			desc:   "write tool on read-write source (readOnlyHint: false) -> not suppressed",
+			source: readWriteSource,
+			tool:   initTool(testutils.MockToolConfig{ConfigBase: tools.ConfigBase{Name: "write-tool"}, Source: "readwrite-db", Annotations: &tools.ToolAnnotations{ReadOnlyHint: boolPtr(false)}}),
+			want:   false,
+		},
+		{
+			desc:   "write tool on read-only source (readOnlyHint: false) -> suppressed",
+			source: readOnlySource,
+			tool:   initTool(testutils.MockToolConfig{ConfigBase: tools.ConfigBase{Name: "write-tool"}, Source: "readonly-db", Annotations: &tools.ToolAnnotations{ReadOnlyHint: boolPtr(false)}}),
+			want:   true,
+		},
+		{
+			desc:   "read-only tool on read-only source (readOnlyHint: true) -> not suppressed",
+			source: readOnlySource,
+			tool:   initTool(testutils.MockToolConfig{ConfigBase: tools.ConfigBase{Name: "readonly-tool"}, Source: "readonly-db", Annotations: &tools.ToolAnnotations{ReadOnlyHint: boolPtr(true)}}),
+			want:   false,
+		},
+		{
+			desc:   "unannotated tool on read-only source -> not suppressed",
+			source: readOnlySource,
+			tool:   initTool(testutils.MockToolConfig{ConfigBase: tools.ConfigBase{Name: "unannotated-tool"}, Source: "readonly-db", Annotations: nil}),
+			want:   false,
+		},
+		{
+			desc:   "tool with non-nil annotations but nil readOnlyHint on read-only source -> not suppressed",
+			source: readOnlySource,
+			tool:   initTool(testutils.MockToolConfig{ConfigBase: tools.ConfigBase{Name: "nil-hint-tool"}, Source: "readonly-db", Annotations: &tools.ToolAnnotations{ReadOnlyHint: nil}}),
+			want:   false,
+		},
+		{
+			desc:   "mysql-execute-sql on read-only source -> not suppressed (session locked at DB layer)",
+			source: readOnlySource,
+			tool: func() tools.Tool {
+				t, err := mysqlexecutesql.Config{
+					ConfigBase: tools.ConfigBase{Name: "mysql-execute-sql", Description: "execute sql query"},
+					Type:       "mysql-execute-sql",
+					Source:     "readonly-db",
+				}.Initialize(ctx)
+				if err != nil {
+					panic(err)
+				}
+				return t
+			}(),
+			want: false,
+		},
+		{
+			desc:   "postgres-execute-sql on read-only source -> not suppressed (session locked at DB layer)",
+			source: readOnlySource,
+			tool: func() tools.Tool {
+				t, err := postgresexecutesql.Config{
+					ConfigBase: tools.ConfigBase{Name: "postgres-execute-sql", Description: "execute sql query"},
+					Type:       "postgres-execute-sql",
+					Source:     "readonly-db",
+				}.Initialize(ctx)
+				if err != nil {
+					panic(err)
+				}
+				return t
+			}(),
+			want: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			if tc.tool == nil {
+				return
+			}
+			got := tc.tool.ShouldSuppress(ctx, tc.source)
+			if got != tc.want {
+				t.Errorf("Tool.ShouldSuppress(ctx) = %v, want %v", got, tc.want)
+			}
+			gotNilLogger := tc.tool.ShouldSuppress(context.Background(), tc.source)
+			if gotNilLogger != tc.want {
+				t.Errorf("Tool.ShouldSuppress(nil logger) = %v, want %v", gotNilLogger, tc.want)
+			}
+		})
+	}
+}
+
+func TestInitializeGroups(t *testing.T) {
+	ctx, err := testutils.ContextWithNewLogger()
+	if err != nil {
+		t.Fatalf("error setting up logger: %s", err)
+	}
+	instrumentation, err := telemetry.CreateTelemetryInstrumentation("0.0.0")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	ctx = util.WithInstrumentation(ctx, instrumentation)
+
+	boolPtr := func(b bool) *bool { return &b }
+
+	t.Run("suppressed tool is pruned from group", func(t *testing.T) {
+		cfg := server.ServerConfig{
+			SourceConfigs: server.SourceConfigs{
+				"readonly-db": &testutils.MockSourceConfig{Name: "readonly-db", ReadOnly: true},
+			},
+			ToolConfigs: server.ToolConfigs{
+				"allowed_read_tool": &testutils.MockToolConfig{
+					ConfigBase:  tools.ConfigBase{Name: "allowed_read_tool"},
+					Source:      "readonly-db",
+					Annotations: &tools.ToolAnnotations{ReadOnlyHint: boolPtr(true)},
+				},
+				"suppressed_write_tool": &testutils.MockToolConfig{
+					ConfigBase:  tools.ConfigBase{Name: "suppressed_write_tool"},
+					Source:      "readonly-db",
+					Annotations: &tools.ToolAnnotations{ReadOnlyHint: boolPtr(false)},
+				},
+			},
+			GroupConfigs: server.GroupConfigs{
+				"my-custom-group": group.GroupConfig{
+					Name:      "my-custom-group",
+					ToolNames: []string{"allowed_read_tool", "suppressed_write_tool"},
+				},
+			},
+		}
+
+		s, err := server.NewServer(ctx, cfg)
+		if err != nil {
+			t.Fatalf("failed to create server: %v", err)
+		}
+
+		grp, ok := s.PrimitiveMgr.GetGroup("my-custom-group")
+		if !ok {
+			t.Fatalf("expected group 'my-custom-group' to be registered, but not found")
+		}
+
+		// Verify allowed tool is present in group
+		if !grp.ContainsTool("allowed_read_tool") {
+			t.Errorf("expected group to contain 'allowed_read_tool'")
+		}
+
+		// Verify suppressed tool was pruned from group
+		if grp.ContainsTool("suppressed_write_tool") {
+			t.Errorf("expected group to NOT contain suppressed tool 'suppressed_write_tool'")
+		}
+
+		// Verify group ToolNames slice only contains allowed_read_tool
+		wantTools := []string{"allowed_read_tool"}
+		if diff := cmp.Diff(wantTools, grp.ToolNames); diff != "" {
+			t.Errorf("group ToolNames mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("group with all tools suppressed remains registered with empty tools", func(t *testing.T) {
+		cfg := server.ServerConfig{
+			SourceConfigs: server.SourceConfigs{
+				"readonly-db": &testutils.MockSourceConfig{Name: "readonly-db", ReadOnly: true},
+			},
+			ToolConfigs: server.ToolConfigs{
+				"write_tool_1": &testutils.MockToolConfig{
+					ConfigBase:  tools.ConfigBase{Name: "write_tool_1"},
+					Source:      "readonly-db",
+					Annotations: &tools.ToolAnnotations{ReadOnlyHint: boolPtr(false)},
+				},
+				"write_tool_2": &testutils.MockToolConfig{
+					ConfigBase:  tools.ConfigBase{Name: "write_tool_2"},
+					Source:      "readonly-db",
+					Annotations: &tools.ToolAnnotations{ReadOnlyHint: boolPtr(false)},
+				},
+			},
+			GroupConfigs: server.GroupConfigs{
+				"admin-group": group.GroupConfig{
+					Name:      "admin-group",
+					ToolNames: []string{"write_tool_1", "write_tool_2"},
+				},
+			},
+		}
+
+		s, err := server.NewServer(ctx, cfg)
+		if err != nil {
+			t.Fatalf("failed to create server: %v", err)
+		}
+
+		grp, ok := s.PrimitiveMgr.GetGroup("admin-group")
+		if !ok {
+			t.Fatalf("expected group 'admin-group' to be registered even when empty, but not found")
+		}
+
+		if len(grp.ToolNames) != 0 {
+			t.Errorf("expected group ToolNames to be empty, got: %v", grp.ToolNames)
+		}
+	})
+
+	t.Run("group with no tools suppressed initializes normally", func(t *testing.T) {
+		cfg := server.ServerConfig{
+			SourceConfigs: server.SourceConfigs{
+				"readwrite-db": &testutils.MockSourceConfig{Name: "readwrite-db", ReadOnly: false},
+			},
+			ToolConfigs: server.ToolConfigs{
+				"tool_1": &testutils.MockToolConfig{
+					ConfigBase:  tools.ConfigBase{Name: "tool_1"},
+					Source:      "readwrite-db",
+					Annotations: &tools.ToolAnnotations{ReadOnlyHint: boolPtr(false)},
+				},
+				"tool_2": &testutils.MockToolConfig{
+					ConfigBase:  tools.ConfigBase{Name: "tool_2"},
+					Source:      "readwrite-db",
+					Annotations: &tools.ToolAnnotations{ReadOnlyHint: boolPtr(true)},
+				},
+			},
+			GroupConfigs: server.GroupConfigs{
+				"all-tools-group": group.GroupConfig{
+					Name:      "all-tools-group",
+					ToolNames: []string{"tool_1", "tool_2"},
+				},
+			},
+		}
+
+		s, err := server.NewServer(ctx, cfg)
+		if err != nil {
+			t.Fatalf("failed to create server: %v", err)
+		}
+
+		grp, ok := s.PrimitiveMgr.GetGroup("all-tools-group")
+		if !ok {
+			t.Fatalf("expected group 'all-tools-group' to be registered, but not found")
+		}
+
+		wantTools := []string{"tool_1", "tool_2"}
+		if diff := cmp.Diff(wantTools, grp.ToolNames); diff != "" {
+			t.Errorf("group ToolNames mismatch (-want +got):\n%s", diff)
+		}
+	})
 }

--- a/internal/sources/alloydbadmin/alloydbadmin.go
+++ b/internal/sources/alloydbadmin/alloydbadmin.go
@@ -56,6 +56,7 @@ type Config struct {
 	Type           string `yaml:"type" validate:"required"`
 	DefaultProject string `yaml:"defaultProject"`
 	UseClientOAuth bool   `yaml:"useClientOAuth"`
+	ReadOnly       bool   `yaml:"readOnly"`
 }
 
 func (r Config) SourceConfigType() string {
@@ -104,6 +105,10 @@ type Source struct {
 	Config
 	BaseURL string
 	Service *alloydbrestapi.Service
+}
+
+func (s *Source) IsReadOnly() bool {
+	return s.ReadOnly
 }
 
 func (s *Source) SourceType() string {

--- a/internal/sources/alloydbadmin/alloydbadmin_test.go
+++ b/internal/sources/alloydbadmin/alloydbadmin_test.go
@@ -62,6 +62,23 @@ func TestParseFromYamlAlloyDBAdmin(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc: "readOnly set to true",
+			in: `
+			kind: source
+			name: my-alloydb-admin-instance
+			type: alloydb-admin
+			readOnly: true
+			`,
+			want: map[string]sources.SourceConfig{
+				"my-alloydb-admin-instance": alloydbadmin.Config{
+					Name:           "my-alloydb-admin-instance",
+					Type:           alloydbadmin.SourceType,
+					UseClientOAuth: false,
+					ReadOnly:       true,
+				},
+			},
+		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
@@ -72,6 +89,14 @@ func TestParseFromYamlAlloyDBAdmin(t *testing.T) {
 			}
 			if !cmp.Equal(tc.want, got) {
 				t.Fatalf("incorrect parse: want %v, got %v", tc.want, got)
+			}
+			for _, sc := range got {
+				if cfg, ok := sc.(alloydbadmin.Config); ok {
+					src := &alloydbadmin.Source{Config: cfg}
+					if src.IsReadOnly() != cfg.ReadOnly {
+						t.Errorf("IsReadOnly() = %v, want %v", src.IsReadOnly(), cfg.ReadOnly)
+					}
+				}
 			}
 		})
 	}

--- a/internal/sources/alloydbpg/alloydb_pg.go
+++ b/internal/sources/alloydbpg/alloydb_pg.go
@@ -92,6 +92,10 @@ type Source struct {
 	Pool *pgxpool.Pool
 }
 
+func (s *Source) IsReadOnly() bool {
+	return false
+}
+
 func (s *Source) SourceType() string {
 	return SourceType
 }

--- a/internal/sources/arcadedb/arcadedb.go
+++ b/internal/sources/arcadedb/arcadedb.go
@@ -102,6 +102,10 @@ type Source struct {
 	Driver neo4j.Driver
 }
 
+func (s *Source) IsReadOnly() bool {
+	return false
+}
+
 func (s *Source) SourceType() string {
 	return SourceType
 }

--- a/internal/sources/bigquery/bigquery.go
+++ b/internal/sources/bigquery/bigquery.go
@@ -313,6 +313,10 @@ type Session struct {
 	LastUsed     time.Time
 }
 
+func (s *Source) IsReadOnly() bool {
+	return false
+}
+
 func (s *Source) SourceType() string {
 	// Returns BigQuery Google SQL source type
 	return SourceType

--- a/internal/sources/bigtable/bigtable.go
+++ b/internal/sources/bigtable/bigtable.go
@@ -91,6 +91,10 @@ type Source struct {
 	Admin         *bigtable.AdminClient
 }
 
+func (s *Source) IsReadOnly() bool {
+	return false
+}
+
 func (s *Source) SourceType() string {
 	return SourceType
 }

--- a/internal/sources/cassandra/cassandra.go
+++ b/internal/sources/cassandra/cassandra.go
@@ -90,6 +90,10 @@ func (s *Source) ToConfig() sources.SourceConfig {
 }
 
 // SourceType implements sources.Source.
+func (s *Source) IsReadOnly() bool {
+	return false
+}
+
 func (s *Source) SourceType() string {
 	return SourceType
 }

--- a/internal/sources/clickhouse/clickhouse.go
+++ b/internal/sources/clickhouse/clickhouse.go
@@ -88,6 +88,10 @@ type Source struct {
 	Pool *sql.DB
 }
 
+func (s *Source) IsReadOnly() bool {
+	return false
+}
+
 func (s *Source) SourceType() string {
 	return SourceType
 }

--- a/internal/sources/cloudgda/cloud_gda.go
+++ b/internal/sources/cloudgda/cloud_gda.go
@@ -93,6 +93,10 @@ type Source struct {
 	userAgent string
 }
 
+func (s *Source) IsReadOnly() bool {
+	return false
+}
+
 func (s *Source) SourceType() string {
 	return SourceType
 }

--- a/internal/sources/cloudhealthcare/cloud_healthcare.go
+++ b/internal/sources/cloudhealthcare/cloud_healthcare.go
@@ -203,6 +203,10 @@ type Source struct {
 	allowedDICOMStores map[string]struct{}
 }
 
+func (s *Source) IsReadOnly() bool {
+	return false
+}
+
 func (s *Source) SourceType() string {
 	return SourceType
 }

--- a/internal/sources/cloudloggingadmin/cloud_logging_admin.go
+++ b/internal/sources/cloudloggingadmin/cloud_logging_admin.go
@@ -113,6 +113,10 @@ type Source struct {
 	logadminClientCache *sources.Cache
 }
 
+func (s *Source) IsReadOnly() bool {
+	return false
+}
+
 func (s *Source) SourceType() string {
 	// Returns logadmin source type
 	return SourceType

--- a/internal/sources/cloudmonitoring/cloud_monitoring.go
+++ b/internal/sources/cloudmonitoring/cloud_monitoring.go
@@ -99,6 +99,10 @@ type Source struct {
 	userAgent string
 }
 
+func (s *Source) IsReadOnly() bool {
+	return false
+}
+
 func (s *Source) SourceType() string {
 	return SourceType
 }

--- a/internal/sources/cloudsqladmin/cloud_sql_admin.go
+++ b/internal/sources/cloudsqladmin/cloud_sql_admin.go
@@ -64,6 +64,7 @@ type Config struct {
 	Type           string `yaml:"type" validate:"required"`
 	DefaultProject string `yaml:"defaultProject"`
 	UseClientOAuth bool   `yaml:"useClientOAuth"`
+	ReadOnly       bool   `yaml:"readOnly"`
 }
 
 func (r Config) SourceConfigType() string {
@@ -112,6 +113,10 @@ type Source struct {
 	Config
 	BaseURL string
 	Service *sqladmin.Service
+}
+
+func (s *Source) IsReadOnly() bool {
+	return s.ReadOnly
 }
 
 func (s *Source) SourceType() string {

--- a/internal/sources/cloudsqladmin/cloud_sql_admin_test.go
+++ b/internal/sources/cloudsqladmin/cloud_sql_admin_test.go
@@ -63,6 +63,23 @@ func TestParseFromYamlCloudSQLAdmin(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc: "readOnly set to true",
+			in: `
+			kind: source
+			name: my-cloud-sql-admin-instance
+			type: cloud-sql-admin
+			readOnly: true
+			`,
+			want: map[string]sources.SourceConfig{
+				"my-cloud-sql-admin-instance": cloudsqladmin.Config{
+					Name:           "my-cloud-sql-admin-instance",
+					Type:           cloudsqladmin.SourceType,
+					UseClientOAuth: false,
+					ReadOnly:       true,
+				},
+			},
+		},
 	}
 	for _, tc := range tcs {
 		tc := tc
@@ -74,6 +91,14 @@ func TestParseFromYamlCloudSQLAdmin(t *testing.T) {
 			}
 			if !cmp.Equal(tc.want, got) {
 				t.Fatalf("incorrect parse: want %v, got %v", tc.want, got)
+			}
+			for _, sc := range got {
+				if cfg, ok := sc.(cloudsqladmin.Config); ok {
+					src := &cloudsqladmin.Source{Config: cfg}
+					if src.IsReadOnly() != cfg.ReadOnly {
+						t.Errorf("IsReadOnly() = %v, want %v", src.IsReadOnly(), cfg.ReadOnly)
+					}
+				}
 			}
 		})
 	}

--- a/internal/sources/cloudsqlmssql/cloud_sql_mssql.go
+++ b/internal/sources/cloudsqlmssql/cloud_sql_mssql.go
@@ -93,6 +93,10 @@ type Source struct {
 	Db *sql.DB
 }
 
+func (s *Source) IsReadOnly() bool {
+	return false
+}
+
 func (s *Source) SourceType() string {
 	// Returns Cloud SQL MSSQL source type
 	return SourceType

--- a/internal/sources/cloudsqlmysql/cloud_sql_mysql.go
+++ b/internal/sources/cloudsqlmysql/cloud_sql_mysql.go
@@ -92,6 +92,10 @@ type Source struct {
 	Pool *sql.DB
 }
 
+func (s *Source) IsReadOnly() bool {
+	return false
+}
+
 func (s *Source) SourceType() string {
 	return SourceType
 }

--- a/internal/sources/cloudsqlpg/cloud_sql_pg.go
+++ b/internal/sources/cloudsqlpg/cloud_sql_pg.go
@@ -98,6 +98,10 @@ type Source struct {
 	Pool *pgxpool.Pool
 }
 
+func (s *Source) IsReadOnly() bool {
+	return false
+}
+
 func (s *Source) SourceType() string {
 	return SourceType
 }

--- a/internal/sources/cloudstorage/cloudstorage.go
+++ b/internal/sources/cloudstorage/cloudstorage.go
@@ -167,6 +167,10 @@ func isUnderRoot(target, root string) bool {
 	return strings.HasPrefix(target, root)
 }
 
+func (s *Source) IsReadOnly() bool {
+	return false
+}
+
 func (s *Source) SourceType() string {
 	return SourceType
 }

--- a/internal/sources/cockroachdb/cockroachdb.go
+++ b/internal/sources/cockroachdb/cockroachdb.go
@@ -122,6 +122,10 @@ type Source struct {
 	Pool *pgxpool.Pool
 }
 
+func (s *Source) IsReadOnly() bool {
+	return false
+}
+
 func (s *Source) SourceType() string {
 	return SourceType
 }

--- a/internal/sources/couchbase/couchbase.go
+++ b/internal/sources/couchbase/couchbase.go
@@ -96,6 +96,10 @@ type Source struct {
 	Scope *gocb.Scope
 }
 
+func (s *Source) IsReadOnly() bool {
+	return false
+}
+
 func (s *Source) SourceType() string {
 	return SourceType
 }

--- a/internal/sources/databaseinsights/databaseinsights.go
+++ b/internal/sources/databaseinsights/databaseinsights.go
@@ -83,6 +83,10 @@ type Source struct {
 	endpoint   string
 }
 
+func (s *Source) IsReadOnly() bool {
+	return false
+}
+
 func (s *Source) SourceType() string {
 	return SourceKind
 }

--- a/internal/sources/datalineage/datalineage.go
+++ b/internal/sources/datalineage/datalineage.go
@@ -78,6 +78,10 @@ type Source struct {
 	Client *lineage.Client
 }
 
+func (s *Source) IsReadOnly() bool {
+	return false
+}
+
 func (s *Source) SourceType() string {
 	return SourceType
 }

--- a/internal/sources/dataplex/dataplex.go
+++ b/internal/sources/dataplex/dataplex.go
@@ -139,6 +139,10 @@ type Source struct {
 	projectNumber     int64
 }
 
+func (s *Source) IsReadOnly() bool {
+	return false
+}
+
 func (s *Source) SourceType() string {
 	// Returns Dataplex source type
 	return SourceType

--- a/internal/sources/dataproc/dataproc.go
+++ b/internal/sources/dataproc/dataproc.go
@@ -100,6 +100,10 @@ type Source struct {
 	JobClient *dataproc.JobControllerClient
 }
 
+func (s *Source) IsReadOnly() bool {
+	return false
+}
+
 func (s *Source) SourceType() string {
 	return SourceType
 }

--- a/internal/sources/dgraph/dgraph.go
+++ b/internal/sources/dgraph/dgraph.go
@@ -103,6 +103,10 @@ type Source struct {
 	Client *DgraphClient `yaml:"client"`
 }
 
+func (s *Source) IsReadOnly() bool {
+	return false
+}
+
 func (s *Source) SourceType() string {
 	return SourceType
 }

--- a/internal/sources/elasticsearch/elasticsearch.go
+++ b/internal/sources/elasticsearch/elasticsearch.go
@@ -140,6 +140,10 @@ func (c Config) Initialize(ctx context.Context, tracer trace.Tracer) (sources.So
 }
 
 // SourceType returns the resourceType string for this source.
+func (s *Source) IsReadOnly() bool {
+	return false
+}
+
 func (s *Source) SourceType() string {
 	return SourceType
 }

--- a/internal/sources/firebird/firebird.go
+++ b/internal/sources/firebird/firebird.go
@@ -84,6 +84,10 @@ type Source struct {
 	Db *sql.DB
 }
 
+func (s *Source) IsReadOnly() bool {
+	return false
+}
+
 func (s *Source) SourceType() string {
 	return SourceType
 }

--- a/internal/sources/firestore/firestore.go
+++ b/internal/sources/firestore/firestore.go
@@ -97,6 +97,10 @@ type Source struct {
 	RulesClient *firebaserules.Service
 }
 
+func (s *Source) IsReadOnly() bool {
+	return false
+}
+
 func (s *Source) SourceType() string {
 	// Returns Firestore source type
 	return SourceType

--- a/internal/sources/http/http.go
+++ b/internal/sources/http/http.go
@@ -173,6 +173,10 @@ type Source struct {
 	client *http.Client
 }
 
+func (s *Source) IsReadOnly() bool {
+	return false
+}
+
 func (s *Source) SourceType() string {
 	return SourceType
 }

--- a/internal/sources/looker/looker.go
+++ b/internal/sources/looker/looker.go
@@ -165,6 +165,10 @@ type Source struct {
 	hostURLGroup    singleflight.Group
 }
 
+func (s *Source) IsReadOnly() bool {
+	return false
+}
+
 func (s *Source) SourceType() string {
 	return SourceType
 }

--- a/internal/sources/mindsdb/mindsdb.go
+++ b/internal/sources/mindsdb/mindsdb.go
@@ -86,6 +86,10 @@ type Source struct {
 	Pool *sql.DB
 }
 
+func (s *Source) IsReadOnly() bool {
+	return false
+}
+
 func (s *Source) SourceType() string {
 	return SourceType
 }

--- a/internal/sources/mongodb/mongodb.go
+++ b/internal/sources/mongodb/mongodb.go
@@ -84,6 +84,10 @@ type Source struct {
 	Client *mongo.Client
 }
 
+func (s *Source) IsReadOnly() bool {
+	return false
+}
+
 func (s *Source) SourceType() string {
 	return SourceType
 }

--- a/internal/sources/mssql/mssql.go
+++ b/internal/sources/mssql/mssql.go
@@ -91,6 +91,10 @@ type Source struct {
 	Db *sql.DB
 }
 
+func (s *Source) IsReadOnly() bool {
+	return false
+}
+
 func (s *Source) SourceType() string {
 	// Returns Cloud SQL MSSQL source type
 	return SourceType

--- a/internal/sources/mysql/mysql.go
+++ b/internal/sources/mysql/mysql.go
@@ -91,6 +91,10 @@ type Source struct {
 	Pool *sql.DB
 }
 
+func (s *Source) IsReadOnly() bool {
+	return false
+}
+
 func (s *Source) SourceType() string {
 	return SourceType
 }

--- a/internal/sources/neo4j/neo4j.go
+++ b/internal/sources/neo4j/neo4j.go
@@ -91,6 +91,10 @@ type Source struct {
 	Driver neo4j.Driver
 }
 
+func (s *Source) IsReadOnly() bool {
+	return false
+}
+
 func (s *Source) SourceType() string {
 	return SourceType
 }

--- a/internal/sources/oceanbase/oceanbase.go
+++ b/internal/sources/oceanbase/oceanbase.go
@@ -86,6 +86,10 @@ type Source struct {
 	Pool *sql.DB
 }
 
+func (s *Source) IsReadOnly() bool {
+	return false
+}
+
 func (s *Source) SourceType() string {
 	return SourceType
 }

--- a/internal/sources/oracle/oracle.go
+++ b/internal/sources/oracle/oracle.go
@@ -125,6 +125,10 @@ type Source struct {
 	DB *sql.DB
 }
 
+func (s *Source) IsReadOnly() bool {
+	return false
+}
+
 func (s *Source) SourceType() string {
 	return SourceType
 }

--- a/internal/sources/postgres/postgres.go
+++ b/internal/sources/postgres/postgres.go
@@ -96,6 +96,10 @@ type Source struct {
 	Pool *pgxpool.Pool
 }
 
+func (s *Source) IsReadOnly() bool {
+	return false
+}
+
 func (s *Source) SourceType() string {
 	return SourceType
 }

--- a/internal/sources/redis/redis.go
+++ b/internal/sources/redis/redis.go
@@ -157,6 +157,10 @@ type Source struct {
 	Client RedisClient
 }
 
+func (s *Source) IsReadOnly() bool {
+	return false
+}
+
 func (s *Source) SourceType() string {
 	return SourceType
 }

--- a/internal/sources/scylladb/scylladb.go
+++ b/internal/sources/scylladb/scylladb.go
@@ -101,6 +101,10 @@ func (s *Source) ToConfig() sources.SourceConfig {
 }
 
 // SourceType implements sources.Source.
+func (s *Source) IsReadOnly() bool {
+	return false
+}
+
 func (s *Source) SourceType() string {
 	return SourceType
 }

--- a/internal/sources/serverlessspark/serverlessspark.go
+++ b/internal/sources/serverlessspark/serverlessspark.go
@@ -107,6 +107,10 @@ type Source struct {
 	SessionClient         *dataproc.SessionControllerClient
 }
 
+func (s *Source) IsReadOnly() bool {
+	return false
+}
+
 func (s *Source) SourceType() string {
 	return SourceType
 }

--- a/internal/sources/singlestore/singlestore.go
+++ b/internal/sources/singlestore/singlestore.go
@@ -94,6 +94,10 @@ type Source struct {
 }
 
 // SourceType returns the type of the source configuration.
+func (s *Source) IsReadOnly() bool {
+	return false
+}
+
 func (s *Source) SourceType() string {
 	return SourceType
 }

--- a/internal/sources/snowflake/snowflake.go
+++ b/internal/sources/snowflake/snowflake.go
@@ -85,6 +85,10 @@ type Source struct {
 	DB *sqlx.DB
 }
 
+func (s *Source) IsReadOnly() bool {
+	return false
+}
+
 func (s *Source) SourceType() string {
 	return SourceType
 }

--- a/internal/sources/sources.go
+++ b/internal/sources/sources.go
@@ -66,6 +66,7 @@ type SourceConfig interface {
 type Source interface {
 	SourceType() string
 	ToConfig() SourceConfig
+	IsReadOnly() bool
 }
 
 // InitConnectionSpan adds a span for database pool connection initialization

--- a/internal/sources/spanner/spanner.go
+++ b/internal/sources/spanner/spanner.go
@@ -94,6 +94,10 @@ type Source struct {
 	dataplexMgr *searchcatalog.DataplexClientManager
 }
 
+func (s *Source) IsReadOnly() bool {
+	return false
+}
+
 func (s *Source) SourceType() string {
 	return SourceType
 }

--- a/internal/sources/sqlite/sqlite.go
+++ b/internal/sources/sqlite/sqlite.go
@@ -83,6 +83,10 @@ type Source struct {
 	Db *sql.DB
 }
 
+func (s *Source) IsReadOnly() bool {
+	return false
+}
+
 func (s *Source) SourceType() string {
 	return SourceType
 }

--- a/internal/sources/tidb/tidb.go
+++ b/internal/sources/tidb/tidb.go
@@ -93,6 +93,10 @@ type Source struct {
 	Pool *sql.DB
 }
 
+func (s *Source) IsReadOnly() bool {
+	return false
+}
+
 func (s *Source) SourceType() string {
 	return SourceType
 }

--- a/internal/sources/trino/trino.go
+++ b/internal/sources/trino/trino.go
@@ -96,6 +96,10 @@ type Source struct {
 	Pool *sql.DB
 }
 
+func (s *Source) IsReadOnly() bool {
+	return false
+}
+
 func (s *Source) SourceType() string {
 	return SourceType
 }

--- a/internal/sources/valkey/valkey.go
+++ b/internal/sources/valkey/valkey.go
@@ -114,6 +114,10 @@ type Source struct {
 	Client valkey.Client
 }
 
+func (s *Source) IsReadOnly() bool {
+	return false
+}
+
 func (s *Source) SourceType() string {
 	return SourceType
 }

--- a/internal/sources/yugabytedb/yugabytedb.go
+++ b/internal/sources/yugabytedb/yugabytedb.go
@@ -87,6 +87,10 @@ type Source struct {
 	Pool *pgxpool.Pool
 }
 
+func (s *Source) IsReadOnly() bool {
+	return false
+}
+
 func (s *Source) SourceType() string {
 	return SourceType
 }

--- a/internal/testutils/mocks.go
+++ b/internal/testutils/mocks.go
@@ -28,13 +28,17 @@ import (
 
 // MockSourceConfig is used to mock source config in tests
 type MockSourceConfig struct {
-	Name string `yaml:"name"`
-	Type string `yaml:"type"`
-	Foo  string `yaml:"foo"`
+	Name     string `yaml:"name"`
+	Type     string `yaml:"type"`
+	Foo      string `yaml:"foo"`
+	ReadOnly bool   `yaml:"readOnly"`
 }
 
 func (m MockSourceConfig) SourceConfigType() string {
-	return m.Type
+	if m.Type != "" {
+		return m.Type
+	}
+	return "mock-source"
 }
 
 func (m MockSourceConfig) Initialize(ctx context.Context, tracer trace.Tracer) (sources.Source, error) {
@@ -46,8 +50,15 @@ type MockSource struct {
 	MockSourceConfig
 }
 
+func (s MockSource) IsReadOnly() bool {
+	return s.ReadOnly
+}
+
 func (s MockSource) SourceType() string {
-	return s.Type
+	if s.Type != "" {
+		return s.Type
+	}
+	return "mock-source"
 }
 
 func (s MockSource) ToConfig() sources.SourceConfig {
@@ -57,19 +68,23 @@ func (s MockSource) ToConfig() sources.SourceConfig {
 // MockToolConfig is used to mock tool config in tests
 type MockToolConfig struct {
 	tools.ConfigBase `yaml:",inline"`
-	Source           string                `yaml:"source"`
-	Parameters       parameters.Parameters `yaml:"parameters"`
-	Type             string                `yaml:"type"`
+	Source           string                 `yaml:"source"`
+	Parameters       parameters.Parameters  `yaml:"parameters"`
+	Type             string                 `yaml:"type"`
+	Annotations      *tools.ToolAnnotations `yaml:"annotations,omitempty"`
 }
 
 func (m MockToolConfig) ToolConfigType() string {
+	if m.Type != "" {
+		return m.Type
+	}
 	return "mock-tool"
 }
 
 func (m MockToolConfig) Initialize(context.Context) (tools.Tool, error) {
 	return MockTool{
 		BaseTool: tools.NewBaseTool(
-			m, tools.GetAnnotationsOrDefault(&tools.ToolAnnotations{}, nil),
+			m, m.Annotations,
 			tools.Manifest{Description: m.Description, Parameters: m.Parameters.Manifest(), AuthRequired: m.AuthRequired},
 			m.Parameters,
 		),
@@ -107,6 +122,14 @@ func NewMockTool(name, desc, source string, params []parameters.Parameter, unaut
 	return mt
 }
 
+func (t MockTool) GetSourceName() string {
+	return t.Cfg.Source
+}
+
+func (t MockTool) ToConfig() tools.ToolConfig {
+	return t.Cfg
+}
+
 func (t MockTool) RequiresClientAuthorization(sources.Source) (bool, error) {
 	// defaulted to false
 	return t.requireClientAuthorization, nil
@@ -120,14 +143,6 @@ func (t MockTool) Invoke(ctx context.Context, s sources.Source, params parameter
 		}
 	}
 	return mock, nil
-}
-
-func (t MockTool) GetSourceName() string {
-	return t.Cfg.Source
-}
-
-func (t MockTool) ToConfig() tools.ToolConfig {
-	return t.Cfg
 }
 
 func (t MockTool) Authorized(verifiedAuthServices []string) bool {
@@ -145,10 +160,6 @@ func (t MockTool) ValidateSource(src sources.Source) error {
 // claims is a map of user info decoded from an auth token
 func (t MockTool) ParseParams(data map[string]any, claimsMap map[string]map[string]any) (parameters.ParamValues, error) {
 	return parameters.ParseParams(t.StaticParameters, data, claimsMap)
-}
-
-func (t MockTool) GetAnnotations() *tools.ToolAnnotations {
-	return nil
 }
 
 // MockPrompt is used to mock prompts in tests

--- a/internal/tools/cloudgda/cloudgda_test.go
+++ b/internal/tools/cloudgda/cloudgda_test.go
@@ -135,6 +135,10 @@ func (f *fakeSource) UseClientAuthorization() bool {
 	return f.useClientOAuth
 }
 
+func (f *fakeSource) IsReadOnly() bool {
+	return false
+}
+
 func (f *fakeSource) SourceType() string {
 	return "cloud-gemini-data-analytics"
 }

--- a/internal/tools/cloudsqlpg/vectorassistapplyspec/vectorassistapplyspec.go
+++ b/internal/tools/cloudsqlpg/vectorassistapplyspec/vectorassistapplyspec.go
@@ -56,8 +56,9 @@ type compatibleSource interface {
 
 type Config struct {
 	tools.ConfigBase `yaml:",inline"`
-	Type             string `yaml:"type" validate:"required"`
-	Source           string `yaml:"source" validate:"required"`
+	Type             string                 `yaml:"type" validate:"required"`
+	Source           string                 `yaml:"source" validate:"required"`
+	Annotations      *tools.ToolAnnotations `yaml:"annotations,omitempty"`
 }
 
 var _ tools.ToolConfig = Config{}
@@ -82,7 +83,7 @@ func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	return Tool{
 		BaseTool: tools.NewBaseTool(
 			cfg,
-			nil,
+			tools.GetAnnotationsOrDefault(cfg.Annotations, tools.NewDestructiveAnnotations),
 			tools.Manifest{Description: cfg.Description, Parameters: allParameters.Manifest(), AuthRequired: cfg.AuthRequired},
 			allParameters,
 		),

--- a/internal/tools/cloudsqlpg/vectorassistdefinespec/vectorassistdefinespec.go
+++ b/internal/tools/cloudsqlpg/vectorassistdefinespec/vectorassistdefinespec.go
@@ -63,8 +63,9 @@ type compatibleSource interface {
 
 type Config struct {
 	tools.ConfigBase `yaml:",inline"`
-	Type             string `yaml:"type" validate:"required"`
-	Source           string `yaml:"source" validate:"required"`
+	Type             string                 `yaml:"type" validate:"required"`
+	Source           string                 `yaml:"source" validate:"required"`
+	Annotations      *tools.ToolAnnotations `yaml:"annotations,omitempty"`
 }
 
 var _ tools.ToolConfig = Config{}
@@ -102,7 +103,7 @@ func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	return Tool{
 		BaseTool: tools.NewBaseTool(
 			cfg,
-			nil,
+			tools.GetAnnotationsOrDefault(cfg.Annotations, tools.NewWriteAnnotations),
 			tools.Manifest{Description: cfg.Description, Parameters: allParameters.Manifest(), AuthRequired: cfg.AuthRequired},
 			allParameters,
 		),

--- a/internal/tools/cloudsqlpg/vectorassistgeneratequery/vectorassistgeneratequery.go
+++ b/internal/tools/cloudsqlpg/vectorassistgeneratequery/vectorassistgeneratequery.go
@@ -64,8 +64,9 @@ type compatibleSource interface {
 
 type Config struct {
 	tools.ConfigBase `yaml:",inline"`
-	Type             string `yaml:"type" validate:"required"`
-	Source           string `yaml:"source" validate:"required"`
+	Type             string                 `yaml:"type" validate:"required"`
+	Source           string                 `yaml:"source" validate:"required"`
+	Annotations      *tools.ToolAnnotations `yaml:"annotations,omitempty"`
 }
 
 var _ tools.ToolConfig = Config{}
@@ -97,7 +98,7 @@ func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	return Tool{
 		BaseTool: tools.NewBaseTool(
 			cfg,
-			nil,
+			tools.GetAnnotationsOrDefault(cfg.Annotations, tools.NewReadOnlyAnnotations),
 			tools.Manifest{Description: cfg.Description, Parameters: allParameters.Manifest(), AuthRequired: cfg.AuthRequired},
 			allParameters,
 		),

--- a/internal/tools/cloudsqlpg/vectorassistgetspec/vectorassistgetspec.go
+++ b/internal/tools/cloudsqlpg/vectorassistgetspec/vectorassistgetspec.go
@@ -80,7 +80,7 @@ func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	return Tool{
 		BaseTool: tools.NewBaseTool(
 			cfg,
-			tools.GetAnnotationsOrDefault(cfg.Annotations, tools.NewDestructiveAnnotations),
+			tools.GetAnnotationsOrDefault(cfg.Annotations, tools.NewReadOnlyAnnotations),
 			tools.Manifest{Description: cfg.Description, Parameters: paramManifest, AuthRequired: cfg.AuthRequired},
 			allParameters,
 		),

--- a/internal/tools/cloudsqlpg/vectorassistimprovequeryrecall/vectorassistimprovequeryrecall.go
+++ b/internal/tools/cloudsqlpg/vectorassistimprovequeryrecall/vectorassistimprovequeryrecall.go
@@ -107,7 +107,7 @@ func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	return Tool{
 		BaseTool: tools.NewBaseTool(
 			cfg,
-			tools.GetAnnotationsOrDefault(cfg.Annotations, tools.NewDestructiveAnnotations),
+			tools.GetAnnotationsOrDefault(cfg.Annotations, tools.NewReadOnlyAnnotations),
 			tools.Manifest{Description: cfg.Description, Parameters: paramManifest, AuthRequired: cfg.AuthRequired},
 			allParameters,
 		),

--- a/internal/tools/cloudsqlpg/vectorassistlistspecs/vectorassistlistspecs.go
+++ b/internal/tools/cloudsqlpg/vectorassistlistspecs/vectorassistlistspecs.go
@@ -81,7 +81,7 @@ func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	return Tool{
 		BaseTool: tools.NewBaseTool(
 			cfg,
-			tools.GetAnnotationsOrDefault(cfg.Annotations, tools.NewDestructiveAnnotations),
+			tools.GetAnnotationsOrDefault(cfg.Annotations, tools.NewReadOnlyAnnotations),
 			tools.Manifest{Description: cfg.Description, Parameters: paramManifest, AuthRequired: cfg.AuthRequired},
 			allParameters,
 		),

--- a/internal/tools/cloudsqlpg/vectorassistmodifyspec/vectorassistmodifyspec.go
+++ b/internal/tools/cloudsqlpg/vectorassistmodifyspec/vectorassistmodifyspec.go
@@ -63,8 +63,9 @@ type compatibleSource interface {
 
 type Config struct {
 	tools.ConfigBase `yaml:",inline"`
-	Type             string `yaml:"type" validate:"required"`
-	Source           string `yaml:"source" validate:"required"`
+	Type             string                 `yaml:"type" validate:"required"`
+	Source           string                 `yaml:"source" validate:"required"`
+	Annotations      *tools.ToolAnnotations `yaml:"annotations,omitempty"`
 }
 
 var _ tools.ToolConfig = Config{}
@@ -102,7 +103,7 @@ func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	return Tool{
 		BaseTool: tools.NewBaseTool(
 			cfg,
-			nil,
+			tools.GetAnnotationsOrDefault(cfg.Annotations, tools.NewWriteAnnotations),
 			tools.Manifest{Description: cfg.Description, Parameters: allParameters.Manifest(), AuthRequired: cfg.AuthRequired},
 			allParameters,
 		),

--- a/internal/tools/mysql/mysqlexecutesql/mysqlexecutesql.go
+++ b/internal/tools/mysql/mysqlexecutesql/mysqlexecutesql.go
@@ -126,3 +126,10 @@ func (t Tool) ValidateSource(source sources.Source) error {
 	}
 	return nil
 }
+
+// ShouldSuppress returns false because single execute_sql tools for MySQL
+// are secured at the database connection layer via connection-string locking parameters.
+// They must remain exposed in read-only mode.
+func (t Tool) ShouldSuppress(ctx context.Context, source sources.Source) bool {
+	return false
+}

--- a/internal/tools/postgres/postgresexecutesql/postgresexecutesql.go
+++ b/internal/tools/postgres/postgresexecutesql/postgresexecutesql.go
@@ -123,3 +123,10 @@ func (t Tool) ValidateSource(source sources.Source) error {
 	}
 	return nil
 }
+
+// ShouldSuppress returns false because single execute_sql tools for Postgres/AlloyDB
+// are secured at the database connection layer via connection-string locking parameters
+// (cloudsql_session_read_only=locked). They must remain exposed in read-only mode.
+func (t Tool) ShouldSuppress(ctx context.Context, source sources.Source) bool {
+	return false
+}

--- a/internal/tools/spanner/spannersearchcatalog/spannersearchcatalog_test.go
+++ b/internal/tools/spanner/spannersearchcatalog/spannersearchcatalog_test.go
@@ -90,6 +90,7 @@ func (m mockSpannerSource) GetCatalogClient(ctx context.Context, tokenString str
 func (m mockSpannerSource) InvokeSearchCatalog(ctx context.Context, params map[string]any, tokenStr string) ([]searchcatalog.DataplexSearchResponse, error) {
 	return m.searchResponse, m.err
 }
+func (m mockSpannerSource) IsReadOnly() bool               { return false }
 func (m mockSpannerSource) SourceType() string             { return "spanner" }
 func (m mockSpannerSource) ToConfig() sources.SourceConfig { return nil }
 

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -139,6 +139,7 @@ type Tool interface {
 	GetParameters(sources.Source) (parameters.Parameters, error)
 	GetScopesRequired() []string
 	ValidateSource(sources.Source) error
+	ShouldSuppress(context.Context, sources.Source) bool
 }
 
 // PrimitiveManagerI defines the minimal view of the primitives.PrimitiveManager
@@ -257,4 +258,34 @@ func (b BaseTool[T]) GetAuthTokenHeaderName(_ sources.Source) (string, error) {
 
 func (b BaseTool[T]) EmbedParams(ctx context.Context, paramValues parameters.ParamValues, pMgr PrimitiveManagerI) (parameters.ParamValues, error) {
 	return parameters.EmbedParams(ctx, b.StaticParameters, paramValues, pMgr, nil)
+}
+
+// ShouldSuppress returns true if the tool should be suppressed from registration
+// when its data source is in read-only mode, and logs relevant warnings or info messages.
+// By default, if the source is read-only and the tool's ReadOnlyHint is explicitly false,
+// the tool is suppressed. Unannotated tools (ReadOnlyHint == nil) or read-only tools
+// (ReadOnlyHint == true) are not suppressed.
+func (b BaseTool[T]) ShouldSuppress(ctx context.Context, src sources.Source) bool {
+	if src == nil || !src.IsReadOnly() {
+		return false
+	}
+
+	toolName := b.GetName()
+	l, _ := util.LoggerFromContext(ctx)
+
+	if b.annotations != nil && b.annotations.ReadOnlyHint != nil {
+		if !*b.annotations.ReadOnlyHint {
+			if l != nil {
+				l.InfoContext(ctx, fmt.Sprintf("Suppressing write-capable tool %q bound to read-only source", toolName))
+			}
+			return true
+		}
+		return false
+	}
+
+	if l != nil {
+		l.WarnContext(ctx, fmt.Sprintf("Tool %q lacks ReadOnlyHint annotation; executing this tool may fail if it attempts write operations. If this tool is meant to be read-only, please add 'readOnlyHint: true' to its annotations. Otherwise, add 'readOnlyHint: false' to suppress it in read-only mode and save agent context window.", toolName))
+	}
+
+	return false
 }

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
+	"github.com/googleapis/mcp-toolbox/internal/testutils"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
 )
@@ -140,5 +142,57 @@ func TestBaseToolEmbedParamsPassthrough(t *testing.T) {
 	}
 	if diff := cmp.Diff(values, got); diff != "" {
 		t.Errorf("EmbedParams() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestBaseToolShouldSuppress(t *testing.T) {
+	roSource := testutils.MockSource{MockSourceConfig: testutils.MockSourceConfig{ReadOnly: true}}
+	rwSource := testutils.MockSource{MockSourceConfig: testutils.MockSourceConfig{ReadOnly: false}}
+
+	tests := []struct {
+		desc        string
+		src         sources.Source
+		annotations *tools.ToolAnnotations
+		want        bool
+	}{
+		{
+			desc:        "nil source -> not suppressed",
+			src:         nil,
+			annotations: tools.NewDestructiveAnnotations(),
+			want:        false,
+		},
+		{
+			desc:        "read-write source with write tool -> not suppressed",
+			src:         rwSource,
+			annotations: tools.NewDestructiveAnnotations(),
+			want:        false,
+		},
+		{
+			desc:        "read-only source with write tool (readOnlyHint: false) -> suppressed",
+			src:         roSource,
+			annotations: tools.NewDestructiveAnnotations(),
+			want:        true,
+		},
+		{
+			desc:        "read-only source with read tool (readOnlyHint: true) -> not suppressed",
+			src:         roSource,
+			annotations: tools.NewReadOnlyAnnotations(),
+			want:        false,
+		},
+		{
+			desc:        "read-only source with nil annotations -> not suppressed",
+			src:         roSource,
+			annotations: nil,
+			want:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			b := tools.NewBaseTool(tools.ConfigBase{}, tt.annotations, tools.Manifest{}, nil)
+			if got := b.ShouldSuppress(context.Background(), tt.src); got != tt.want {
+				t.Errorf("ShouldSuppress() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Description

This PR introduces core framework support for agent-level tool suppression and dynamic annotations in read-only mode.

When a data source or admin service is configured as `readonly: true`, write-capable and destructive tools bound to that source are automatically suppressed from tool registration and pruned from tool groups. This saves valuable LLM agent context window space, eliminates agent confusion by preventing tool hallucination/misuse on read-only resources, and acts as a defense-in-depth layer in conjunction with database-level session locking.

### Design

1. **`sources.Source` Interface Extension**:
   - Added `IsReadOnly() bool` to the `sources.Source` interface.
   - Implemented `IsReadOnly()` across all existing data source drivers (50+ sources).
   - Added `readonly` configuration support to `alloydb-admin` and `cloud-sql-admin` sources.

2. **Tool Suppression Protocol**:
   - Added `ShouldSuppress(sources.Source) bool` to the `tools.Tool` interface.
   - In `BaseTool`, default suppression logic checks if the bound source is in read-only mode and suppresses any tool whose `ReadOnlyHint` annotation is `false`.
   - Read-only tools (`ReadOnlyHint == true`) and unannotated tools are preserved (with a warning logged for unannotated tools to encourage explicit annotation).
   - Tools like `postgresexecutesql` and `mysqlexecutesql` override `ShouldSuppress` to remain enabled because they enforce read-only semantics at the database connection/session level.

3. **Server-Level Tool Filtering & Group Pruning**:
   - During tool initialization (`initializeTools`), write-capable tools bound to read-only sources are suppressed and omitted from the server's registered tools map with an informative log.
   - During group initialization (`initializeGroups`), suppressed tools are cleanly pruned from configured groups while keeping the group intact and preserving standard validation errors for genuinely missing tools.

4. **Dynamic Tool Annotations in MCP Manifests**:
   - Updated MCP version manifests (`v20241105`, `v20250326`, `v20250618`, `v20251125`, `v20260728`) to query `tool.Manifest(src)` dynamically.

5. **Cloud SQL PG Vector Assist Annotations**:
   - Updated vector assist tools (`vectorassistapplyspec`, `vectorassistdefinespec`, `vectorassistgeneratequery`, `vectorassistgetspec`, `vectorassistimprovequeryrecall`, `vectorassistlistspecs`, `vectorassistmodifyspec`) with annotations (`ReadOnlyAnnotations` vs `DestructiveAnnotations`) and support for custom YAML annotations.

## PR Checklist

- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
