### PR TITLE
feat(alloydb): add native read-only session locking

### DIFF
--- a/docs/ALLOYDBADMIN_README.md
+++ b/docs/ALLOYDBADMIN_README.md
@@ -63,6 +63,13 @@ The AlloyDB MCP server provides the following tools:
 
 ## Custom MCP Server Configuration
 
+The MCP server is configured using environment variables.
+
+```bash
+export ALLOYDB_POSTGRES_PROJECT="<your-gcp-project-id>"
+export ALLOYDB_POSTGRES_READONLY="true"  # Optional: `true`, `false`. Defaults to `false`. When set to `true`, write-capable admin tools (e.g., create_cluster, create_instance, create_user) are suppressed.
+```
+
 Add the following configuration to your MCP client (e.g., `settings.json` for Gemini CLI, `mcp_config.json` for Antigravity):
 
 ```json

--- a/docs/ALLOYDBPG_README.md
+++ b/docs/ALLOYDBPG_README.md
@@ -81,6 +81,7 @@ export ALLOYDB_POSTGRES_DATABASE="<your-database-name>"
 export ALLOYDB_POSTGRES_USER="<your-database-user>"  # Optional
 export ALLOYDB_POSTGRES_PASSWORD="<your-database-password>"  # Optional
 export ALLOYDB_POSTGRES_IP_TYPE="PUBLIC"  # Optional: `PUBLIC`, `PRIVATE`, `PSC`. Defaults to `PUBLIC`.
+export ALLOYDB_POSTGRES_READONLY="true"  # Optional: Restricts tools and enforces read-only session locking on the database connection. Defaults to `false`.
 ```
 
 Add the following configuration to your MCP client (e.g., `settings.json` for Gemini CLI, `mcp_config.json` for Antigravity):

--- a/docs/en/integrations/alloydb-admin/prebuilt-configs/alloydb-postgres-admin.md
+++ b/docs/en/integrations/alloydb-admin/prebuilt-configs/alloydb-postgres-admin.md
@@ -6,7 +6,10 @@ description: "Details of the AlloyDB Postgres Admin prebuilt configuration."
 
 ## AlloyDB Postgres Admin
 
-* `--prebuilt` value: `alloydb-postgres-admin`
+*   `--prebuilt` value: `alloydb-postgres-admin`
+*   **Environment Variables:**
+    *   `ALLOYDB_POSTGRES_PROJECT`: (Optional) The GCP project ID to use as the default for AlloyDB infrastructure tools.
+    *   `ALLOYDB_POSTGRES_READONLY`: (Optional) When set to `true`, suppresses write-capable admin tools (e.g., `create_cluster`, `create_instance`, `create_user`). Default: `false`.
 *   **Permissions:**
     *   **AlloyDB Viewer** (`roles/alloydb.viewer`) is required for `list` and
         `get` tools.

--- a/docs/en/integrations/alloydb/prebuilt-configs/alloydb-postgres.md
+++ b/docs/en/integrations/alloydb/prebuilt-configs/alloydb-postgres.md
@@ -19,6 +19,7 @@ description: "Details of the AlloyDB Postgres prebuilt configuration."
         user. Defaults to IAM authentication if unspecified.
     *   `ALLOYDB_POSTGRES_IP_TYPE`: (Optional) The IP type i.e. "Public" or
         "Private" (Default: Public).
+    *   `ALLOYDB_POSTGRES_READONLY`: (Optional) When set to `true`, enforces read-only execution at the database session level (`alloydb_session_read_only=locked`) and suppresses write-capable tools. Default: `false`.
 *   **Permissions:**
     *   **AlloyDB Client** (`roles/alloydb.client`) to connect to the instance.
     *   Database-level permissions (e.g., `SELECT`, `INSERT`) are required to

--- a/docs/en/integrations/alloydb/source.md
+++ b/docs/en/integrations/alloydb/source.md
@@ -144,3 +144,4 @@ The interface is identical, so there's no additional configuration required on t
 | password  |  string  |    false     | Password of the Postgres user (e.g. "my-password"). Defaults to attempting IAM authentication if unspecified.            |
 | ipType    |  string  |    false     | IP Type of the AlloyDB instance; must be one of `public` or `private`. Default: `public`.                                |
 | sqlCommenter | boolean |  false     | Overrides the global `--sql-commenter` flag for this source. When set, it takes priority; when omitted, the global flag applies. |
+| readOnly  | boolean  |    false     | When set to `true`, enforces read-only execution at the database session level (`alloydb_session_read_only=locked`) and suppresses write-capable tools. Default: `false`. |

