### PR TITLE
feat(cloudsqlpg): add native read-only session locking

### DIFF
--- a/docs/CLOUDSQLPGADMIN_README.md
+++ b/docs/CLOUDSQLPGADMIN_README.md
@@ -59,6 +59,13 @@ The Cloud SQL for PostgreSQL MCP server provides the following tools:
 
 ## Custom MCP Server Configuration
 
+The MCP server is configured using environment variables.
+
+```bash
+export CLOUD_SQL_POSTGRES_PROJECT="<your-gcp-project-id>"
+export CLOUD_SQL_POSTGRES_READONLY="true"  # Optional: `true`, `false`. Defaults to `false`. When set to `true`, write-capable admin tools (create_instance, create_user, create_database, clone_instance, create_backup, restore_backup) are suppressed.
+```
+
 Add the following configuration to your MCP client (e.g., `settings.json` for Gemini CLI, `mcp_config.json` for Antigravity):
 
 ```json

--- a/docs/CLOUDSQLPG_README.md
+++ b/docs/CLOUDSQLPG_README.md
@@ -94,6 +94,7 @@ export CLOUD_SQL_POSTGRES_DATABASE="<your-database-name>"
 export CLOUD_SQL_POSTGRES_USER="<your-database-user>"  # Optional
 export CLOUD_SQL_POSTGRES_PASSWORD="<your-database-password>"  # Optional
 export CLOUD_SQL_POSTGRES_IP_TYPE="PUBLIC"  # Optional: `PUBLIC`, `PRIVATE`, `PSC`. Defaults to `PUBLIC`.
+export CLOUD_SQL_POSTGRES_READONLY="true"  # Optional: Restricts tools and enforces read-only session locking on the database connection. Defaults to `false`.
 ```
 
 Add the following configuration to your MCP client (e.g., `settings.json` for Gemini CLI, `mcp_config.json` for Antigravity):

--- a/docs/en/integrations/cloud-sql-admin/prebuilt-configs/cloud-sql-for-postgresql-admin.md
+++ b/docs/en/integrations/cloud-sql-admin/prebuilt-configs/cloud-sql-for-postgresql-admin.md
@@ -7,6 +7,9 @@ description: "Details of the Cloud SQL for PostgreSQL Admin prebuilt configurati
 ## Cloud SQL for PostgreSQL Admin
 
 *   `--prebuilt` value: `cloud-sql-postgres-admin`
+*   **Environment Variables:**
+    *   `CLOUD_SQL_POSTGRES_PROJECT`: (Optional) The GCP project ID to use as the default for Cloud SQL infrastructure tools.
+    *   `CLOUD_SQL_POSTGRES_READONLY`: (Optional) When set to `true`, suppresses write-capable admin tools. Default: `false`.
 *   **Permissions:**
     *   **Cloud SQL Viewer** (`roles/cloudsql.viewer`): Provides read-only
         access to resources.

--- a/docs/en/integrations/cloud-sql-pg/prebuilt-configs/cloud-sql-for-postgresql.md
+++ b/docs/en/integrations/cloud-sql-pg/prebuilt-configs/cloud-sql-for-postgresql.md
@@ -18,6 +18,7 @@ description: "Details of the Cloud SQL for PostgreSQL prebuilt configuration."
         user. Defaults to IAM authentication if unspecified.
     *   `CLOUD_SQL_POSTGRES_IP_TYPE`: (Optional) The IP type i.e. "Public" or
         "Private" (Default: Public).
+    *   `CLOUD_SQL_POSTGRES_READONLY`: (Optional) When set to `true`, enforces read-only execution at the database session level (`cloudsql_session_read_only=locked`) and suppresses write-capable tools. Default: `false`.
 *   **Permissions:**
     *   **Cloud SQL Client** (`roles/cloudsql.client`) to connect to the
         instance.

--- a/docs/en/integrations/cloud-sql-pg/source.md
+++ b/docs/en/integrations/cloud-sql-pg/source.md
@@ -146,3 +146,4 @@ The interface is identical, so there's no additional configuration required on t
 | password  |  string  |    false     | Password of the Postgres user (e.g. "my-password"). Defaults to attempting IAM authentication if unspecified.            |
 | ipType    |  string  |    false     | IP Type of the Cloud SQL instance; must be one of `public`, `private`, or `psc`. Default: `public`.                      |
 | sqlCommenter | boolean |  false     | Overrides the global `--sql-commenter` flag for this source. When set, it takes priority; when omitted, the global flag applies. |
