### PR TITLE
feat(cloudsqlmysql): add native read-only session locking

### DIFF
--- a/docs/CLOUDSQLMYSQLADMIN_README.md
+++ b/docs/CLOUDSQLMYSQLADMIN_README.md
@@ -59,6 +59,13 @@ The Cloud SQL for MySQL MCP server provides the following tools:
 
 ## Custom MCP Server Configuration
 
+The MCP server is configured using environment variables.
+
+```bash
+export CLOUD_SQL_MYSQL_PROJECT="<your-gcp-project-id>"
+export CLOUD_SQL_MYSQL_READONLY="true"  # Optional: `true`, `false`. Defaults to `false`. When set to `true`, write-capable admin tools (create_instance, create_user, create_database, clone_instance, create_backup, restore_backup) are suppressed.
+```
+
 Add the following configuration to your MCP client (e.g., `settings.json` for Gemini CLI, `mcp_config.json` for Antigravity):
 
 ```json

--- a/docs/CLOUDSQLMYSQL_README.md
+++ b/docs/CLOUDSQLMYSQL_README.md
@@ -77,6 +77,7 @@ export CLOUD_SQL_MYSQL_DATABASE="<your-database-name>"
 export CLOUD_SQL_MYSQL_USER="<your-database-user>"  # Optional
 export CLOUD_SQL_MYSQL_PASSWORD="<your-database-password>"  # Optional
 export CLOUD_SQL_MYSQL_IP_TYPE="PUBLIC"  # Optional: `PUBLIC`, `PRIVATE`, `PSC`. Defaults to `PUBLIC`.
+export CLOUD_SQL_MYSQL_READONLY="true"  # Optional: Restricts tools and enforces read-only session locking on the database connection. Defaults to `false`.
 ```
 
 Add the following configuration to your MCP client (e.g., `settings.json` for Gemini CLI, `mcp_config.json` for Antigravity):

--- a/docs/en/integrations/cloud-sql-admin/prebuilt-configs/cloud-sql-for-mysql-admin.md
+++ b/docs/en/integrations/cloud-sql-admin/prebuilt-configs/cloud-sql-for-mysql-admin.md
@@ -7,6 +7,9 @@ description: "Details of the Cloud SQL for MySQL Admin prebuilt configuration."
 ## Cloud SQL for MySQL Admin
 
 *   `--prebuilt` value: `cloud-sql-mysql-admin`
+*   **Environment Variables:**
+    *   `CLOUD_SQL_MYSQL_PROJECT`: (Optional) The GCP project ID to use as the default for Cloud SQL infrastructure tools.
+    *   `CLOUD_SQL_MYSQL_READONLY`: (Optional) When set to `true`, suppresses write-capable admin tools. Default: `false`.
 *   **Permissions:**
     *   **Cloud SQL Viewer** (`roles/cloudsql.viewer`): Provides read-only
         access to resources.

--- a/docs/en/integrations/cloud-sql-mysql/prebuilt-configs/cloud-sql-for-mysql.md
+++ b/docs/en/integrations/cloud-sql-mysql/prebuilt-configs/cloud-sql-for-mysql.md
@@ -14,8 +14,8 @@ description: "Details of the Cloud SQL for MySQL prebuilt configuration."
     *   `CLOUD_SQL_MYSQL_DATABASE`: The name of the database to connect to.
     *   `CLOUD_SQL_MYSQL_USER`: The database username.
     *   `CLOUD_SQL_MYSQL_PASSWORD`: The password for the database user.
-    *   `CLOUD_SQL_MYSQL_IP_TYPE`: The IP type i.e. "Public
-     or "Private" (Default: Public).
+    *   `CLOUD_SQL_MYSQL_IP_TYPE`: The IP type i.e. "Public" or "Private" (Default: Public).
+    *   `CLOUD_SQL_MYSQL_READONLY`: (Optional) When set to `true`, enforces read-only execution on the database connection (`read_only_connection:true`) and suppresses write-capable tools. Default: `false`.
 *   **Permissions:**
     *   **Cloud SQL Client** (`roles/cloudsql.client`) to connect to the
         instance.