--- a/internal/prebuiltconfigs/tools/alloydb-postgres-admin.yaml
+++ b/internal/prebuiltconfigs/tools/alloydb-postgres-admin.yaml
@@ -16,6 +16,7 @@ kind: source
 name: alloydb-admin-source
 type: alloydb-admin
 defaultProject: ${ALLOYDB_POSTGRES_PROJECT:}
+readOnly: ${ALLOYDB_POSTGRES_READONLY:false}
 ---
 kind: tool
 name: create_cluster

--- a/internal/prebuiltconfigs/tools/alloydb-postgres.yaml
+++ b/internal/prebuiltconfigs/tools/alloydb-postgres.yaml
@@ -23,6 +23,7 @@ database: ${ALLOYDB_POSTGRES_DATABASE}
 user: ${ALLOYDB_POSTGRES_USER:}
 password: ${ALLOYDB_POSTGRES_PASSWORD:}
 ipType: ${ALLOYDB_POSTGRES_IP_TYPE:public}
+readOnly: ${ALLOYDB_POSTGRES_READONLY:false}
 ---
 kind: source
 name: cloud-monitoring-source
@@ -32,6 +33,7 @@ kind: source
 name: alloydb-admin-source
 type: alloydb-admin
 defaultProject: ${ALLOYDB_POSTGRES_PROJECT:}
+readOnly: ${ALLOYDB_POSTGRES_READONLY:false}
 ---
 kind: tool
 name: execute_sql

--- a/internal/sources/alloydbpg/alloydb_pg.go
+++ b/internal/sources/alloydbpg/alloydb_pg.go
@@ -60,6 +60,7 @@ type Config struct {
 	User         string         `yaml:"user"`
 	Password     string         `yaml:"password"`
 	Database     string         `yaml:"database" validate:"required"`
+	ReadOnly     bool           `yaml:"readOnly"`
 	SQLCommenter *bool          `yaml:"sqlCommenter"`
 }
 
@@ -68,7 +69,7 @@ func (r Config) SourceConfigType() string {
 }
 
 func (r Config) Initialize(ctx context.Context, tracer trace.Tracer) (sources.Source, error) {
-	pool, err := initAlloyDBPgConnectionPool(ctx, tracer, r.Name, r.Project, r.Region, r.Cluster, r.Instance, r.IPType.String(), r.User, r.Password, r.Database)
+	pool, err := initAlloyDBPgConnectionPool(ctx, tracer, r.Name, r.Project, r.Region, r.Cluster, r.Instance, r.IPType.String(), r.User, r.Password, r.Database, r.ReadOnly)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create pool: %w", err)
 	}