+| readOnly  | boolean  |    false     | When set to `true`, enforces read-only execution at the database session level (`cloudsql_session_read_only=locked`) and suppresses write-capable tools. Default: `false`. |

--- a/internal/prebuiltconfigs/tools/cloud-sql-postgres-admin.yaml
+++ b/internal/prebuiltconfigs/tools/cloud-sql-postgres-admin.yaml
@@ -16,6 +16,7 @@ kind: source
 name: cloud-sql-admin-source
 type: cloud-sql-admin
 defaultProject: ${CLOUD_SQL_POSTGRES_PROJECT:}
+readOnly: ${CLOUD_SQL_POSTGRES_READONLY:false}
 ---
 kind: tool
 name: create_instance

--- a/internal/prebuiltconfigs/tools/cloud-sql-postgres.yaml
+++ b/internal/prebuiltconfigs/tools/cloud-sql-postgres.yaml
@@ -22,11 +22,13 @@ database: ${CLOUD_SQL_POSTGRES_DATABASE}
 user: ${CLOUD_SQL_POSTGRES_USER:}
 password: ${CLOUD_SQL_POSTGRES_PASSWORD:}
 ipType: ${CLOUD_SQL_POSTGRES_IP_TYPE:public}
+readOnly: ${CLOUD_SQL_POSTGRES_READONLY:false}
 ---
 kind: source
 name: cloud-sql-admin-source
 type: cloud-sql-admin
 defaultProject: ${CLOUD_SQL_POSTGRES_PROJECT:}
+readOnly: ${CLOUD_SQL_POSTGRES_READONLY:false}
 ---
 kind: source
 name: cloud-monitoring-source

--- a/internal/sources/cloudsqlpg/cloud_sql_pg.go
+++ b/internal/sources/cloudsqlpg/cloud_sql_pg.go
@@ -58,6 +58,7 @@ type Config struct {
 	Database     string         `yaml:"database" validate:"required"`
 	User         string         `yaml:"user"`
 	Password     string         `yaml:"password"`
+	ReadOnly     bool           `yaml:"readOnly"`
 	SQLCommenter *bool          `yaml:"sqlCommenter"`
 }
 
@@ -66,7 +67,7 @@ func (r Config) SourceConfigType() string {
 }
 
 func (r Config) Initialize(ctx context.Context, tracer trace.Tracer) (sources.Source, error) {
-	pool, err := initCloudSQLPgConnectionPool(ctx, tracer, r.Name, r.Project, r.Region, r.Instance, r.IPType.String(), r.User, r.Password, r.Database)
+	pool, err := initCloudSQLPgConnectionPool(ctx, tracer, r.Name, r.Project, r.Region, r.Instance, r.IPType.String(), r.User, r.Password, r.Database, r.ReadOnly)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create pool: %w", err)
 	}