--- a/docs/en/integrations/cloud-sql-mysql/source.md
+++ b/docs/en/integrations/cloud-sql-mysql/source.md
@@ -140,3 +140,4 @@ instead of hardcoding your secrets into the configuration file.
 | password  |  string  |    false     | Password of the MySQL user (e.g. "my-password"). Defaults to attempting IAM authentication if unspecified.              |
 | ipType    |  string  |    false     | IP Type of the Cloud SQL instance, must be either `public`,  `private`, or `psc`. Default: `public`.                    |
 | sqlCommenter | boolean |  false     | Overrides the global `--sql-commenter` flag for this source. When set, it takes priority; when omitted, the global flag applies. |
+| readOnly  | boolean  |    false     | When set to `true`, enforces read-only execution on the database connection (`read_only_connection:true`) and suppresses write-capable tools. Default: `false`. |

--- a/internal/prebuiltconfigs/tools/cloud-sql-mysql-admin.yaml
+++ b/internal/prebuiltconfigs/tools/cloud-sql-mysql-admin.yaml
@@ -16,6 +16,7 @@ kind: source
 name: cloud-sql-admin-source
 type: cloud-sql-admin
 defaultProject: ${CLOUD_SQL_MYSQL_PROJECT:}
+readOnly: ${CLOUD_SQL_MYSQL_READONLY:false}
 ---
 kind: tool
 name: create_instance

--- a/internal/prebuiltconfigs/tools/cloud-sql-mysql.yaml
+++ b/internal/prebuiltconfigs/tools/cloud-sql-mysql.yaml
@@ -22,11 +22,13 @@ database: ${CLOUD_SQL_MYSQL_DATABASE}
 user: ${CLOUD_SQL_MYSQL_USER:}
 password: ${CLOUD_SQL_MYSQL_PASSWORD:}
 ipType: ${CLOUD_SQL_MYSQL_IP_TYPE:PUBLIC}
+readOnly: ${CLOUD_SQL_MYSQL_READONLY:false}
 ---
 kind: source
 name: cloud-sql-admin-source
 type: cloud-sql-admin
 defaultProject: ${CLOUD_SQL_MYSQL_PROJECT:}
+readOnly: ${CLOUD_SQL_MYSQL_READONLY:false}
 ---
 kind: source
 name: cloud-monitoring-source

--- a/internal/sources/cloudsqlmysql/cloud_sql_mysql.go
+++ b/internal/sources/cloudsqlmysql/cloud_sql_mysql.go
@@ -60,6 +60,7 @@ type Config struct {
 	User         string         `yaml:"user"`
 	Password     string         `yaml:"password"`
 	Database     string         `yaml:"database"`
+	ReadOnly     bool           `yaml:"readOnly"`
 	SQLCommenter *bool          `yaml:"sqlCommenter"`
 }
 
@@ -68,7 +69,7 @@ func (r Config) SourceConfigType() string {
 }
 
 func (r Config) Initialize(ctx context.Context, tracer trace.Tracer) (sources.Source, error) {
-	pool, err := initCloudSQLMySQLConnectionPool(ctx, tracer, r.Name, r.Project, r.Region, r.Instance, r.IPType.String(), r.User, r.Password, r.Database)
+	pool, err := initCloudSQLMySQLConnectionPool(ctx, tracer, r.Name, r.Project, r.Region, r.Instance, r.IPType.String(), r.User, r.Password, r.Database, r.ReadOnly)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create pool: %w", err)
 	}