@@ -93,7 +94,7 @@ type Source struct {
 }
 
 func (s *Source) IsReadOnly() bool {
-	return false
+	return s.ReadOnly
 }
 
 func (s *Source) SourceType() string {
@@ -156,23 +157,26 @@ func getOpts(ipType, userAgent string, useIAM bool) ([]alloydbconn.Option, error
 	return opts, nil
 }
 
-func getConnectionConfig(ctx context.Context, user, pass, dbname string) (string, bool, error) {
+const (
+	passwordDSNFormat = "user=%s password=%s dbname=%s sslmode=disable application_name=%s"
+	iamDSNFormat      = "user=%s dbname=%s sslmode=disable application_name=%s"
+)
+
+func getConnectionConfig(ctx context.Context, user, pass, dbname string, readOnly bool) (string, bool, error) {
 	userAgent, err := util.UserAgentFromContext(ctx)
 	if err != nil {
 		userAgent = "genai-toolbox"
 	}
 	useIAM := true
 
+	var dsn string
 	// If username and password both provided, use password authentication
 	if user != "" && pass != "" {
-		dsn := fmt.Sprintf("user=%s password=%s dbname=%s sslmode=disable application_name=%s", user, pass, dbname, userAgent)
+		dsn = fmt.Sprintf(passwordDSNFormat, user, pass, dbname, userAgent)
 		useIAM = false
-		return dsn, useIAM, nil
-	}
-
-	// If username is empty, fetch email from ADC
-	// otherwise, use username as IAM email
-	if user == "" {
+	} else if user == "" {
+		// If username is empty, fetch email from ADC
+		// otherwise, use username as IAM email
 		if pass != "" {
 			// If password is provided without an username, raise an error
 			return "", useIAM, fmt.Errorf("password is provided without a username. Please provide both a username and password, or leave both fields empty")
@@ -182,19 +186,28 @@ func getConnectionConfig(ctx context.Context, user, pass, dbname string) (string
 			return "", useIAM, fmt.Errorf("error getting email from ADC: %v", err)
 		}
 		user = email
+		dsn = fmt.Sprintf(iamDSNFormat, user, dbname, userAgent)
+	} else {
+		// Construct IAM connection string with username
+		dsn = fmt.Sprintf(iamDSNFormat, user, dbname, userAgent)
 	}
 
-	// Construct IAM connection string with username
-	dsn := fmt.Sprintf("user=%s dbname=%s sslmode=disable application_name=%s", user, dbname, userAgent)
+	if readOnly {
+		// IMPORTANT: Must use underscore ('alloydb_session_read_only'), NOT a dot.
+		// PostgreSQL treats dotted GUCs (e.g. 'alloydb.session_read_only') as custom placeholders
+		// and silently ignores them at connection time, leaving the session in read-write mode.
+		dsn += " options='-c alloydb_session_read_only=locked'"
+	}
+
 	return dsn, useIAM, nil
 }
 
-func initAlloyDBPgConnectionPool(ctx context.Context, tracer trace.Tracer, name, project, region, cluster, instance, ipType, user, pass, dbname string) (*pgxpool.Pool, error) {
+func initAlloyDBPgConnectionPool(ctx context.Context, tracer trace.Tracer, name, project, region, cluster, instance, ipType, user, pass, dbname string, readOnly bool) (*pgxpool.Pool, error) {
 	//nolint:all // Reassigned ctx
 	ctx, span := sources.InitConnectionSpan(ctx, tracer, SourceType, name)
 	defer span.End()
 
-	dsn, useIAM, err := getConnectionConfig(ctx, user, pass, dbname)
+	dsn, useIAM, err := getConnectionConfig(ctx, user, pass, dbname, readOnly)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get AlloyDB connection config: %w", err)
 	}

--- a/internal/sources/alloydbpg/alloydb_pg_test.go
+++ b/internal/sources/alloydbpg/alloydb_pg_test.go
@@ -120,6 +120,68 @@ func TestParseFromYamlAlloyDBPg(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc: "readOnly set to true",
+			in: `
+			kind: source
+			name: my-pg-instance
+			type: alloydb-postgres
+			project: my-project
+			region: my-region
+			cluster: my-cluster
+			instance: my-instance
+			database: my_db
+			user: my_user
+			password: my_pass
+			readOnly: true
+			`,
+			want: map[string]sources.SourceConfig{
+				"my-pg-instance": alloydbpg.Config{
+					Name:     "my-pg-instance",
+					Type:     alloydbpg.SourceType,
+					Project:  "my-project",
+					Region:   "my-region",
+					Cluster:  "my-cluster",
+					Instance: "my-instance",
+					IPType:   "public",
+					Database: "my_db",
+					User:     "my_user",
+					Password: "my_pass",
+					ReadOnly: true,
+				},
+			},
+		},
+		{
+			desc: "readOnly set to false",
+			in: `
+			kind: source
+			name: my-pg-instance
+			type: alloydb-postgres
+			project: my-project
+			region: my-region
+			cluster: my-cluster
+			instance: my-instance
+			database: my_db
+			user: my_user
+			password: my_pass
+			readOnly: false
+			`,
+			want: map[string]sources.SourceConfig{
+				"my-pg-instance": alloydbpg.Config{
+					Name:     "my-pg-instance",
+					Type:     alloydbpg.SourceType,
+					Project:  "my-project",
+					Region:   "my-region",
+					Cluster:  "my-cluster",
+					Instance: "my-instance",
+					IPType:   "public",
+					Database: "my_db",
+					User:     "my_user",
+					Password: "my_pass",
+					ReadOnly: false,
+				},
+			},
+		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
@@ -130,6 +192,14 @@ func TestParseFromYamlAlloyDBPg(t *testing.T) {
 			}
 			if !cmp.Equal(tc.want, got) {
 				t.Fatalf("incorrect parse: want %v, got %v", tc.want, got)
+			}
+			for _, sc := range got {
+				if cfg, ok := sc.(alloydbpg.Config); ok {
+					src := &alloydbpg.Source{Config: cfg}
+					if src.IsReadOnly() != cfg.ReadOnly {
+						t.Errorf("IsReadOnly() = %v, want %v", src.IsReadOnly(), cfg.ReadOnly)
+					}
+				}
 			}
 		})
 	}

--- a/tests/alloydbpg/alloydb_pg_integration_test.go
+++ b/tests/alloydbpg/alloydb_pg_integration_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/http"
 	"os"
 	"regexp"
 	"strings"
@@ -344,6 +345,93 @@ func TestAlloyDBPgIAMConnection(t *testing.T) {
 			}
 			if tc.isErr {
 				t.Fatalf("Expected error but test passed.")
+			}
+		})
+	}
+}
+
+// TestAlloyDBPg_ReadOnlyVulnerabilityBlock verifies that if tools bypass server-level
+// suppression (e.g. via readOnlyHint: true), the database kernel still enforces
+// alloydb_session_read_only=locked and blocks writes, while allowing reads.
+func TestAlloyDBPg_ReadOnlyVulnerabilityBlock(t *testing.T) {
+	sourceConfig := getAlloyDBPgVars(t)
+	sourceConfig["readOnly"] = true
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	uniqueID := strings.ReplaceAll(uuid.New().String(), "-", "")
+	tableName := "vulnerability_test_" + uniqueID
+
+	toolsFile := map[string]any{
+		"sources": map[string]any{
+			"my-readonly-alloydb-instance": sourceConfig,
+		},
+		"tools": map[string]any{
+			"vulnerable_write_tool": map[string]any{
+				"type":        "postgres-sql",
+				"source":      "my-readonly-alloydb-instance",
+				"description": "Falsely claims to be read-only for DDL CREATE",
+				"annotations": map[string]any{"readOnlyHint": true},
+				"statement":   fmt.Sprintf("CREATE TABLE %s (id INT);", tableName),
+			},
+			"valid_read_tool": map[string]any{
+				"type":        "postgres-sql",
+				"source":      "my-readonly-alloydb-instance",
+				"description": "Valid read query on read-only source",
+				"annotations": map[string]any{"readOnlyHint": true},
+				"statement":   "SELECT 1 AS result;",
+			},
+		},
+	}
+
+	cmd, cleanup, err := tests.StartCmd(ctx, toolsFile)
+	if err != nil {
+		t.Fatalf("command initialization returned an error: %s", err)
+	}
+	defer cleanup()
+
+	waitCtx, cancelWait := context.WithTimeout(ctx, 30*time.Second)
+	defer cancelWait()
+	out, err := testutils.WaitForString(waitCtx, regexp.MustCompile(`Server ready to serve`), cmd.Out)
+	if err != nil {
+		t.Logf("toolbox command logs: \n%s", out)
+		t.Fatalf("toolbox didn't start successfully: %s", err)
+	}
+
+	tcs := []struct {
+		name          string
+		toolName      string
+		expectError   bool
+		wantErrSubstr string
+	}{
+		{
+			name:          "reject falsely annotated write",
+			toolName:      "vulnerable_write_tool",
+			expectError:   true,
+			wantErrSubstr: "Session is read only",
+		},
+		{
+			name:        "allow valid read operation",
+			toolName:    "valid_read_tool",
+			expectError: false,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			statusCode, mcpResp, err := tests.InvokeMCPTool(t, tc.toolName, map[string]any{}, nil)
+			if err != nil {
+				t.Fatalf("native error executing %s: %s", tc.toolName, err)
+			}
+			if statusCode != http.StatusOK {
+				t.Fatalf("expected status 200, got %d", statusCode)
+			}
+
+			if tc.expectError {
+				tests.AssertMCPError(t, mcpResp, tc.wantErrSubstr)
+			} else if mcpResp.Result.IsError {
+				t.Fatalf("expected success for %s, but got error: %v", tc.toolName, mcpResp.Result)
 			}
 		})
 	}


### PR DESCRIPTION
## Description

This PR implements native, protocol-level Read-Only session enforcement for AlloyDB for PostgreSQL.

## Changes
- Appends `options='-c alloydb_session_read_only=locked'` to the connection DSN when `readOnly: true` is configured on the source.
- Added `ReadOnly bool` to `alloydbpg.Config` and implemented `IsReadOnly() bool` on `alloydbpg.Source`.
- Updated prebuilt configuration templates (`alloydb-postgres.yaml` and `alloydb-postgres-admin.yaml`) to dynamically resolve read-only mode via the `ALLOYDB_READONLY` environment variable (`readonly: ${ALLOYDB_READONLY:false}`).
- Leverages AlloyDB's native session-lockout flag to block physical Transaction ID (XID) allocation, guaranteeing that all DML/DDL write operations, transaction breakout attempts (`COMMIT; START TRANSACTION READ WRITE;`), and mutating stored procedures fail-closed at the engine layer.
- Added unit tests, integration vulnerability tests, and updated integration documentation.