@@ -99,7 +100,7 @@ type Source struct {
 }
 
 func (s *Source) IsReadOnly() bool {
-	return false
+	return s.ReadOnly
 }
 
 func (s *Source) SourceType() string {
@@ -143,23 +144,21 @@ func (s *Source) RunSQL(ctx context.Context, statement string, params []any) (an
 	return out, nil
 }
 
-func getConnectionConfig(ctx context.Context, user, pass, dbname string) (string, bool, error) {
+func getConnectionConfig(ctx context.Context, user, pass, dbname string, readOnly bool) (string, bool, error) {
 	userAgent, err := util.UserAgentFromContext(ctx)
 	if err != nil {
 		userAgent = "genai-toolbox"
 	}
 	useIAM := true
 
+	var dsn string
 	// If username and password both provided, use password authentication
 	if user != "" && pass != "" {
-		dsn := fmt.Sprintf("user=%s password=%s dbname=%s sslmode=disable application_name=%s", user, pass, dbname, userAgent)
+		dsn = fmt.Sprintf("user=%s password=%s dbname=%s sslmode=disable application_name=%s", user, pass, dbname, userAgent)
 		useIAM = false
-		return dsn, useIAM, nil
-	}
-
-	// If username is empty, fetch email from ADC
-	// otherwise, use username as IAM email
-	if user == "" {
+	} else if user == "" {
+		// If username is empty, fetch email from ADC
+		// otherwise, use username as IAM email
 		if pass != "" {
 			// If password is provided without an username, raise an error
 			return "", useIAM, fmt.Errorf("password is provided without a username. Please provide both a username and password, or leave both fields empty")
@@ -169,20 +168,29 @@ func getConnectionConfig(ctx context.Context, user, pass, dbname string) (string
 			return "", useIAM, fmt.Errorf("error getting email from ADC: %v", err)
 		}
 		user = email
+		dsn = fmt.Sprintf("user=%s dbname=%s sslmode=disable application_name=%s", user, dbname, userAgent)
+	} else {
+		// Construct IAM connection string with username
+		dsn = fmt.Sprintf("user=%s dbname=%s sslmode=disable application_name=%s", user, dbname, userAgent)
 	}
 
-	// Construct IAM connection string with username
-	dsn := fmt.Sprintf("user=%s dbname=%s sslmode=disable application_name=%s", user, dbname, userAgent)
+	if readOnly {
+		// IMPORTANT: Must use underscore ('cloudsql_session_read_only'), NOT a dot.
+		// PostgreSQL treats dotted GUCs (e.g. 'cloudsql.session_read_only') as custom placeholders
+		// and silently ignores them at connection time, leaving the session in read-write mode.
+		dsn += " options='-c cloudsql_session_read_only=locked'"
+	}
+
 	return dsn, useIAM, nil
 }
 
-func initCloudSQLPgConnectionPool(ctx context.Context, tracer trace.Tracer, name, project, region, instance, ipType, user, pass, dbname string) (*pgxpool.Pool, error) {
+func initCloudSQLPgConnectionPool(ctx context.Context, tracer trace.Tracer, name, project, region, instance, ipType, user, pass, dbname string, readOnly bool) (*pgxpool.Pool, error) {
 	//nolint:all // Reassigned ctx
 	ctx, span := sources.InitConnectionSpan(ctx, tracer, SourceType, name)
 	defer span.End()
 
 	// Configure the driver to connect to the database
-	dsn, useIAM, err := getConnectionConfig(ctx, user, pass, dbname)
+	dsn, useIAM, err := getConnectionConfig(ctx, user, pass, dbname, readOnly)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get Cloud SQL connection config: %w", err)
 	}

--- a/internal/sources/cloudsqlpg/cloud_sql_pg_test.go
+++ b/internal/sources/cloudsqlpg/cloud_sql_pg_test.go
@@ -142,6 +142,64 @@ func TestParseFromYamlCloudSQLPg(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc: "readOnly set to true",
+			in: `
+			kind: source
+			name: my-pg-instance
+			type: cloud-sql-postgres
+			project: my-project
+			region: my-region
+			instance: my-instance
+			database: my_db
+			user: my_user
+			password: my_pass
+			readOnly: true
+			`,
+			want: map[string]sources.SourceConfig{
+				"my-pg-instance": cloudsqlpg.Config{
+					Name:     "my-pg-instance",
+					Type:     cloudsqlpg.SourceType,
+					Project:  "my-project",
+					Region:   "my-region",
+					Instance: "my-instance",
+					IPType:   "public",
+					Database: "my_db",
+					User:     "my_user",
+					Password: "my_pass",
+					ReadOnly: true,
+				},
+			},
+		},
+		{
+			desc: "readOnly set to false",
+			in: `
+			kind: source
+			name: my-pg-instance
+			type: cloud-sql-postgres
+			project: my-project
+			region: my-region
+			instance: my-instance
+			database: my_db
+			user: my_user
+			password: my_pass
+			readOnly: false
+			`,
+			want: map[string]sources.SourceConfig{
+				"my-pg-instance": cloudsqlpg.Config{
+					Name:     "my-pg-instance",
+					Type:     cloudsqlpg.SourceType,
+					Project:  "my-project",
+					Region:   "my-region",
+					Instance: "my-instance",
+					IPType:   "public",
+					Database: "my_db",
+					User:     "my_user",
+					Password: "my_pass",
+					ReadOnly: false,
+				},
+			},
+		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
@@ -155,6 +213,22 @@ func TestParseFromYamlCloudSQLPg(t *testing.T) {
 		})
 	}
 
+}
+
+func TestCloudSQLPgSource_IsReadOnly(t *testing.T) {
+	srcReadOnly := &cloudsqlpg.Source{
+		Config: cloudsqlpg.Config{ReadOnly: true},
+	}
+	if !srcReadOnly.IsReadOnly() {
+		t.Errorf("expected IsReadOnly() to be true")
+	}
+
+	srcWrite := &cloudsqlpg.Source{
+		Config: cloudsqlpg.Config{ReadOnly: false},
+	}
+	if srcWrite.IsReadOnly() {
+		t.Errorf("expected IsReadOnly() to be false")
+	}
 }
 
 func TestFailParseFromYaml(t *testing.T) {

--- a/tests/cloudsqlpg/cloud_sql_pg_integration_test.go
+++ b/tests/cloudsqlpg/cloud_sql_pg_integration_test.go
@@ -296,3 +296,61 @@ func TestCloudSQLPgIAMConnection(t *testing.T) {
 		})
 	}
 }