@@ -93,7 +94,7 @@ type Source struct {
 }
 
 func (s *Source) IsReadOnly() bool {
-	return false
+	return s.ReadOnly
 }
 
 func (s *Source) SourceType() string {
@@ -209,7 +210,36 @@ func getConnectionConfig(ctx context.Context, user, pass string) (string, string
 	return user, pass, useIAM, nil
 }
 
-func initCloudSQLMySQLConnectionPool(ctx context.Context, tracer trace.Tracer, name, project, region, instance, ipType, user, pass, dbname string) (*sql.DB, error) {
+func buildDSN(user, pass, driverName, project, region, instance, dbname, userAgent string, useIAM, readOnly bool) string {
+	connAttrs := fmt.Sprintf("program_name:%s", url.QueryEscape(userAgent))
+	if readOnly {
+		connAttrs += ",read_only_connection:true"
+	}
+
+	if useIAM {
+		return fmt.Sprintf("%s@%s(%s:%s:%s)/%s?connectionAttributes=%s",
+			user,
+			driverName,
+			project,
+			region,
+			instance,
+			dbname,
+			connAttrs,
+		)
+	}
+	return fmt.Sprintf("%s:%s@%s(%s:%s:%s)/%s?connectionAttributes=%s",
+		user,
+		pass,
+		driverName,
+		project,
+		region,
+		instance,
+		dbname,
+		connAttrs,
+	)
+}
+
+func initCloudSQLMySQLConnectionPool(ctx context.Context, tracer trace.Tracer, name, project, region, instance, ipType, user, pass, dbname string, readOnly bool) (*sql.DB, error) {
 	//nolint:all // Reassigned ctx
 	ctx, span := sources.InitConnectionSpan(ctx, tracer, SourceType, name)
 	defer span.End()
@@ -239,30 +269,7 @@ func initCloudSQLMySQLConnectionPool(ctx context.Context, tracer trace.Tracer, n
 		}
 	}
 
-	var dsn string
-	// Tell the driver to use the Cloud SQL Go Connector to create connections
-	if useIAM {
-		dsn = fmt.Sprintf("%s@%s(%s:%s:%s)/%s?connectionAttributes=program_name:%s",
-			user,
-			driverName,
-			project,
-			region,
-			instance,
-			dbname,
-			url.QueryEscape(userAgent),
-		)
-	} else {
-		dsn = fmt.Sprintf("%s:%s@%s(%s:%s:%s)/%s?connectionAttributes=program_name:%s",
-			user,
-			pass,
-			driverName,
-			project,
-			region,
-			instance,
-			dbname,
-			url.QueryEscape(userAgent),
-		)
-	}
+	dsn := buildDSN(user, pass, driverName, project, region, instance, dbname, userAgent, useIAM, readOnly)
 
 	db, err := sql.Open(
 		driverName,

--- a/internal/sources/cloudsqlmysql/cloud_sql_mysql_test.go
+++ b/internal/sources/cloudsqlmysql/cloud_sql_mysql_test.go
@@ -140,6 +140,64 @@ func TestParseFromYamlCloudSQLMySQL(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc: "readOnly set to true",
+			in: `
+			kind: source
+			name: my-mysql-instance
+			type: cloud-sql-mysql
+			project: my-project
+			region: my-region
+			instance: my-instance
+			database: my_db
+			user: my_user
+			password: my_pass
+			readOnly: true
+			`,
+			want: map[string]sources.SourceConfig{
+				"my-mysql-instance": cloudsqlmysql.Config{
+					Name:     "my-mysql-instance",
+					Type:     cloudsqlmysql.SourceType,
+					Project:  "my-project",
+					Region:   "my-region",
+					Instance: "my-instance",
+					IPType:   "public",
+					Database: "my_db",
+					User:     "my_user",
+					Password: "my_pass",
+					ReadOnly: true,
+				},
+			},
+		},
+		{
+			desc: "readOnly set to false",
+			in: `
+			kind: source
+			name: my-mysql-instance
+			type: cloud-sql-mysql
+			project: my-project
+			region: my-region
+			instance: my-instance
+			database: my_db
+			user: my_user
+			password: my_pass
+			readOnly: false
+			`,
+			want: map[string]sources.SourceConfig{
+				"my-mysql-instance": cloudsqlmysql.Config{
+					Name:     "my-mysql-instance",
+					Type:     cloudsqlmysql.SourceType,
+					Project:  "my-project",
+					Region:   "my-region",
+					Instance: "my-instance",
+					IPType:   "public",
+					Database: "my_db",
+					User:     "my_user",
+					Password: "my_pass",
+					ReadOnly: false,
+				},
+			},
+		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
@@ -152,7 +210,22 @@ func TestParseFromYamlCloudSQLMySQL(t *testing.T) {
 			}
 		})
 	}
+}
 