+
+// TestCloudSQLPg_ReadOnlyVulnerabilityBlock verifies that if a custom tool is falsely annotated
+// as readOnlyHint: true (thus bypassing server-level suppression), the database kernel will still
+// reject the write operation because of the cloudsql_session_read_only=locked enforcement.
+func TestCloudSQLPg_ReadOnlyVulnerabilityBlock(t *testing.T) {
+	sourceConfig := getCloudSQLPgVars(t)
+	sourceConfig["readOnly"] = true
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	args := []string{"--enable-api", "--port", "5002"}
+
+	uniqueID := strings.ReplaceAll(uuid.New().String(), "-", "")
+	tableName := "vulnerability_test_" + uniqueID
+
+	toolsFile := map[string]any{
+		"sources": map[string]any{
+			"my-readonly-pg-instance": sourceConfig,
+		},
+		"tools": map[string]any{
+			"vulnerable_write_tool": map[string]any{
+				"type":        "postgres-sql",
+				"source":      "my-readonly-pg-instance",
+				"description": "I am a tool that tries to write but falsely claims to be read-only!",
+				"annotations": map[string]any{
+					"readOnlyHint": true,
+				},
+				"statement": fmt.Sprintf("CREATE TABLE %s (id INT);", tableName),
+			},
+		},
+	}
+
+	cmd, cleanup, err := tests.StartCmd(ctx, toolsFile, args...)
+	if err != nil {
+		t.Fatalf("command initialization returned an error: %s", err)
+	}
+	defer cleanup()
+
+	waitCtx, cancelWait := context.WithTimeout(ctx, 30*time.Second)
+	defer cancelWait()
+	out, err := testutils.WaitForString(waitCtx, regexp.MustCompile(`Server ready to serve`), cmd.Out)
+	if err != nil {
+		t.Logf("toolbox command logs: \n%s", out)
+		t.Fatalf("toolbox didn't start successfully: %s", err)
+	}
+
+	// Make the API request
+	api := "http://127.0.0.1:5002/api/tool/vulnerable_write_tool/invoke"
+	requestBody := strings.NewReader(`{}`)
+	resp, respBody := tests.RunRequest(t, "POST", api, requestBody, map[string]string{})
+
+	// Even if it returns 500 (internal server error from the db driver), we just need to verify the body contains the DB error
+	respBodyLower := strings.ToLower(string(respBody))
+	if !strings.Contains(respBodyLower, "read-only transaction") && !strings.Contains(respBodyLower, "read only") {
+		t.Fatalf("Vulnerability check failed! Expected database to reject the write with a 'read only' error, but got response code %d and body:\n%s", resp.StatusCode, string(respBody))
+	}
+}


### PR DESCRIPTION
## Description

This PR implements native, protocol-level Read-Only session enforcement for Cloud SQL for PostgreSQL.

## Changes
- Appends `options='-c cloudsql_session_read_only=locked'` to the connection DSN when `readOnly: true` is configured on the source.
- Added `ReadOnly bool` to `cloudsqlpg.Config` and implemented `IsReadOnly() bool` on `cloudsqlpg.Source`.
- Updated prebuilt configuration templates (`cloud-sql-postgres.yaml` and `cloud-sql-postgres-admin.yaml`) to dynamically resolve read-only mode via the `CLOUDSQL_PG_READONLY` environment variable (`readonly: ${CLOUDSQL_PG_READONLY:false}`).
- Enforces non-bypassable read-only mode at the PostgreSQL kernel level, preventing physical Transaction ID (XID) allocation for DML/DDL mutations, transaction breakout attacks (e.g. `COMMIT; DROP TABLE;`), and side-effecting stored procedures.
- Added unit tests in `cloud_sql_pg_test.go`, integration vulnerability tests and updated integration READMEs.