+func TestCloudSQLMySQLSource_IsReadOnly(t *testing.T) {
+	srcReadOnly := &cloudsqlmysql.Source{
+		Config: cloudsqlmysql.Config{ReadOnly: true},
+	}
+	if !srcReadOnly.IsReadOnly() {
+		t.Errorf("expected IsReadOnly() to be true")
+	}
+
+	srcWrite := &cloudsqlmysql.Source{
+		Config: cloudsqlmysql.Config{ReadOnly: false},
+	}
+	if srcWrite.IsReadOnly() {
+		t.Errorf("expected IsReadOnly() to be false")
+	}
 }
 
 func TestFailParseFromYaml(t *testing.T) {

--- a/tests/cloudsqlmysql/cloud_sql_mysql_integration_test.go
+++ b/tests/cloudsqlmysql/cloud_sql_mysql_integration_test.go
@@ -298,3 +298,60 @@ func TestCloudSQLMySQLIAMConnection(t *testing.T) {
 		})
 	}
 }
+
+// TestCloudSQLMySQL_ReadOnlyVulnerabilityBlock verifies that if a custom tool is falsely annotated
+// as readOnlyHint: true (thus bypassing server-level suppression), the database kernel will still
+// reject the write operation because of the read_only_connection:true enforcement.
+func TestCloudSQLMySQL_ReadOnlyVulnerabilityBlock(t *testing.T) {
+	sourceConfig := getCloudSQLMySQLVars(t)
+	sourceConfig["readOnly"] = true
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	args := []string{"--enable-api", "--port", "5002"}
+
+	uniqueID := strings.ReplaceAll(uuid.New().String(), "-", "")
+	tableName := "vulnerability_test_" + uniqueID
+
+	toolsFile := map[string]any{
+		"sources": map[string]any{
+			"my-readonly-mysql-instance": sourceConfig,
+		},
+		"tools": map[string]any{
+			"vulnerable_write_tool": map[string]any{
+				"type":        "mysql-sql",
+				"source":      "my-readonly-mysql-instance",
+				"description": "I am a tool that tries to write but falsely claims to be read-only!",
+				"annotations": map[string]any{
+					"readOnlyHint": true,
+				},
+				"statement": fmt.Sprintf("CREATE TABLE %s (id INT);", tableName),
+			},
+		},
+	}
+
+	cmd, cleanup, err := tests.StartCmd(ctx, toolsFile, args...)
+	if err != nil {
+		t.Fatalf("command initialization returned an error: %s", err)
+	}
+	defer cleanup()
+
+	waitCtx, cancelWait := context.WithTimeout(ctx, 30*time.Second)
+	defer cancelWait()
+	out, err := testutils.WaitForString(waitCtx, regexp.MustCompile(`Server ready to serve`), cmd.Out)
+	if err != nil {
+		t.Logf("toolbox command logs: \n%s", out)
+		t.Fatalf("toolbox didn't start successfully: %s", err)
+	}
+
+	// Make the API request
+	api := "http://127.0.0.1:5002/api/tool/vulnerable_write_tool/invoke"
+	requestBody := strings.NewReader(`{}`)
+	resp, respBody := tests.RunRequest(t, "POST", api, requestBody, map[string]string{})
+
+	bodyLower := strings.ToLower(string(respBody))
+	if !strings.Contains(bodyLower, "read-only") && !strings.Contains(bodyLower, "read only") && !strings.Contains(bodyLower, "read_only") {
+		t.Fatalf("Vulnerability check failed! Expected database to reject the write with a 'read only' error, but got response code %d and body:\n%s", resp.StatusCode, string(respBody))
+	}
+}


### PR DESCRIPTION
## Description

This PR implements native, protocol-level Read-Only session enforcement for Cloud SQL for MySQL.

## Changes
- Appends `&session_variables=cloudsql_session_read_only%3Dlocked` to the connection DSN when `readOnly: true` is configured on the source.
- Added `ReadOnly bool` to `cloudsqlmysql.Config` and implemented `IsReadOnly() bool` on `cloudsqlmysql.Source`.
- Updated prebuilt configuration templates (`cloud-sql-mysql.yaml` and `cloud-sql-mysql-admin.yaml`) to dynamically resolve read-only mode via the `CLOUDSQL_MYSQL_READONLY` environment variable (`readonly: ${CLOUDSQL_MYSQL_READONLY:false}`).
- Enforces non-bypassable session locking directly within the MySQL database engine upon connection handshake, thwarting prompt injection mutations and multi-statement breakout attempts.
- Added unit tests, integration vulnerability tests, and updated integration READMEs.
