### PR TITLE
refactor: clean tool and remove GetSourceFromMap

### DIFF
--- a/cmd/internal/invoke/command.go
+++ b/cmd/internal/invoke/command.go
@@ -23,6 +23,7 @@ import (
 	"github.com/googleapis/mcp-toolbox/cmd/internal"
 	"github.com/googleapis/mcp-toolbox/internal/server"
 	"github.com/googleapis/mcp-toolbox/internal/server/primitives"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
 	"github.com/spf13/cobra"
@@ -82,6 +83,23 @@ func runInvoke(cmd *cobra.Command, args []string, opts *internal.ToolboxOptions)
 		return errMsg
 	}
 
+	err = tool.ValidateSource(primitiveMgr)
+	if err != nil {
+		opts.Logger.ErrorContext(ctx, err.Error())
+		return err
+	}
+
+	srcName := tool.GetSource()
+	var src sources.Source
+	if srcName != "" {
+		src, ok = primitiveMgr.GetSource(srcName)
+		if !ok {
+			errMsg := fmt.Errorf("unable to retrieve source for tool %s", toolName)
+			opts.Logger.ErrorContext(ctx, errMsg.Error())
+			return err
+		}
+	}
+
 	var paramsInput string
 	if len(args) > 1 {
 		paramsInput = args[1]
@@ -96,7 +114,7 @@ func runInvoke(cmd *cobra.Command, args []string, opts *internal.ToolboxOptions)
 		}
 	}
 
-	toolParams, err := tool.GetParameters(sourcesMap)
+	toolParams, err := tool.GetParameters(src)
 	if err != nil {
 		errMsg := fmt.Errorf("error getting parameters for tool: %w", err)
 		opts.Logger.ErrorContext(ctx, errMsg.Error())
@@ -118,7 +136,7 @@ func runInvoke(cmd *cobra.Command, args []string, opts *internal.ToolboxOptions)
 	}
 
 	// Client Auth not supported for ephemeral CLI call
-	requiresAuth, err := tool.RequiresClientAuthorization(primitiveMgr)
+	requiresAuth, err := tool.RequiresClientAuthorization(src)
 	if err != nil {
 		errMsg := fmt.Errorf("failed to check auth requirements: %w", err)
 		opts.Logger.ErrorContext(ctx, errMsg.Error())
@@ -130,7 +148,7 @@ func runInvoke(cmd *cobra.Command, args []string, opts *internal.ToolboxOptions)
 		return errMsg
 	}
 
-	result, err := tool.Invoke(ctx, primitiveMgr, parsedParams, "")
+	result, err := tool.Invoke(ctx, src, parsedParams, "")
 	if err != nil {
 		errMsg := fmt.Errorf("tool execution failed: %w", err)
 		opts.Logger.ErrorContext(ctx, errMsg.Error())

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -24,6 +24,7 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/render"
 	"github.com/googleapis/mcp-toolbox/internal/auth/generic"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -74,7 +75,7 @@ func toolsetHandler(s *Server, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	manifest, err := toolset.BuildManifest(s.PrimitiveMgr.GetSourcesMap())
+	manifest, err := toolset.BuildManifest(s.PrimitiveMgr)
 	if err != nil {
 		s.logger.DebugContext(ctx, err.Error())
 		_ = render.Render(w, r, newErrResponse(err, http.StatusInternalServerError))
@@ -107,7 +108,18 @@ func toolGetHandler(s *Server, w http.ResponseWriter, r *http.Request) {
 		_ = render.Render(w, r, newErrResponse(err, http.StatusNotFound))
 		return
 	}
-	toolManifest, err := tool.Manifest(s.PrimitiveMgr.GetSourcesMap())
+	srcName := tool.GetSource()
+	var src sources.Source
+	if srcName != "" {
+		src, ok = s.PrimitiveMgr.GetSource(srcName)
+		if !ok {
+			err = fmt.Errorf("unable to retrieve source for tool %s", toolName)
+			s.logger.DebugContext(ctx, err.Error())
+			_ = render.Render(w, r, newErrResponse(err, http.StatusNotFound))
+			return
+		}
+	}
+	toolManifest, err := tool.Manifest(src)
 	if err != nil {
 		err = fmt.Errorf("error generating manifest for tool %q: %w", toolName, err)
 		s.logger.DebugContext(ctx, err.Error())
@@ -150,12 +162,31 @@ func toolInvokeHandler(s *Server, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	err = tool.ValidateSource(s.PrimitiveMgr)
+	if err != nil {
+		s.logger.DebugContext(ctx, err.Error())
+		_ = render.Render(w, r, newErrResponse(err, http.StatusNotFound))
+		return
+	}
+
+	srcName := tool.GetSource()
+	var src sources.Source
+	if srcName != "" {
+		src, ok = s.PrimitiveMgr.GetSource(srcName)
+		if !ok {
+			err = fmt.Errorf("unable to retrieve source for tool %s", toolName)
+			s.logger.DebugContext(ctx, err.Error())
+			_ = render.Render(w, r, newErrResponse(err, http.StatusNotFound))
+			return
+		}
+	}
+
 	// Extract OAuth access token from the "Authorization" header (currently for
 	// BigQuery end-user credentials usage only)
 	accessToken := tools.AccessToken(r.Header.Get("Authorization"))
 
 	// Check if this specific tool requires the standard authorization header
-	clientAuth, err := tool.RequiresClientAuthorization(s.PrimitiveMgr)
+	clientAuth, err := tool.RequiresClientAuthorization(src)
 	if err != nil {
 		errMsg := fmt.Errorf("error during invocation: %w", err)
 		s.logger.DebugContext(ctx, errMsg.Error())
@@ -233,7 +264,7 @@ func toolInvokeHandler(s *Server, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	toolParams, err := tool.GetParameters(s.PrimitiveMgr.GetSourcesMap())
+	toolParams, err := tool.GetParameters(src)
 	if err != nil {
 		err = fmt.Errorf("error getting parameters for tool: %w", err)
 		s.logger.DebugContext(ctx, err.Error())
@@ -276,7 +307,7 @@ func toolInvokeHandler(s *Server, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	res, err := tool.Invoke(ctx, s.PrimitiveMgr, params, accessToken)
+	res, err := tool.Invoke(ctx, src, params, accessToken)
 
 	// Determine what error to return to the users.
 	if err != nil {

--- a/internal/server/mcp/v20241105/manifests.go
+++ b/internal/server/mcp/v20241105/manifests.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/googleapis/mcp-toolbox/internal/prompts"
+	"github.com/googleapis/mcp-toolbox/internal/server/primitives"
 	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -97,14 +98,22 @@ func generateParamManifest(ps parameters.Parameters, urlParams map[string]string
 }
 
 // GenerateListToolsResult generates tools/list method result according to mcp schema
-func GenerateListToolsResult(srcs map[string]sources.Source, t tools.Toolset, toolsMap map[string]tools.Tool, urlParams map[string]string) (ListToolsResult, error) {
+func GenerateListToolsResult(pMgr *primitives.PrimitiveManager, t tools.Toolset, urlParams map[string]string) (ListToolsResult, error) {
 	mcpManifest := make([]Tool, 0, len(t.ToolNames))
 	for _, toolName := range t.ToolNames {
-		tool, ok := toolsMap[toolName]
+		tool, ok := pMgr.GetTool(toolName)
 		if !ok {
 			return ListToolsResult{}, fmt.Errorf("tool does not exist: %s", toolName)
 		}
-		params, err := tool.GetParameters(srcs)
+		srcName := tool.GetSource()
+		var src sources.Source
+		if srcName != "" {
+			src, ok = pMgr.GetSource(tool.GetSource())
+			if !ok {
+				return ListToolsResult{}, fmt.Errorf("unable to retrieve %s source for tool %q", tool.GetSource(), tool.GetName())
+			}
+		}
+		params, err := tool.GetParameters(src)
 		if err != nil {
 			return ListToolsResult{}, fmt.Errorf("error getting parameters for tool %q: %w", toolName, err)
 		}

--- a/internal/server/mcp/v20241105/manifests_test.go
+++ b/internal/server/mcp/v20241105/manifests_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/mcp-toolbox/internal/prompts"
+	"github.com/googleapis/mcp-toolbox/internal/server/primitives"
 	"github.com/googleapis/mcp-toolbox/internal/testutils"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -248,8 +249,8 @@ func TestGenerateListToolsResult(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to initialize toolset %q: %s", "test-toolset", err)
 	}
-
-	got, err := GenerateListToolsResult(nil, toolset, toolsMap, nil)
+	pMgr := primitives.NewPrimitiveManager(nil, nil, nil, toolsMap, nil, nil, nil)
+	got, err := GenerateListToolsResult(pMgr, toolset, nil)
 	if err != nil {
 		t.Fatalf("unable to generate list tools result: %s", err)
 	}

--- a/internal/server/mcp/v20241105/method.go
+++ b/internal/server/mcp/v20241105/method.go
@@ -29,6 +29,7 @@ import (
 	"github.com/googleapis/mcp-toolbox/internal/server/mcp/jsonrpc"
 	mcputil "github.com/googleapis/mcp-toolbox/internal/server/mcp/util"
 	"github.com/googleapis/mcp-toolbox/internal/server/primitives"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -118,8 +119,7 @@ func toolsListHandler(ctx context.Context, id jsonrpc.RequestId, primitiveMgr *p
 	}
 
 	urlParams, _ := util.UrlParamsFromContext(ctx)
-	toolsMap := primitiveMgr.GetToolsMap()
-	listToolsResult, err := GenerateListToolsResult(primitiveMgr.GetSourcesMap(), toolset, toolsMap, urlParams)
+	listToolsResult, err := GenerateListToolsResult(primitiveMgr, toolset, urlParams)
 	if err != nil {
 		err = fmt.Errorf("error generating manifest: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
@@ -178,6 +178,21 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 		return jsonrpc.NewError(id, jsonrpc.INVALID_PARAMS, err.Error(), nil), err
 	}
 
+	err = tool.ValidateSource(primitiveMgr)
+	if err != nil {
+		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+	}
+
+	srcName := tool.GetSource()
+	var src sources.Source
+	if srcName != "" {
+		src, ok = primitiveMgr.GetSource(srcName)
+		if !ok {
+			err = fmt.Errorf("unable to retrieve source for tool %s", toolName)
+			return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+		}
+	}
+
 	// Populate gen_ai attributes for operation duration metric
 	if genAIAttrs := util.GenAIMetricAttrsFromContext(ctx); genAIAttrs != nil {
 		genAIAttrs.OperationName = "execute_tool"
@@ -185,7 +200,7 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 	}
 
 	// Get access token
-	authTokenHeadername, err := tool.GetAuthTokenHeaderName(primitiveMgr)
+	authTokenHeadername, err := tool.GetAuthTokenHeaderName(src)
 	if err != nil {
 		errMsg := fmt.Errorf("error during invocation: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, errMsg.Error(), nil), errMsg
@@ -196,7 +211,7 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 	}
 
 	// Check if this specific tool requires the standard authorization header
-	clientAuth, err := tool.RequiresClientAuthorization(primitiveMgr)
+	clientAuth, err := tool.RequiresClientAuthorization(src)
 	if err != nil {
 		errMsg := fmt.Errorf("error during invocation: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, errMsg.Error(), nil), errMsg
@@ -282,7 +297,7 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 		return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
 	}
 
-	toolParams, err := tool.GetParameters(primitiveMgr.GetSourcesMap())
+	toolParams, err := tool.GetParameters(src)
 	if err != nil {
 		err = fmt.Errorf("error getting parameters for tool: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
@@ -310,7 +325,7 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 
 	// run tool invocation and generate response.
 	executionStart := time.Now()
-	results, err := tool.Invoke(ctx, primitiveMgr, params, accessToken)
+	results, err := tool.Invoke(ctx, src, params, accessToken)
 	executionDuration := time.Since(executionStart).Seconds()
 
 	// Record tool execution duration metric

--- a/internal/server/mcp/v20250326/manifests.go
+++ b/internal/server/mcp/v20250326/manifests.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/googleapis/mcp-toolbox/internal/prompts"
+	"github.com/googleapis/mcp-toolbox/internal/server/primitives"
 	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -96,14 +97,22 @@ func generateParamManifest(ps parameters.Parameters, urlParams map[string]string
 }
 
 // GenerateListToolsResult generates tools/list method result according to mcp schema
-func GenerateListToolsResult(srcs map[string]sources.Source, t tools.Toolset, toolsMap map[string]tools.Tool, urlParams map[string]string) (ListToolsResult, error) {
+func GenerateListToolsResult(pMgr *primitives.PrimitiveManager, t tools.Toolset, urlParams map[string]string) (ListToolsResult, error) {
 	mcpManifest := make([]Tool, 0, len(t.ToolNames))
 	for _, toolName := range t.ToolNames {
-		tool, ok := toolsMap[toolName]
+		tool, ok := pMgr.GetTool(toolName)
 		if !ok {
 			return ListToolsResult{}, fmt.Errorf("tool does not exist: %s", toolName)
 		}
-		params, err := tool.GetParameters(srcs)
+		srcName := tool.GetSource()
+		var src sources.Source
+		if srcName != "" {
+			src, ok = pMgr.GetSource(tool.GetSource())
+			if !ok {
+				return ListToolsResult{}, fmt.Errorf("unable to retrieve %s source for tool %q", tool.GetSource(), tool.GetName())
+			}
+		}
+		params, err := tool.GetParameters(src)
 		if err != nil {
 			return ListToolsResult{}, fmt.Errorf("error getting parameters for tool %q: %w", toolName, err)
 		}

--- a/internal/server/mcp/v20250326/manifests_test.go
+++ b/internal/server/mcp/v20250326/manifests_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/mcp-toolbox/internal/prompts"
+	"github.com/googleapis/mcp-toolbox/internal/server/primitives"
 	"github.com/googleapis/mcp-toolbox/internal/testutils"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -249,7 +250,8 @@ func TestGenerateListToolsResult(t *testing.T) {
 		t.Fatalf("unable to initialize toolset %q: %s", "test-toolset", err)
 	}
 
-	got, err := GenerateListToolsResult(nil, toolset, toolsMap, nil)
+	pMgr := primitives.NewPrimitiveManager(nil, nil, nil, toolsMap, nil, nil, nil)
+	got, err := GenerateListToolsResult(pMgr, toolset, nil)
 	if err != nil {
 		t.Fatalf("unable to generate list tools result: %s", err)
 	}

--- a/internal/server/mcp/v20250326/method.go
+++ b/internal/server/mcp/v20250326/method.go
@@ -29,6 +29,7 @@ import (
 	"github.com/googleapis/mcp-toolbox/internal/server/mcp/jsonrpc"
 	mcputil "github.com/googleapis/mcp-toolbox/internal/server/mcp/util"
 	"github.com/googleapis/mcp-toolbox/internal/server/primitives"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -118,8 +119,7 @@ func toolsListHandler(ctx context.Context, id jsonrpc.RequestId, primitiveMgr *p
 	}
 
 	urlParams, _ := util.UrlParamsFromContext(ctx)
-	toolsMap := primitiveMgr.GetToolsMap()
-	listToolsResult, err := GenerateListToolsResult(primitiveMgr.GetSourcesMap(), toolset, toolsMap, urlParams)
+	listToolsResult, err := GenerateListToolsResult(primitiveMgr, toolset, urlParams)
 	if err != nil {
 		err = fmt.Errorf("error generating manifest: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
@@ -178,6 +178,21 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 		return jsonrpc.NewError(id, jsonrpc.INVALID_PARAMS, err.Error(), nil), err
 	}
 
+	err = tool.ValidateSource(primitiveMgr)
+	if err != nil {
+		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+	}
+
+	srcName := tool.GetSource()
+	var src sources.Source
+	if srcName != "" {
+		src, ok = primitiveMgr.GetSource(srcName)
+		if !ok {
+			err = fmt.Errorf("unable to retrieve source for tool %s", toolName)
+			return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+		}
+	}
+
 	// Populate gen_ai attributes for operation duration metric
 	if genAIAttrs := util.GenAIMetricAttrsFromContext(ctx); genAIAttrs != nil {
 		genAIAttrs.OperationName = "execute_tool"
@@ -185,7 +200,7 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 	}
 
 	// Get access token
-	authTokenHeadername, err := tool.GetAuthTokenHeaderName(primitiveMgr)
+	authTokenHeadername, err := tool.GetAuthTokenHeaderName(src)
 	if err != nil {
 		errMsg := fmt.Errorf("error during invocation: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, errMsg.Error(), nil), errMsg
@@ -196,7 +211,7 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 	}
 
 	// Check if this specific tool requires the standard authorization header
-	clientAuth, err := tool.RequiresClientAuthorization(primitiveMgr)
+	clientAuth, err := tool.RequiresClientAuthorization(src)
 	if err != nil {
 		errMsg := fmt.Errorf("error during invocation: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, errMsg.Error(), nil), errMsg
@@ -282,7 +297,7 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 		return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
 	}
 
-	toolParams, err := tool.GetParameters(primitiveMgr.GetSourcesMap())
+	toolParams, err := tool.GetParameters(src)
 	if err != nil {
 		err = fmt.Errorf("error getting parameters for tool: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
@@ -310,7 +325,7 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 
 	// run tool invocation and generate response.
 	executionStart := time.Now()
-	results, err := tool.Invoke(ctx, primitiveMgr, params, accessToken)
+	results, err := tool.Invoke(ctx, src, params, accessToken)
 	executionDuration := time.Since(executionStart).Seconds()
 
 	// Record tool execution duration metric

--- a/internal/server/mcp/v20250618/manifests.go
+++ b/internal/server/mcp/v20250618/manifests.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/googleapis/mcp-toolbox/internal/prompts"
+	"github.com/googleapis/mcp-toolbox/internal/server/primitives"
 	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -98,14 +99,22 @@ func generateParamManifest(ps parameters.Parameters, urlParams map[string]string
 }
 
 // GenerateListToolsResult generates tools/list method result according to mcp schema
-func GenerateListToolsResult(srcs map[string]sources.Source, t tools.Toolset, toolsMap map[string]tools.Tool, urlParams map[string]string) (ListToolsResult, error) {
+func GenerateListToolsResult(pMgr *primitives.PrimitiveManager, t tools.Toolset, urlParams map[string]string) (ListToolsResult, error) {
 	mcpManifest := make([]Tool, 0, len(t.ToolNames))
 	for _, toolName := range t.ToolNames {
-		tool, ok := toolsMap[toolName]
+		tool, ok := pMgr.GetTool(toolName)
 		if !ok {
 			return ListToolsResult{}, fmt.Errorf("tool does not exist: %s", toolName)
 		}
-		params, err := tool.GetParameters(srcs)
+		srcName := tool.GetSource()
+		var src sources.Source
+		if srcName != "" {
+			src, ok = pMgr.GetSource(tool.GetSource())
+			if !ok {
+				return ListToolsResult{}, fmt.Errorf("unable to retrieve %s source for tool %q", tool.GetSource(), tool.GetName())
+			}
+		}
+		params, err := tool.GetParameters(src)
 		if err != nil {
 			return ListToolsResult{}, fmt.Errorf("error getting parameters for tool %q: %w", toolName, err)
 		}

--- a/internal/server/mcp/v20250618/manifests_test.go
+++ b/internal/server/mcp/v20250618/manifests_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/mcp-toolbox/internal/prompts"
+	"github.com/googleapis/mcp-toolbox/internal/server/primitives"
 	"github.com/googleapis/mcp-toolbox/internal/testutils"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -249,7 +250,8 @@ func TestGenerateListToolsResult(t *testing.T) {
 		t.Fatalf("unable to initialize toolset %q: %s", "test-toolset", err)
 	}
 
-	got, err := GenerateListToolsResult(nil, toolset, toolsMap, nil)
+	pMgr := primitives.NewPrimitiveManager(nil, nil, nil, toolsMap, nil, nil, nil)
+	got, err := GenerateListToolsResult(pMgr, toolset, nil)
 	if err != nil {
 		t.Fatalf("unable to generate list tools result: %s", err)
 	}

--- a/internal/server/mcp/v20250618/method.go
+++ b/internal/server/mcp/v20250618/method.go
@@ -29,6 +29,7 @@ import (
 	"github.com/googleapis/mcp-toolbox/internal/server/mcp/jsonrpc"
 	mcputil "github.com/googleapis/mcp-toolbox/internal/server/mcp/util"
 	"github.com/googleapis/mcp-toolbox/internal/server/primitives"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -118,8 +119,7 @@ func toolsListHandler(ctx context.Context, id jsonrpc.RequestId, primitiveMgr *p
 	}
 
 	urlParams, _ := util.UrlParamsFromContext(ctx)
-	toolsMap := primitiveMgr.GetToolsMap()
-	listToolsResult, err := GenerateListToolsResult(primitiveMgr.GetSourcesMap(), toolset, toolsMap, urlParams)
+	listToolsResult, err := GenerateListToolsResult(primitiveMgr, toolset, urlParams)
 	if err != nil {
 		err = fmt.Errorf("error generating manifest: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
@@ -177,6 +177,21 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 		return jsonrpc.NewError(id, jsonrpc.INVALID_PARAMS, err.Error(), nil), err
 	}
 
+	err = tool.ValidateSource(primitiveMgr)
+	if err != nil {
+		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+	}
+
+	srcName := tool.GetSource()
+	var src sources.Source
+	if srcName != "" {
+		src, ok = primitiveMgr.GetSource(srcName)
+		if !ok {
+			err = fmt.Errorf("unable to retrieve source for tool %s", toolName)
+			return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+		}
+	}
+
 	// Populate gen_ai attributes for operation duration metric
 	if genAIAttrs := util.GenAIMetricAttrsFromContext(ctx); genAIAttrs != nil {
 		genAIAttrs.OperationName = "execute_tool"
@@ -184,7 +199,7 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 	}
 
 	// Get access token
-	authTokenHeadername, err := tool.GetAuthTokenHeaderName(primitiveMgr)
+	authTokenHeadername, err := tool.GetAuthTokenHeaderName(src)
 	if err != nil {
 		errMsg := fmt.Errorf("error during invocation: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, errMsg.Error(), nil), errMsg
@@ -195,7 +210,7 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 	}
 
 	// Check if this specific tool requires the standard authorization header
-	clientAuth, err := tool.RequiresClientAuthorization(primitiveMgr)
+	clientAuth, err := tool.RequiresClientAuthorization(src)
 	if err != nil {
 		errMsg := fmt.Errorf("error during invocation: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, errMsg.Error(), nil), errMsg
@@ -281,7 +296,7 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 		return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
 	}
 
-	toolParams, err := tool.GetParameters(primitiveMgr.GetSourcesMap())
+	toolParams, err := tool.GetParameters(src)
 	if err != nil {
 		err = fmt.Errorf("error getting parameters for tool: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
@@ -309,7 +324,7 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 
 	// run tool invocation and generate response.
 	executionStart := time.Now()
-	results, err := tool.Invoke(ctx, primitiveMgr, params, accessToken)
+	results, err := tool.Invoke(ctx, src, params, accessToken)
 	executionDuration := time.Since(executionStart).Seconds()
 
 	// Record tool execution duration metric

--- a/internal/server/mcp/v20251125/manifests.go
+++ b/internal/server/mcp/v20251125/manifests.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/googleapis/mcp-toolbox/internal/prompts"
+	"github.com/googleapis/mcp-toolbox/internal/server/primitives"
 	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -98,14 +99,22 @@ func generateParamManifest(ps parameters.Parameters, urlParams map[string]string
 }
 
 // GenerateListToolsResult generates tools/list method result according to mcp schema
-func GenerateListToolsResult(srcs map[string]sources.Source, t tools.Toolset, toolsMap map[string]tools.Tool, urlParams map[string]string) (ListToolsResult, error) {
+func GenerateListToolsResult(pMgr *primitives.PrimitiveManager, t tools.Toolset, urlParams map[string]string) (ListToolsResult, error) {
 	mcpManifest := make([]Tool, 0, len(t.ToolNames))
 	for _, toolName := range t.ToolNames {
-		tool, ok := toolsMap[toolName]
+		tool, ok := pMgr.GetTool(toolName)
 		if !ok {
 			return ListToolsResult{}, fmt.Errorf("tool does not exist: %s", toolName)
 		}
-		params, err := tool.GetParameters(srcs)
+		srcName := tool.GetSource()
+		var src sources.Source
+		if srcName != "" {
+			src, ok = pMgr.GetSource(tool.GetSource())
+			if !ok {
+				return ListToolsResult{}, fmt.Errorf("unable to retrieve %s source for tool %q", tool.GetSource(), tool.GetName())
+			}
+		}
+		params, err := tool.GetParameters(src)
 		if err != nil {
 			return ListToolsResult{}, fmt.Errorf("error getting parameters for tool %q: %w", toolName, err)
 		}

--- a/internal/server/mcp/v20251125/manifests_test.go
+++ b/internal/server/mcp/v20251125/manifests_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/mcp-toolbox/internal/prompts"
+	"github.com/googleapis/mcp-toolbox/internal/server/primitives"
 	"github.com/googleapis/mcp-toolbox/internal/testutils"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -249,7 +250,8 @@ func TestGenerateListToolsResult(t *testing.T) {
 		t.Fatalf("unable to initialize toolset %q: %s", "test-toolset", err)
 	}
 
-	got, err := GenerateListToolsResult(nil, toolset, toolsMap, nil)
+	pMgr := primitives.NewPrimitiveManager(nil, nil, nil, toolsMap, nil, nil, nil)
+	got, err := GenerateListToolsResult(pMgr, toolset, nil)
 	if err != nil {
 		t.Fatalf("unable to generate list tools result: %s", err)
 	}

--- a/internal/server/mcp/v20251125/method.go
+++ b/internal/server/mcp/v20251125/method.go
@@ -29,6 +29,7 @@ import (
 	"github.com/googleapis/mcp-toolbox/internal/server/mcp/jsonrpc"
 	mcputil "github.com/googleapis/mcp-toolbox/internal/server/mcp/util"
 	"github.com/googleapis/mcp-toolbox/internal/server/primitives"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -118,8 +119,7 @@ func toolsListHandler(ctx context.Context, id jsonrpc.RequestId, primitiveMgr *p
 	}
 
 	urlParams, _ := util.UrlParamsFromContext(ctx)
-	toolsMap := primitiveMgr.GetToolsMap()
-	listToolsResult, err := GenerateListToolsResult(primitiveMgr.GetSourcesMap(), toolset, toolsMap, urlParams)
+	listToolsResult, err := GenerateListToolsResult(primitiveMgr, toolset, urlParams)
 	if err != nil {
 		err = fmt.Errorf("error generating manifest: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
@@ -177,6 +177,21 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 		return jsonrpc.NewError(id, jsonrpc.INVALID_PARAMS, err.Error(), nil), err
 	}
 
+	err = tool.ValidateSource(primitiveMgr)
+	if err != nil {
+		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+	}
+
+	srcName := tool.GetSource()
+	var src sources.Source
+	if srcName != "" {
+		src, ok = primitiveMgr.GetSource(srcName)
+		if !ok {
+			err = fmt.Errorf("unable to retrieve source for tool %s", toolName)
+			return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+		}
+	}
+
 	// Populate gen_ai attributes for operation duration metric
 	if genAIAttrs := util.GenAIMetricAttrsFromContext(ctx); genAIAttrs != nil {
 		genAIAttrs.OperationName = "execute_tool"
@@ -184,7 +199,7 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 	}
 
 	// Get access token
-	authTokenHeadername, err := tool.GetAuthTokenHeaderName(primitiveMgr)
+	authTokenHeadername, err := tool.GetAuthTokenHeaderName(src)
 	if err != nil {
 		errMsg := fmt.Errorf("error during invocation: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, errMsg.Error(), nil), errMsg
@@ -195,7 +210,7 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 	}
 
 	// Check if this specific tool requires the standard authorization header
-	clientAuth, err := tool.RequiresClientAuthorization(primitiveMgr)
+	clientAuth, err := tool.RequiresClientAuthorization(src)
 	if err != nil {
 		errMsg := fmt.Errorf("error during invocation: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, errMsg.Error(), nil), errMsg
@@ -281,7 +296,7 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 		return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
 	}
 
-	toolParams, err := tool.GetParameters(primitiveMgr.GetSourcesMap())
+	toolParams, err := tool.GetParameters(src)
 	if err != nil {
 		err = fmt.Errorf("error getting parameters for tool: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
@@ -309,7 +324,7 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 
 	// run tool invocation and generate response.
 	executionStart := time.Now()
-	results, err := tool.Invoke(ctx, primitiveMgr, params, accessToken)
+	results, err := tool.Invoke(ctx, src, params, accessToken)
 	executionDuration := time.Since(executionStart).Seconds()
 
 	// Record tool execution duration metric

--- a/internal/server/mcp/vdraft/manifests.go
+++ b/internal/server/mcp/vdraft/manifests.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/googleapis/mcp-toolbox/internal/prompts"
+	"github.com/googleapis/mcp-toolbox/internal/server/primitives"
 	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -98,14 +99,22 @@ func generateParamManifest(ps parameters.Parameters, urlParams map[string]string
 }
 
 // GenerateListToolsResult generates tools/list method result according to mcp schema
-func GenerateListToolsResult(srcs map[string]sources.Source, t tools.Toolset, toolsMap map[string]tools.Tool, urlParams map[string]string) (ListToolsResult, error) {
+func GenerateListToolsResult(pMgr *primitives.PrimitiveManager, t tools.Toolset, urlParams map[string]string) (ListToolsResult, error) {
 	mcpManifest := make([]Tool, 0, len(t.ToolNames))
 	for _, toolName := range t.ToolNames {
-		tool, ok := toolsMap[toolName]
+		tool, ok := pMgr.GetTool(toolName)
 		if !ok {
 			return ListToolsResult{}, fmt.Errorf("tool does not exist: %s", toolName)
 		}
-		params, err := tool.GetParameters(srcs)
+		srcName := tool.GetSource()
+		var src sources.Source
+		if srcName != "" {
+			src, ok = pMgr.GetSource(tool.GetSource())
+			if !ok {
+				return ListToolsResult{}, fmt.Errorf("unable to retrieve %s source for tool %q", tool.GetSource(), tool.GetName())
+			}
+		}
+		params, err := tool.GetParameters(src)
 		if err != nil {
 			return ListToolsResult{}, fmt.Errorf("error getting parameters for tool %q: %w", toolName, err)
 		}

--- a/internal/server/mcp/vdraft/manifests_test.go
+++ b/internal/server/mcp/vdraft/manifests_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/mcp-toolbox/internal/prompts"
+	"github.com/googleapis/mcp-toolbox/internal/server/primitives"
 	"github.com/googleapis/mcp-toolbox/internal/testutils"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -249,7 +250,8 @@ func TestGenerateListToolsResult(t *testing.T) {
 		t.Fatalf("unable to initialize toolset %q: %s", "test-toolset", err)
 	}
 
-	got, err := GenerateListToolsResult(nil, toolset, toolsMap, nil)
+	pMgr := primitives.NewPrimitiveManager(nil, nil, nil, toolsMap, nil, nil, nil)
+	got, err := GenerateListToolsResult(pMgr, toolset, nil)
 	if err != nil {
 		t.Fatalf("unable to generate list tools result: %s", err)
 	}

--- a/internal/server/mcp/vdraft/method.go
+++ b/internal/server/mcp/vdraft/method.go
@@ -28,6 +28,7 @@ import (
 	"github.com/googleapis/mcp-toolbox/internal/server/mcp/jsonrpc"
 	mcputil "github.com/googleapis/mcp-toolbox/internal/server/mcp/util"
 	"github.com/googleapis/mcp-toolbox/internal/server/primitives"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -226,8 +227,7 @@ func toolsListHandler(ctx context.Context, id jsonrpc.RequestId, primitiveMgr *p
 	}
 
 	urlParams, _ := util.UrlParamsFromContext(ctx)
-	toolsMap := primitiveMgr.GetToolsMap()
-	listToolsResult, err := GenerateListToolsResult(primitiveMgr.GetSourcesMap(), toolset, toolsMap, urlParams)
+	listToolsResult, err := GenerateListToolsResult(primitiveMgr, toolset, urlParams)
 	if err != nil {
 		err = fmt.Errorf("error generating manifest: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
@@ -296,6 +296,21 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 		return jsonrpc.NewError(id, jsonrpc.INVALID_PARAMS, err.Error(), nil), err
 	}
 
+	err = tool.ValidateSource(primitiveMgr)
+	if err != nil {
+		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+	}
+
+	srcName := tool.GetSource()
+	var src sources.Source
+	if srcName != "" {
+		src, ok = primitiveMgr.GetSource(srcName)
+		if !ok {
+			err = fmt.Errorf("unable to retrieve source for tool %s", toolName)
+			return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
+		}
+	}
+
 	// Populate gen_ai attributes for operation duration metric
 	if genAIAttrs := util.GenAIMetricAttrsFromContext(ctx); genAIAttrs != nil {
 		genAIAttrs.OperationName = "execute_tool"
@@ -303,7 +318,7 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 	}
 
 	// Get access token
-	authTokenHeadername, err := tool.GetAuthTokenHeaderName(primitiveMgr)
+	authTokenHeadername, err := tool.GetAuthTokenHeaderName(src)
 	if err != nil {
 		errMsg := fmt.Errorf("error during invocation: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, errMsg.Error(), nil), errMsg
@@ -314,7 +329,7 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 	}
 
 	// Check if this specific tool requires the standard authorization header
-	clientAuth, err := tool.RequiresClientAuthorization(primitiveMgr)
+	clientAuth, err := tool.RequiresClientAuthorization(src)
 	if err != nil {
 		errMsg := fmt.Errorf("error during invocation: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, errMsg.Error(), nil), errMsg
@@ -400,7 +415,7 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 		return jsonrpc.NewError(id, jsonrpc.INVALID_REQUEST, err.Error(), nil), err
 	}
 
-	toolParams, err := tool.GetParameters(primitiveMgr.GetSourcesMap())
+	toolParams, err := tool.GetParameters(src)
 	if err != nil {
 		err = fmt.Errorf("error getting parameters for tool: %w", err)
 		return jsonrpc.NewError(id, jsonrpc.INTERNAL_ERROR, err.Error(), nil), err
@@ -428,7 +443,7 @@ func toolsCallHandler(ctx context.Context, id jsonrpc.RequestId, toolset tools.T
 
 	// run tool invocation and generate response.
 	executionStart := time.Now()
-	results, err := tool.Invoke(ctx, primitiveMgr, params, accessToken)
+	results, err := tool.Invoke(ctx, src, params, accessToken)
 	executionDuration := time.Since(executionStart).Seconds()
 
 	// Record tool execution duration metric

--- a/internal/server/primitives/primitives.go
+++ b/internal/server/primitives/primitives.go
@@ -119,16 +119,6 @@ func (r *PrimitiveManager) SetPrimitives(sourcesMap map[string]sources.Source, a
 	r.promptsets = promptsetsMap
 }
 
-func (r *PrimitiveManager) GetSourcesMap() map[string]sources.Source {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	copiedMap := make(map[string]sources.Source, len(r.sources))
-	for k, v := range r.sources {
-		copiedMap[k] = v
-	}
-	return copiedMap
-}
-
 func (r *PrimitiveManager) GetAuthServiceMap() map[string]auth.AuthService {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -144,16 +134,6 @@ func (r *PrimitiveManager) GetEmbeddingModelMap() map[string]embeddingmodels.Emb
 	defer r.mu.RUnlock()
 	copiedMap := make(map[string]embeddingmodels.EmbeddingModel, len(r.embeddingModels))
 	for k, v := range r.embeddingModels {
-		copiedMap[k] = v
-	}
-	return copiedMap
-}
-
-func (r *PrimitiveManager) GetToolsMap() map[string]tools.Tool {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	copiedMap := make(map[string]tools.Tool, len(r.tools))
-	for k, v := range r.tools {
 		copiedMap[k] = v
 	}
 	return copiedMap

--- a/internal/testutils/mocks.go
+++ b/internal/testutils/mocks.go
@@ -57,7 +57,7 @@ func NewMockTool(name, desc string, params []parameters.Parameter, unauthorized,
 	}
 }
 
-func (t MockTool) Invoke(ctx context.Context, s tools.SourceProvider, params parameters.ParamValues, token tools.AccessToken) (any, util.ToolboxError) {
+func (t MockTool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, token tools.AccessToken) (any, util.ToolboxError) {
 	mock := []any{t.Name}
 	if t.ReturnParamsInInvoke && len(params) > 0 {
 		for _, p := range params {
@@ -67,7 +67,15 @@ func (t MockTool) Invoke(ctx context.Context, s tools.SourceProvider, params par
 	return mock, nil
 }
 
+func (t MockTool) GetSource() string {
+	return ""
+}
+
 func (t MockTool) ToConfig() tools.ToolConfig {
+	return nil
+}
+
+func (t MockTool) ValidateSource(tools.SourceManager) error {
 	return nil
 }
 
@@ -80,7 +88,7 @@ func (t MockTool) EmbedParams(ctx context.Context, paramValues parameters.ParamV
 	return parameters.EmbedParams(ctx, t.Params, paramValues, embeddingModelsMap, nil)
 }
 
-func (t MockTool) Manifest(map[string]sources.Source) (tools.Manifest, error) {
+func (t MockTool) Manifest(sources.Source) (tools.Manifest, error) {
 	return t.manifest, nil
 }
 
@@ -93,12 +101,12 @@ func (t MockTool) Authorized(verifiedAuthServices []string) bool {
 	return !t.unauthorized
 }
 
-func (t MockTool) RequiresClientAuthorization(tools.SourceProvider) (bool, error) {
+func (t MockTool) RequiresClientAuthorization(sources.Source) (bool, error) {
 	// defaulted to false
 	return t.requireClientAuthorization, nil
 }
 
-func (t MockTool) GetParameters(map[string]sources.Source) (parameters.Parameters, error) {
+func (t MockTool) GetParameters(sources.Source) (parameters.Parameters, error) {
 	return t.Params, nil
 }
 
@@ -118,7 +126,7 @@ func (t MockTool) GetAnnotations() *tools.ToolAnnotations {
 	return nil
 }
 
-func (t MockTool) GetAuthTokenHeaderName(tools.SourceProvider) (string, error) {
+func (t MockTool) GetAuthTokenHeaderName(sources.Source) (string, error) {
 	return "Authorization", nil
 }
 

--- a/internal/tools/alloydb/alloydbcreatecluster/alloydbcreatecluster.go
+++ b/internal/tools/alloydb/alloydbcreatecluster/alloydbcreatecluster.go
@@ -91,6 +91,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 // Invoke executes the tool's logic.
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)

--- a/internal/tools/alloydb/alloydbcreatecluster/alloydbcreatecluster.go
+++ b/internal/tools/alloydb/alloydbcreatecluster/alloydbcreatecluster.go
@@ -43,6 +43,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	GetDefaultProject() string
 	UseClientAuthorization() bool
 	CreateCluster(context.Context, string, string, string, string, string, string, string) (any, error)
@@ -87,12 +88,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -104,12 +109,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 }
 
 // Invoke executes the tool's logic.
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	project, ok := paramsMap["project"].(string)
 	if !ok || project == "" {
@@ -154,13 +158,12 @@ func (t Tool) Authorized(verifiedAuthServices []string) bool {
 	return true
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
 // buildParams builds the tool's parameters. A non-empty project means the source has a
@@ -181,22 +184,22 @@ func buildParams(project string) parameters.Parameters {
 }
 
 // resolveParams builds the tool's parameters using the source's configured default GCP project.
-func (t Tool) resolveParams(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	s, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, err
+func (t Tool) resolveParams(source sources.Source) (parameters.Parameters, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
 	return buildParams(s.GetDefaultProject()), nil
 }
 
 // GetParameters returns the tool's parameters, resolved against the source.
-func (t Tool) GetParameters(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	return t.resolveParams(srcs)
+func (t Tool) GetParameters(source sources.Source) (parameters.Parameters, error) {
+	return t.resolveParams(source)
 }
 
 // Manifest returns the tool's manifest, resolved against the source.
-func (t Tool) Manifest(srcs map[string]sources.Source) (tools.Manifest, error) {
-	allParameters, err := t.resolveParams(srcs)
+func (t Tool) Manifest(source sources.Source) (tools.Manifest, error) {
+	allParameters, err := t.resolveParams(source)
 	if err != nil {
 		return tools.Manifest{}, err
 	}

--- a/internal/tools/alloydb/alloydbcreateinstance/alloydbcreateinstance.go
+++ b/internal/tools/alloydb/alloydbcreateinstance/alloydbcreateinstance.go
@@ -91,6 +91,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 // Invoke executes the tool's logic.
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)

--- a/internal/tools/alloydb/alloydbcreateinstance/alloydbcreateinstance.go
+++ b/internal/tools/alloydb/alloydbcreateinstance/alloydbcreateinstance.go
@@ -43,6 +43,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	GetDefaultProject() string
 	UseClientAuthorization() bool
 	CreateInstance(context.Context, string, string, string, string, string, string, int, string) (any, error)
@@ -87,12 +88,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -104,12 +109,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 }
 
 // Invoke executes the tool's logic.
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	project, ok := paramsMap["project"].(string)
 	if !ok || project == "" {
@@ -158,13 +162,12 @@ func (t Tool) Authorized(verifiedAuthServices []string) bool {
 	return true
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
 // buildParams builds the tool's parameters. A non-empty project means the source has a
@@ -186,22 +189,22 @@ func buildParams(project string) parameters.Parameters {
 }
 
 // resolveParams builds the tool's parameters using the source's configured default GCP project.
-func (t Tool) resolveParams(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	s, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, err
+func (t Tool) resolveParams(source sources.Source) (parameters.Parameters, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
 	return buildParams(s.GetDefaultProject()), nil
 }
 
 // GetParameters returns the tool's parameters, resolved against the source.
-func (t Tool) GetParameters(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	return t.resolveParams(srcs)
+func (t Tool) GetParameters(source sources.Source) (parameters.Parameters, error) {
+	return t.resolveParams(source)
 }
 
 // Manifest returns the tool's manifest, resolved against the source.
-func (t Tool) Manifest(srcs map[string]sources.Source) (tools.Manifest, error) {
-	allParameters, err := t.resolveParams(srcs)
+func (t Tool) Manifest(source sources.Source) (tools.Manifest, error) {
+	allParameters, err := t.resolveParams(source)
 	if err != nil {
 		return tools.Manifest{}, err
 	}

--- a/internal/tools/alloydb/alloydbcreateuser/alloydbcreateuser.go
+++ b/internal/tools/alloydb/alloydbcreateuser/alloydbcreateuser.go
@@ -91,6 +91,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 // Invoke executes the tool's logic.
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)

--- a/internal/tools/alloydb/alloydbcreateuser/alloydbcreateuser.go
+++ b/internal/tools/alloydb/alloydbcreateuser/alloydbcreateuser.go
@@ -43,6 +43,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	GetDefaultProject() string
 	UseClientAuthorization() bool
 	CreateUser(context.Context, string, string, []string, string, string, string, string, string) (any, error)
@@ -87,12 +88,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -104,12 +109,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 }
 
 // Invoke executes the tool's logic.
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	project, ok := paramsMap["project"].(string)
 	if !ok || project == "" {
@@ -164,13 +168,12 @@ func (t Tool) Authorized(verifiedAuthServices []string) bool {
 	return true
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
 // buildParams builds the tool's parameters. A non-empty project means the source has a
@@ -192,22 +195,22 @@ func buildParams(project string) parameters.Parameters {
 }
 
 // resolveParams builds the tool's parameters using the source's configured default GCP project.
-func (t Tool) resolveParams(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	s, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, err
+func (t Tool) resolveParams(source sources.Source) (parameters.Parameters, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
 	return buildParams(s.GetDefaultProject()), nil
 }
 
 // GetParameters returns the tool's parameters, resolved against the source.
-func (t Tool) GetParameters(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	return t.resolveParams(srcs)
+func (t Tool) GetParameters(source sources.Source) (parameters.Parameters, error) {
+	return t.resolveParams(source)
 }
 
 // Manifest returns the tool's manifest, resolved against the source.
-func (t Tool) Manifest(srcs map[string]sources.Source) (tools.Manifest, error) {
-	allParameters, err := t.resolveParams(srcs)
+func (t Tool) Manifest(source sources.Source) (tools.Manifest, error) {
+	allParameters, err := t.resolveParams(source)
 	if err != nil {
 		return tools.Manifest{}, err
 	}

--- a/internal/tools/alloydb/alloydbgetcluster/alloydbgetcluster.go
+++ b/internal/tools/alloydb/alloydbgetcluster/alloydbgetcluster.go
@@ -43,6 +43,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	GetDefaultProject() string
 	UseClientAuthorization() bool
 	GetCluster(context.Context, string, string, string, string) (any, error)
@@ -87,12 +88,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -104,12 +109,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 }
 
 // Invoke executes the tool's logic.
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 
 	project, ok := paramsMap["project"].(string)
@@ -137,13 +141,12 @@ func (t Tool) Authorized(verifiedAuthServices []string) bool {
 	return true
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
 // buildParams builds the tool's parameters. A non-empty project means the source has a
@@ -161,22 +164,22 @@ func buildParams(project string) parameters.Parameters {
 }
 
 // resolveParams builds the tool's parameters using the source's configured default GCP project.
-func (t Tool) resolveParams(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	s, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, err
+func (t Tool) resolveParams(source sources.Source) (parameters.Parameters, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
 	return buildParams(s.GetDefaultProject()), nil
 }
 
 // GetParameters returns the tool's parameters, resolved against the source.
-func (t Tool) GetParameters(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	return t.resolveParams(srcs)
+func (t Tool) GetParameters(source sources.Source) (parameters.Parameters, error) {
+	return t.resolveParams(source)
 }
 
 // Manifest returns the tool's manifest, resolved against the source.
-func (t Tool) Manifest(srcs map[string]sources.Source) (tools.Manifest, error) {
-	allParameters, err := t.resolveParams(srcs)
+func (t Tool) Manifest(source sources.Source) (tools.Manifest, error) {
+	allParameters, err := t.resolveParams(source)
 	if err != nil {
 		return tools.Manifest{}, err
 	}

--- a/internal/tools/alloydb/alloydbgetcluster/alloydbgetcluster.go
+++ b/internal/tools/alloydb/alloydbgetcluster/alloydbgetcluster.go
@@ -91,6 +91,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 // Invoke executes the tool's logic.
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)

--- a/internal/tools/alloydb/alloydbgetinstance/alloydbgetinstance.go
+++ b/internal/tools/alloydb/alloydbgetinstance/alloydbgetinstance.go
@@ -43,6 +43,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	GetDefaultProject() string
 	UseClientAuthorization() bool
 	GetInstance(context.Context, string, string, string, string, string) (any, error)
@@ -87,12 +88,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -104,12 +109,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 }
 
 // Invoke executes the tool's logic.
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 
 	project, ok := paramsMap["project"].(string)
@@ -141,13 +145,12 @@ func (t Tool) Authorized(verifiedAuthServices []string) bool {
 	return true
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
 // buildParams builds the tool's parameters. A non-empty project means the source has a
@@ -166,22 +169,22 @@ func buildParams(project string) parameters.Parameters {
 }
 
 // resolveParams builds the tool's parameters using the source's configured default GCP project.
-func (t Tool) resolveParams(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	s, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, err
+func (t Tool) resolveParams(source sources.Source) (parameters.Parameters, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
 	return buildParams(s.GetDefaultProject()), nil
 }
 
 // GetParameters returns the tool's parameters, resolved against the source.
-func (t Tool) GetParameters(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	return t.resolveParams(srcs)
+func (t Tool) GetParameters(source sources.Source) (parameters.Parameters, error) {
+	return t.resolveParams(source)
 }
 
 // Manifest returns the tool's manifest, resolved against the source.
-func (t Tool) Manifest(srcs map[string]sources.Source) (tools.Manifest, error) {
-	allParameters, err := t.resolveParams(srcs)
+func (t Tool) Manifest(source sources.Source) (tools.Manifest, error) {
+	allParameters, err := t.resolveParams(source)
 	if err != nil {
 		return tools.Manifest{}, err
 	}

--- a/internal/tools/alloydb/alloydbgetinstance/alloydbgetinstance.go
+++ b/internal/tools/alloydb/alloydbgetinstance/alloydbgetinstance.go
@@ -91,6 +91,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 // Invoke executes the tool's logic.
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)

--- a/internal/tools/alloydb/alloydbgetuser/alloydbgetuser.go
+++ b/internal/tools/alloydb/alloydbgetuser/alloydbgetuser.go
@@ -91,6 +91,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 // Invoke executes the tool's logic.
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)

--- a/internal/tools/alloydb/alloydbgetuser/alloydbgetuser.go
+++ b/internal/tools/alloydb/alloydbgetuser/alloydbgetuser.go
@@ -43,6 +43,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	GetDefaultProject() string
 	UseClientAuthorization() bool
 	GetUsers(context.Context, string, string, string, string, string) (any, error)
@@ -87,12 +88,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -104,12 +109,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 }
 
 // Invoke executes the tool's logic.
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 
 	project, ok := paramsMap["project"].(string)
@@ -141,13 +145,12 @@ func (t Tool) Authorized(verifiedAuthServices []string) bool {
 	return true
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
 // buildParams builds the tool's parameters. A non-empty project means the source has a
@@ -166,22 +169,22 @@ func buildParams(project string) parameters.Parameters {
 }
 
 // resolveParams builds the tool's parameters using the source's configured default GCP project.
-func (t Tool) resolveParams(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	s, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, err
+func (t Tool) resolveParams(source sources.Source) (parameters.Parameters, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
 	return buildParams(s.GetDefaultProject()), nil
 }
 
 // GetParameters returns the tool's parameters, resolved against the source.
-func (t Tool) GetParameters(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	return t.resolveParams(srcs)
+func (t Tool) GetParameters(source sources.Source) (parameters.Parameters, error) {
+	return t.resolveParams(source)
 }
 
 // Manifest returns the tool's manifest, resolved against the source.
-func (t Tool) Manifest(srcs map[string]sources.Source) (tools.Manifest, error) {
-	allParameters, err := t.resolveParams(srcs)
+func (t Tool) Manifest(source sources.Source) (tools.Manifest, error) {
+	allParameters, err := t.resolveParams(source)
 	if err != nil {
 		return tools.Manifest{}, err
 	}

--- a/internal/tools/alloydb/alloydblistclusters/alloydblistclusters.go
+++ b/internal/tools/alloydb/alloydblistclusters/alloydblistclusters.go
@@ -43,6 +43,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	GetDefaultProject() string
 	UseClientAuthorization() bool
 	ListCluster(context.Context, string, string, string) (any, error)
@@ -86,12 +87,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -117,22 +122,22 @@ func buildParams(project string) parameters.Parameters {
 
 // resolveParams builds the tool's parameters using the source's configured
 // defaults (e.g. the default GCP project).
-func (t Tool) resolveParams(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	s, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, err
+func (t Tool) resolveParams(source sources.Source) (parameters.Parameters, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
 	return buildParams(s.GetDefaultProject()), nil
 }
 
 // GetParameters returns the tool's parameters, resolved against the source.
-func (t Tool) GetParameters(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	return t.resolveParams(srcs)
+func (t Tool) GetParameters(source sources.Source) (parameters.Parameters, error) {
+	return t.resolveParams(source)
 }
 
 // Manifest returns the tool's manifest, resolved against the source.
-func (t Tool) Manifest(srcs map[string]sources.Source) (tools.Manifest, error) {
-	allParameters, err := t.resolveParams(srcs)
+func (t Tool) Manifest(source sources.Source) (tools.Manifest, error) {
+	allParameters, err := t.resolveParams(source)
 	if err != nil {
 		return tools.Manifest{}, err
 	}
@@ -140,12 +145,11 @@ func (t Tool) Manifest(srcs map[string]sources.Source) (tools.Manifest, error) {
 }
 
 // Invoke executes the tool's logic.
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 
 	project, ok := paramsMap["project"].(string)
@@ -169,11 +173,10 @@ func (t Tool) Authorized(verifiedAuthServices []string) bool {
 	return true
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }

--- a/internal/tools/alloydb/alloydblistclusters/alloydblistclusters.go
+++ b/internal/tools/alloydb/alloydblistclusters/alloydblistclusters.go
@@ -90,6 +90,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 // buildParams builds the tool's parameters. A non-empty project means the source has a
 // configured default project, which is baked into the project param; otherwise the plain form is used.
 func buildParams(project string) parameters.Parameters {

--- a/internal/tools/alloydb/alloydblistinstances/alloydblistinstances.go
+++ b/internal/tools/alloydb/alloydblistinstances/alloydblistinstances.go
@@ -43,6 +43,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	GetDefaultProject() string
 	UseClientAuthorization() bool
 	ListInstance(context.Context, string, string, string, string) (any, error)
@@ -87,12 +88,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -104,12 +109,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 }
 
 // Invoke executes the tool's logic.
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 
 	project, ok := paramsMap["project"].(string)
@@ -137,13 +141,12 @@ func (t Tool) Authorized(verifiedAuthServices []string) bool {
 	return true
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
 // buildParams builds the tool's parameters. A non-empty project means the source has a
@@ -161,22 +164,22 @@ func buildParams(project string) parameters.Parameters {
 }
 
 // resolveParams builds the tool's parameters using the source's configured default GCP project.
-func (t Tool) resolveParams(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	s, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, err
+func (t Tool) resolveParams(source sources.Source) (parameters.Parameters, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
 	return buildParams(s.GetDefaultProject()), nil
 }
 
 // GetParameters returns the tool's parameters, resolved against the source.
-func (t Tool) GetParameters(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	return t.resolveParams(srcs)
+func (t Tool) GetParameters(source sources.Source) (parameters.Parameters, error) {
+	return t.resolveParams(source)
 }
 
 // Manifest returns the tool's manifest, resolved against the source.
-func (t Tool) Manifest(srcs map[string]sources.Source) (tools.Manifest, error) {
-	allParameters, err := t.resolveParams(srcs)
+func (t Tool) Manifest(source sources.Source) (tools.Manifest, error) {
+	allParameters, err := t.resolveParams(source)
 	if err != nil {
 		return tools.Manifest{}, err
 	}

--- a/internal/tools/alloydb/alloydblistinstances/alloydblistinstances.go
+++ b/internal/tools/alloydb/alloydblistinstances/alloydblistinstances.go
@@ -91,6 +91,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 // Invoke executes the tool's logic.
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)

--- a/internal/tools/alloydb/alloydblistusers/alloydblistusers.go
+++ b/internal/tools/alloydb/alloydblistusers/alloydblistusers.go
@@ -91,6 +91,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 // Invoke executes the tool's logic.
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)

--- a/internal/tools/alloydb/alloydblistusers/alloydblistusers.go
+++ b/internal/tools/alloydb/alloydblistusers/alloydblistusers.go
@@ -43,6 +43,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	GetDefaultProject() string
 	UseClientAuthorization() bool
 	ListUsers(context.Context, string, string, string, string) (any, error)
@@ -87,12 +88,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -104,12 +109,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 }
 
 // Invoke executes the tool's logic.
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 
 	project, ok := paramsMap["project"].(string)
@@ -137,13 +141,12 @@ func (t Tool) Authorized(verifiedAuthServices []string) bool {
 	return true
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
 // buildParams builds the tool's parameters. A non-empty project means the source has a
@@ -161,22 +164,22 @@ func buildParams(project string) parameters.Parameters {
 }
 
 // resolveParams builds the tool's parameters using the source's configured default GCP project.
-func (t Tool) resolveParams(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	s, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, err
+func (t Tool) resolveParams(source sources.Source) (parameters.Parameters, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
 	return buildParams(s.GetDefaultProject()), nil
 }
 
 // GetParameters returns the tool's parameters, resolved against the source.
-func (t Tool) GetParameters(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	return t.resolveParams(srcs)
+func (t Tool) GetParameters(source sources.Source) (parameters.Parameters, error) {
+	return t.resolveParams(source)
 }
 
 // Manifest returns the tool's manifest, resolved against the source.
-func (t Tool) Manifest(srcs map[string]sources.Source) (tools.Manifest, error) {
-	allParameters, err := t.resolveParams(srcs)
+func (t Tool) Manifest(source sources.Source) (tools.Manifest, error) {
+	allParameters, err := t.resolveParams(source)
 	if err != nil {
 		return tools.Manifest{}, err
 	}

--- a/internal/tools/alloydb/alloydbwaitforoperation/alloydbwaitforoperation.go
+++ b/internal/tools/alloydb/alloydbwaitforoperation/alloydbwaitforoperation.go
@@ -184,6 +184,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 // Invoke executes the tool's logic.
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)

--- a/internal/tools/alloydb/alloydbwaitforoperation/alloydbwaitforoperation.go
+++ b/internal/tools/alloydb/alloydbwaitforoperation/alloydbwaitforoperation.go
@@ -87,6 +87,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	GetDefaultProject() string
 	UseClientAuthorization() bool
 	GetOperations(context.Context, string, string, string, string, time.Duration, string) (any, error)
@@ -180,12 +181,16 @@ type Tool struct {
 	MaxRetries int
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -197,12 +202,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 }
 
 // Invoke executes the tool's logic.
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 
 	project, ok := paramsMap["project"].(string)
@@ -257,13 +261,12 @@ func (t Tool) Authorized(verifiedAuthServices []string) bool {
 	return true
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
 // buildParams builds the tool's parameters. A non-empty project means the source has a
@@ -281,22 +284,22 @@ func buildParams(project string) parameters.Parameters {
 }
 
 // resolveParams builds the tool's parameters using the source's configured default GCP project.
-func (t Tool) resolveParams(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	s, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, err
+func (t Tool) resolveParams(source sources.Source) (parameters.Parameters, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
 	return buildParams(s.GetDefaultProject()), nil
 }
 
 // GetParameters returns the tool's parameters, resolved against the source.
-func (t Tool) GetParameters(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	return t.resolveParams(srcs)
+func (t Tool) GetParameters(source sources.Source) (parameters.Parameters, error) {
+	return t.resolveParams(source)
 }
 
 // Manifest returns the tool's manifest, resolved against the source.
-func (t Tool) Manifest(srcs map[string]sources.Source) (tools.Manifest, error) {
-	allParameters, err := t.resolveParams(srcs)
+func (t Tool) Manifest(source sources.Source) (tools.Manifest, error) {
+	allParameters, err := t.resolveParams(source)
 	if err != nil {
 		return tools.Manifest{}, err
 	}

--- a/internal/tools/alloydbainl/alloydbainl.go
+++ b/internal/tools/alloydbainl/alloydbainl.go
@@ -144,3 +144,15 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/alloydbainl/alloydbainl.go
+++ b/internal/tools/alloydbainl/alloydbainl.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -44,6 +45,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	PostgresPool() *pgxpool.Pool
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -120,12 +122,11 @@ type Tool struct {
 	Statement string
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	sliceParams := params.AsSlice()
 	allParamValues := make([]any, len(sliceParams)+1)
 	allParamValues[0] = fmt.Sprintf("%s", sliceParams[0]) // nl_question
@@ -141,12 +142,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/arcadedb/arcadedbexecutecypher/arcadedbexecutecypher.go
+++ b/internal/tools/arcadedb/arcadedbexecutecypher/arcadedbexecutecypher.go
@@ -21,6 +21,7 @@ import (
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -43,6 +44,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	ArcadeDBDatabase() string
 	RunCypher(context.Context, string, map[string]any, bool, bool) (any, error)
 }
@@ -102,12 +104,11 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	cypherStr, ok := paramsMap["cypher"].(string)
 	if !ok {
@@ -139,12 +140,16 @@ func (t Tool) EmbedParams(ctx context.Context, paramValues parameters.ParamValue
 	return parameters.EmbedParams(ctx, t.StaticParameters, paramValues, embeddingModelsMap, nil)
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/arcadedb/arcadedbexecutecypher/arcadedbexecutecypher.go
+++ b/internal/tools/arcadedb/arcadedbexecutecypher/arcadedbexecutecypher.go
@@ -142,3 +142,15 @@ func (t Tool) EmbedParams(ctx context.Context, paramValues parameters.ParamValue
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/arcadedb/arcadedbexecutesql/arcadedbexecutesql.go
+++ b/internal/tools/arcadedb/arcadedbexecutesql/arcadedbexecutesql.go
@@ -145,3 +145,15 @@ func (t Tool) EmbedParams(ctx context.Context, paramValues parameters.ParamValue
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/arcadedb/arcadedbexecutesql/arcadedbexecutesql.go
+++ b/internal/tools/arcadedb/arcadedbexecutesql/arcadedbexecutesql.go
@@ -21,6 +21,7 @@ import (
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -43,6 +44,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	ArcadeDBDatabase() string
 	RunSQL(context.Context, string, map[string]any, bool) (any, error)
 }
@@ -101,12 +103,11 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	sqlStr, ok := paramsMap["sql"].(string)
 	if !ok {
@@ -142,12 +143,16 @@ func (t Tool) EmbedParams(ctx context.Context, paramValues parameters.ParamValue
 	return parameters.EmbedParams(ctx, t.StaticParameters, paramValues, embeddingModelsMap, nil)
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/bigquery/bigqueryanalyzecontribution/bigqueryanalyzecontribution.go
+++ b/internal/tools/bigquery/bigqueryanalyzecontribution/bigqueryanalyzecontribution.go
@@ -103,6 +103,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 // Invoke runs the contribution analysis.
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)

--- a/internal/tools/bigquery/bigqueryanalyzecontribution/bigqueryanalyzecontribution.go
+++ b/internal/tools/bigquery/bigqueryanalyzecontribution/bigqueryanalyzecontribution.go
@@ -49,6 +49,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	BigQueryClient() *bigqueryapi.Client
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
@@ -99,12 +100,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -116,12 +121,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 }
 
 // Invoke runs the contribution analysis.
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	inputData, ok := paramsMap["input_data"].(string)
 	if !ok {
@@ -294,20 +298,20 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }
 
 // resolveParams builds the tool's parameters using the source's allowed-dataset configuration.
@@ -350,22 +354,22 @@ func buildParams(allowedDatasets []string) parameters.Parameters {
 	}
 }
 
-func (t Tool) resolveParams(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	s, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, err
+func (t Tool) resolveParams(source sources.Source) (parameters.Parameters, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
 	return buildParams(s.BigQueryAllowedDatasets()), nil
 }
 
 // GetParameters returns the tool's parameters, resolved against the source.
-func (t Tool) GetParameters(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	return t.resolveParams(srcs)
+func (t Tool) GetParameters(source sources.Source) (parameters.Parameters, error) {
+	return t.resolveParams(source)
 }
 
 // Manifest returns the tool's manifest, resolved against the source.
-func (t Tool) Manifest(srcs map[string]sources.Source) (tools.Manifest, error) {
-	params, err := t.resolveParams(srcs)
+func (t Tool) Manifest(source sources.Source) (tools.Manifest, error) {
+	params, err := t.resolveParams(source)
 	if err != nil {
 		return tools.Manifest{}, err
 	}

--- a/internal/tools/bigquery/bigqueryanalyzecontribution/bigqueryanalyzecontribution_test.go
+++ b/internal/tools/bigquery/bigqueryanalyzecontribution/bigqueryanalyzecontribution_test.go
@@ -26,7 +26,6 @@ import (
 	bigqueryapi "cloud.google.com/go/bigquery"
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/mcp-toolbox/internal/server"
-	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/testutils"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/tools/bigquery/bigqueryanalyzecontribution"
@@ -127,9 +126,6 @@ func TestInvoke(t *testing.T) {
 		Source: "my-bq-source",
 	}
 	src := &bigquerycommon.MockSource{Client: bqClient, RunSQLResult: "mocked_analyze_contribution_result"}
-	sourcesMap := map[string]sources.Source{
-		"my-bq-source": src,
-	}
 	tool, err := cfg.Initialize(context.Background())
 	if err != nil {
 		t.Fatalf("failed to initialize tool: %v", err)
@@ -189,8 +185,6 @@ func TestInvoke(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
-			provider := &bigquerycommon.MockSourceProvider{Source: src}
-
 			data := map[string]any{}
 			if tc.inputData != nil {
 				data["input_data"] = tc.inputData
@@ -205,7 +199,7 @@ func TestInvoke(t *testing.T) {
 				data["dimension_id_cols"] = tc.dimensionIdCols
 			}
 
-			params, err := analyzeContributionTool.GetParameters(sourcesMap)
+			params, err := analyzeContributionTool.GetParameters(src)
 			if err != nil {
 				t.Fatalf("failed to get parameters: %v", err)
 			}
@@ -225,7 +219,7 @@ func TestInvoke(t *testing.T) {
 				t.Fatalf("failed to create context with logger: %v", err)
 			}
 
-			resp, err := tool.Invoke(ctx, provider, paramVals, "")
+			resp, err := tool.Invoke(ctx, src, paramVals, "")
 			if tc.wantErr {
 				if err == nil {
 					t.Fatalf("expected error, got nil")
@@ -333,9 +327,6 @@ func TestInvokeAllowedDatasetsValidation(t *testing.T) {
 		Type:   "bigquery-analyze-contribution",
 		Source: "my-bq-source",
 	}
-	sourcesMap := map[string]sources.Source{
-		"my-bq-source": testSrc,
-	}
 	tool, err := cfg.Initialize(ctx)
 	if err != nil {
 		t.Fatalf("failed to initialize tool: %v", err)
@@ -354,7 +345,7 @@ func TestInvokeAllowedDatasetsValidation(t *testing.T) {
 		"dimension_id_cols":   []any{"dim1"},
 	}
 
-	params, err := analyzeContributionTool.GetParameters(sourcesMap)
+	params, err := analyzeContributionTool.GetParameters(testSrc)
 	if err != nil {
 		t.Fatalf("failed to get parameters: %v", err)
 	}
@@ -364,8 +355,7 @@ func TestInvokeAllowedDatasetsValidation(t *testing.T) {
 	}
 
 	// 5. Invoke the tool and assert it fails with the dataset permission check error
-	provider := &bigquerycommon.MockSourceProvider{Source: testSrc}
-	_, err = tool.Invoke(ctx, provider, paramVals, "")
+	_, err = tool.Invoke(ctx, testSrc, paramVals, "")
 	if err == nil {
 		t.Fatal("expected Invoke to return an error due to out-of-allowlist dataset reference, but got nil")
 	}

--- a/internal/tools/bigquery/bigquerycommon/mock_source.go
+++ b/internal/tools/bigquery/bigquerycommon/mock_source.go
@@ -87,13 +87,3 @@ func (m *MockSource) RunSQL(ctx context.Context, client *bigqueryapi.Client, sql
 	m.CalledSQL = sql
 	return m.RunSQLResult, m.RunSQLError
 }
-
-// MockSourceProvider is a reusable mock implementation of tools.SourceProvider.
-type MockSourceProvider struct {
-	tools.SourceProvider
-	Source sources.Source
-}
-
-func (m *MockSourceProvider) GetSource(name string) (sources.Source, bool) {
-	return m.Source, true
-}

--- a/internal/tools/bigquery/bigqueryconversationalanalytics/bigqueryconversationalanalytics.go
+++ b/internal/tools/bigquery/bigqueryconversationalanalytics/bigqueryconversationalanalytics.go
@@ -151,6 +151,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/bigquery/bigqueryconversationalanalytics/bigqueryconversationalanalytics.go
+++ b/internal/tools/bigquery/bigqueryconversationalanalytics/bigqueryconversationalanalytics.go
@@ -60,6 +60,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	BigQueryClient() *bigqueryapi.Client
 	BigQueryTokenSourceWithScope(ctx context.Context, scopes []string) (oauth2.TokenSource, error)
 	BigQueryProject() string
@@ -147,12 +148,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -163,12 +168,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	var tokenSource oauth2.TokenSource
 
 	// Get credentials for the API call
@@ -184,7 +188,7 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 		tokenSource = oauth2.StaticTokenSource(&oauth2.Token{AccessToken: tokenStr})
 	} else {
 		// Get a token source for the Gemini Data Analytics API.
-		tokenSource, err = source.BigQueryTokenSourceWithScope(ctx, nil)
+		tokenSource, err := source.BigQueryTokenSourceWithScope(ctx, nil)
 		if err != nil {
 			return nil, util.NewClientServerError("failed to get token source", http.StatusInternalServerError, err)
 		}
@@ -259,12 +263,12 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return response, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
 func getStream(client *http.Client, url string, payload CAPayload, headers map[string]string, maxRows int) (string, error) {
@@ -427,12 +431,12 @@ func formatDataRetrieved(result map[string]any, maxRows int) map[string]any {
 	}
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }
 
 // resolveParams builds the tool's parameters using the source's allowed-dataset configuration.
@@ -450,22 +454,22 @@ func buildParams(allowedDatasets []string) parameters.Parameters {
 	return parameters.Parameters{userQueryParameter, tableRefsParameter}
 }
 
-func (t Tool) resolveParams(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	s, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, err
+func (t Tool) resolveParams(source sources.Source) (parameters.Parameters, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
 	return buildParams(s.BigQueryAllowedDatasets()), nil
 }
 
 // GetParameters returns the tool's parameters, resolved against the source.
-func (t Tool) GetParameters(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	return t.resolveParams(srcs)
+func (t Tool) GetParameters(source sources.Source) (parameters.Parameters, error) {
+	return t.resolveParams(source)
 }
 
 // Manifest returns the tool's manifest, resolved against the source.
-func (t Tool) Manifest(srcs map[string]sources.Source) (tools.Manifest, error) {
-	params, err := t.resolveParams(srcs)
+func (t Tool) Manifest(source sources.Source) (tools.Manifest, error) {
+	params, err := t.resolveParams(source)
 	if err != nil {
 		return tools.Manifest{}, err
 	}

--- a/internal/tools/bigquery/bigqueryexecutesql/bigqueryexecutesql.go
+++ b/internal/tools/bigquery/bigqueryexecutesql/bigqueryexecutesql.go
@@ -49,6 +49,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	BigQueryClient() *bigqueryapi.Client
 	BigQuerySession() bigqueryds.BigQuerySessionProvider
 	BigQueryWriteMode() string
@@ -101,12 +102,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -117,12 +122,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	sql, ok := paramsMap["sql"].(string)
 	if !ok {
@@ -243,20 +247,20 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }
 
 // buildParams builds the tool's parameters from the source's write mode and allowed-dataset
@@ -302,22 +306,22 @@ func buildParams(writeMode string, allowedDatasets []string) (parameters.Paramet
 }
 
 // resolveParams builds the tool's parameters using the source's allowed-dataset configuration.
-func (t Tool) resolveParams(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	s, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, err
+func (t Tool) resolveParams(source sources.Source) (parameters.Parameters, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
 	return buildParams(s.BigQueryWriteMode(), s.BigQueryAllowedDatasets())
 }
 
 // GetParameters returns the tool's parameters, resolved against the source.
-func (t Tool) GetParameters(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	return t.resolveParams(srcs)
+func (t Tool) GetParameters(source sources.Source) (parameters.Parameters, error) {
+	return t.resolveParams(source)
 }
 
 // Manifest returns the tool's manifest, resolved against the source.
-func (t Tool) Manifest(srcs map[string]sources.Source) (tools.Manifest, error) {
-	params, err := t.resolveParams(srcs)
+func (t Tool) Manifest(source sources.Source) (tools.Manifest, error) {
+	params, err := t.resolveParams(source)
 	if err != nil {
 		return tools.Manifest{}, err
 	}

--- a/internal/tools/bigquery/bigqueryexecutesql/bigqueryexecutesql.go
+++ b/internal/tools/bigquery/bigqueryexecutesql/bigqueryexecutesql.go
@@ -105,6 +105,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/bigquery/bigqueryexecutesql/bigqueryexecutesql_test.go
+++ b/internal/tools/bigquery/bigqueryexecutesql/bigqueryexecutesql_test.go
@@ -24,7 +24,6 @@ import (
 	bigqueryapi "cloud.google.com/go/bigquery"
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/mcp-toolbox/internal/server"
-	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/testutils"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	bqutil "github.com/googleapis/mcp-toolbox/internal/tools/bigquery/bigquerycommon"
@@ -177,9 +176,6 @@ func TestInvokeDatasetRestrictions(t *testing.T) {
 		Type:   "bigquery-execute-sql",
 		Source: "my-bq-source",
 	}
-	sourcesMap := map[string]sources.Source{
-		"my-bq-source": testSrc,
-	}
 	tool, err := cfg.Initialize(ctx)
 	if err != nil {
 		t.Fatalf("failed to initialize tool: %v", err)
@@ -251,14 +247,12 @@ func TestInvokeDatasetRestrictions(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
-			provider := &bqutil.MockSourceProvider{Source: testSrc}
-
 			data := map[string]any{
 				"sql":     tc.sql,
 				"dry_run": true,
 			}
 
-			params, err := executeSqlTool.GetParameters(sourcesMap)
+			params, err := executeSqlTool.GetParameters(testSrc)
 			if err != nil {
 				t.Fatalf("failed to get parameters: %v", err)
 			}
@@ -267,7 +261,7 @@ func TestInvokeDatasetRestrictions(t *testing.T) {
 				t.Fatalf("unexpected error parsing parameters: %v", err)
 			}
 
-			_, err = tool.Invoke(ctx, provider, paramVals, "")
+			_, err = tool.Invoke(ctx, testSrc, paramVals, "")
 			if tc.wantErr {
 				if err == nil {
 					t.Fatalf("expected error, got nil")

--- a/internal/tools/bigquery/bigqueryforecast/bigqueryforecast.go
+++ b/internal/tools/bigquery/bigqueryforecast/bigqueryforecast.go
@@ -102,6 +102,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/bigquery/bigqueryforecast/bigqueryforecast.go
+++ b/internal/tools/bigquery/bigqueryforecast/bigqueryforecast.go
@@ -48,6 +48,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	BigQueryClient() *bigqueryapi.Client
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
@@ -98,12 +99,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -114,12 +119,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	historyData, ok := paramsMap["history_data"].(string)
 	if !ok {
@@ -267,20 +271,20 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }
 
 // resolveParams builds the tool's parameters using the source's allowed-dataset configuration.
@@ -305,22 +309,22 @@ func buildParams(allowedDatasets []string) parameters.Parameters {
 		timestampColumnNameParameter, dataColumnNameParameter, idColumnNameParameter, horizonParameter}
 }
 
-func (t Tool) resolveParams(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	s, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, err
+func (t Tool) resolveParams(source sources.Source) (parameters.Parameters, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
 	return buildParams(s.BigQueryAllowedDatasets()), nil
 }
 
 // GetParameters returns the tool's parameters, resolved against the source.
-func (t Tool) GetParameters(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	return t.resolveParams(srcs)
+func (t Tool) GetParameters(source sources.Source) (parameters.Parameters, error) {
+	return t.resolveParams(source)
 }
 
 // Manifest returns the tool's manifest, resolved against the source.
-func (t Tool) Manifest(srcs map[string]sources.Source) (tools.Manifest, error) {
-	params, err := t.resolveParams(srcs)
+func (t Tool) Manifest(source sources.Source) (tools.Manifest, error) {
+	params, err := t.resolveParams(source)
 	if err != nil {
 		return tools.Manifest{}, err
 	}

--- a/internal/tools/bigquery/bigqueryforecast/bigqueryforecast_test.go
+++ b/internal/tools/bigquery/bigqueryforecast/bigqueryforecast_test.go
@@ -25,7 +25,6 @@ import (
 	bigqueryapi "cloud.google.com/go/bigquery"
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/mcp-toolbox/internal/server"
-	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/testutils"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/tools/bigquery/bigquerycommon"
@@ -88,10 +87,6 @@ func TestInvoke(t *testing.T) {
 		},
 		Type:   "bigquery-forecast",
 		Source: "my-bq-source",
-	}
-	src := &bigquerycommon.MockSource{RunSQLResult: "mocked_forecast_result"}
-	sourcesMap := map[string]sources.Source{
-		"my-bq-source": src,
 	}
 	tool, err := cfg.Initialize(context.Background())
 	if err != nil {
@@ -160,8 +155,6 @@ func TestInvoke(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
 			src := &bigquerycommon.MockSource{RunSQLResult: "mocked_forecast_result"}
-			provider := &bigquerycommon.MockSourceProvider{Source: src}
-
 			data := map[string]any{}
 			if tc.historyData != nil {
 				data["history_data"] = tc.historyData
@@ -179,7 +172,7 @@ func TestInvoke(t *testing.T) {
 				data["id_cols"] = tc.idCols
 			}
 
-			params, err := forecastTool.GetParameters(sourcesMap)
+			params, err := forecastTool.GetParameters(src)
 			if err != nil {
 				t.Fatalf("failed to get parameters: %v", err)
 			}
@@ -199,7 +192,7 @@ func TestInvoke(t *testing.T) {
 				t.Fatalf("failed to create context with logger: %v", err)
 			}
 
-			resp, err := tool.Invoke(ctx, provider, paramVals, "")
+			resp, err := tool.Invoke(ctx, src, paramVals, "")
 			if tc.wantErr {
 				if err == nil {
 					t.Fatalf("expected error, got nil")
@@ -313,9 +306,6 @@ func TestInvokeAllowedDatasetsValidation(t *testing.T) {
 		Type:   "bigquery-forecast",
 		Source: "my-bq-source",
 	}
-	sourcesMap := map[string]sources.Source{
-		"my-bq-source": testSrc,
-	}
 	tool, err := cfg.Initialize(ctx)
 	if err != nil {
 		t.Fatalf("failed to initialize tool: %v", err)
@@ -335,7 +325,7 @@ func TestInvokeAllowedDatasetsValidation(t *testing.T) {
 		"horizon":       5,
 	}
 
-	params, err := forecastTool.GetParameters(sourcesMap)
+	params, err := forecastTool.GetParameters(testSrc)
 	if err != nil {
 		t.Fatalf("failed to get parameters: %v", err)
 	}
@@ -345,8 +335,7 @@ func TestInvokeAllowedDatasetsValidation(t *testing.T) {
 	}
 
 	// 5. Invoke the tool and assert it fails with the dataset permission check error
-	provider := &bigquerycommon.MockSourceProvider{Source: testSrc}
-	_, err = tool.Invoke(ctx, provider, paramVals, "")
+	_, err = tool.Invoke(ctx, testSrc, paramVals, "")
 	if err == nil {
 		t.Fatal("expected Invoke to return an error due to out-of-allowlist dataset reference, but got nil")
 	}

--- a/internal/tools/bigquery/bigquerygetdatasetinfo/bigquerygetdatasetinfo.go
+++ b/internal/tools/bigquery/bigquerygetdatasetinfo/bigquerygetdatasetinfo.go
@@ -97,6 +97,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/bigquery/bigquerygetdatasetinfo/bigquerygetdatasetinfo.go
+++ b/internal/tools/bigquery/bigquerygetdatasetinfo/bigquerygetdatasetinfo.go
@@ -48,6 +48,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	BigQueryProject() string
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
@@ -93,12 +94,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -109,12 +114,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	mapParams := params.AsMap()
 	projectId, ok := mapParams[projectKey].(string)
 	if !ok {
@@ -146,20 +150,20 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return metadata, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }
 
 // buildParams builds the tool's parameters from the source's allowed-dataset configuration.
@@ -172,22 +176,22 @@ func buildParams(allowedDatasets []string, defaultProject string) parameters.Par
 }
 
 // resolveParams builds the tool's parameters using the source's allowed-dataset configuration.
-func (t Tool) resolveParams(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	s, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, err
+func (t Tool) resolveParams(source sources.Source) (parameters.Parameters, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
 	return buildParams(s.BigQueryAllowedDatasets(), s.BigQueryProject()), nil
 }
 
 // GetParameters returns the tool's parameters, resolved against the source.
-func (t Tool) GetParameters(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	return t.resolveParams(srcs)
+func (t Tool) GetParameters(source sources.Source) (parameters.Parameters, error) {
+	return t.resolveParams(source)
 }
 
 // Manifest returns the tool's manifest, resolved against the source.
-func (t Tool) Manifest(srcs map[string]sources.Source) (tools.Manifest, error) {
-	params, err := t.resolveParams(srcs)
+func (t Tool) Manifest(source sources.Source) (tools.Manifest, error) {
+	params, err := t.resolveParams(source)
 	if err != nil {
 		return tools.Manifest{}, err
 	}

--- a/internal/tools/bigquery/bigquerygettableinfo/bigquerygettableinfo.go
+++ b/internal/tools/bigquery/bigquerygettableinfo/bigquerygettableinfo.go
@@ -49,6 +49,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	BigQueryProject() string
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
@@ -94,12 +95,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -110,12 +115,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	mapParams := params.AsMap()
 	projectId, ok := mapParams[projectKey].(string)
 	if !ok {
@@ -152,20 +156,20 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return metadata, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }
 
 // buildParams builds the tool's parameters from the source's allowed-dataset configuration.
@@ -179,22 +183,22 @@ func buildParams(allowedDatasets []string, defaultProject string) parameters.Par
 }
 
 // resolveParams builds the tool's parameters using the source's allowed-dataset configuration.
-func (t Tool) resolveParams(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	s, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, err
+func (t Tool) resolveParams(source sources.Source) (parameters.Parameters, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
 	return buildParams(s.BigQueryAllowedDatasets(), s.BigQueryProject()), nil
 }
 
 // GetParameters returns the tool's parameters, resolved against the source.
-func (t Tool) GetParameters(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	return t.resolveParams(srcs)
+func (t Tool) GetParameters(source sources.Source) (parameters.Parameters, error) {
+	return t.resolveParams(source)
 }
 
 // Manifest returns the tool's manifest, resolved against the source.
-func (t Tool) Manifest(srcs map[string]sources.Source) (tools.Manifest, error) {
-	params, err := t.resolveParams(srcs)
+func (t Tool) Manifest(source sources.Source) (tools.Manifest, error) {
+	params, err := t.resolveParams(source)
 	if err != nil {
 		return tools.Manifest{}, err
 	}

--- a/internal/tools/bigquery/bigquerygettableinfo/bigquerygettableinfo.go
+++ b/internal/tools/bigquery/bigquerygettableinfo/bigquerygettableinfo.go
@@ -98,6 +98,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/bigquery/bigquerylistdatasetids/bigquerylistdatasetids.go
+++ b/internal/tools/bigquery/bigquerylistdatasetids/bigquerylistdatasetids.go
@@ -47,6 +47,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	BigQueryProject() string
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
@@ -91,12 +92,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -107,12 +112,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	if len(source.BigQueryAllowedDatasets()) > 0 {
 		return source.BigQueryAllowedDatasets(), nil
 	}
@@ -150,20 +154,20 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return datasetIds, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }
 
 // buildParams builds the tool's parameters from the source's allowed-dataset configuration.
@@ -178,22 +182,22 @@ func buildParams(allowedDatasets []string, defaultProject string) parameters.Par
 }
 
 // resolveParams builds the tool's parameters using the source's allowed-dataset configuration.
-func (t Tool) resolveParams(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	s, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, err
+func (t Tool) resolveParams(source sources.Source) (parameters.Parameters, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
 	return buildParams(s.BigQueryAllowedDatasets(), s.BigQueryProject()), nil
 }
 
 // GetParameters returns the tool's parameters, resolved against the source.
-func (t Tool) GetParameters(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	return t.resolveParams(srcs)
+func (t Tool) GetParameters(source sources.Source) (parameters.Parameters, error) {
+	return t.resolveParams(source)
 }
 
 // Manifest returns the tool's manifest, resolved against the source.
-func (t Tool) Manifest(srcs map[string]sources.Source) (tools.Manifest, error) {
-	params, err := t.resolveParams(srcs)
+func (t Tool) Manifest(source sources.Source) (tools.Manifest, error) {
+	params, err := t.resolveParams(source)
 	if err != nil {
 		return tools.Manifest{}, err
 	}

--- a/internal/tools/bigquery/bigquerylistdatasetids/bigquerylistdatasetids.go
+++ b/internal/tools/bigquery/bigquerylistdatasetids/bigquerylistdatasetids.go
@@ -95,6 +95,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/bigquery/bigquerylisttableids/bigquerylisttableids.go
+++ b/internal/tools/bigquery/bigquerylisttableids/bigquerylisttableids.go
@@ -98,6 +98,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/bigquery/bigquerylisttableids/bigquerylisttableids.go
+++ b/internal/tools/bigquery/bigquerylisttableids/bigquerylisttableids.go
@@ -49,6 +49,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	BigQueryProject() string
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
@@ -94,12 +95,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -110,12 +115,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	mapParams := params.AsMap()
 	projectId, ok := mapParams[projectKey].(string)
 	if !ok {
@@ -160,20 +164,20 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return tableIds, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }
 
 // buildParams builds the tool's parameters from the source's allowed-dataset configuration.
@@ -186,22 +190,22 @@ func buildParams(allowedDatasets []string, defaultProject string) parameters.Par
 }
 
 // resolveParams builds the tool's parameters using the source's allowed-dataset configuration.
-func (t Tool) resolveParams(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	s, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, err
+func (t Tool) resolveParams(source sources.Source) (parameters.Parameters, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
 	return buildParams(s.BigQueryAllowedDatasets(), s.BigQueryProject()), nil
 }
 
 // GetParameters returns the tool's parameters, resolved against the source.
-func (t Tool) GetParameters(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	return t.resolveParams(srcs)
+func (t Tool) GetParameters(source sources.Source) (parameters.Parameters, error) {
+	return t.resolveParams(source)
 }
 
 // Manifest returns the tool's manifest, resolved against the source.
-func (t Tool) Manifest(srcs map[string]sources.Source) (tools.Manifest, error) {
-	params, err := t.resolveParams(srcs)
+func (t Tool) Manifest(source sources.Source) (tools.Manifest, error) {
+	params, err := t.resolveParams(source)
 	if err != nil {
 		return tools.Manifest{}, err
 	}

--- a/internal/tools/bigquery/bigquerysearchcatalog/bigquerysearchcatalog.go
+++ b/internal/tools/bigquery/bigquerysearchcatalog/bigquerysearchcatalog.go
@@ -21,6 +21,7 @@ import (
 
 	dataplexapi "cloud.google.com/go/dataplex/apiv1"
 	"github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	bigqueryds "github.com/googleapis/mcp-toolbox/internal/sources/bigquery"
 	"github.com/googleapis/mcp-toolbox/internal/sources/dataplex/searchcatalog"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
@@ -45,6 +46,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	MakeDataplexCatalogClient() func() (*dataplexapi.CatalogClient, bigqueryds.DataplexClientCreator, error)
 	BigQueryProject() string
 	UseClientAuthorization() bool
@@ -92,12 +94,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -108,21 +114,21 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	var tokenStr string
+	var err error
 	if source.UseClientAuthorization() {
 		tokenStr, err = accessToken.ParseBearerToken()
 		if err != nil {
@@ -138,10 +144,10 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return results, nil
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/bigquery/bigquerysearchcatalog/bigquerysearchcatalog.go
+++ b/internal/tools/bigquery/bigquerysearchcatalog/bigquerysearchcatalog.go
@@ -96,6 +96,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/bigquery/bigquerysql/bigquerysql.go
+++ b/internal/tools/bigquery/bigquerysql/bigquerysql.go
@@ -25,6 +25,7 @@ import (
 	bigqueryapi "cloud.google.com/go/bigquery"
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	bigqueryds "github.com/googleapis/mcp-toolbox/internal/sources/bigquery"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	bqutil "github.com/googleapis/mcp-toolbox/internal/tools/bigquery/bigquerycommon"
@@ -50,6 +51,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	BigQuerySession() bigqueryds.BigQuerySessionProvider
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
@@ -102,12 +104,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -118,12 +124,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	newStatement, err := parameters.ResolveTemplateParams(t.Cfg.TemplateParameters, t.Cfg.Statement, paramsMap)
 	if err != nil {
@@ -322,18 +327,18 @@ func (t Tool) EmbedParams(ctx context.Context, paramValues parameters.ParamValue
 	return parameters.EmbedParams(ctx, t.StaticParameters, paramValues, embeddingModelsMap, formatVectorForBigQuery)
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/bigquery/bigquerysql/bigquerysql.go
+++ b/internal/tools/bigquery/bigquerysql/bigquerysql.go
@@ -106,6 +106,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/bigtable/bigtable.go
+++ b/internal/tools/bigtable/bigtable.go
@@ -21,6 +21,7 @@ import (
 
 	"cloud.google.com/go/bigtable"
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -43,6 +44,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	BigtableClient() *bigtable.Client
 	RunSQL(context.Context, string, parameters.Parameters, parameters.ParamValues) (any, error)
 }
@@ -91,12 +93,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -107,12 +113,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	newStatement, err := parameters.ResolveTemplateParams(t.Cfg.TemplateParameters, t.Cfg.Statement, paramsMap)
 	if err != nil {

--- a/internal/tools/bigtable/bigtable.go
+++ b/internal/tools/bigtable/bigtable.go
@@ -95,6 +95,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/cassandra/cassandracql/cassandracql.go
+++ b/internal/tools/cassandra/cassandracql/cassandracql.go
@@ -95,6 +95,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 // Invoke implements tools.Tool.
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)

--- a/internal/tools/cassandra/cassandracql/cassandracql.go
+++ b/internal/tools/cassandra/cassandracql/cassandracql.go
@@ -21,6 +21,7 @@ import (
 
 	gocql "github.com/apache/cassandra-gocql-driver/v2"
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -43,6 +44,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	CassandraSession() *gocql.Session
 	RunSQL(context.Context, string, parameters.ParamValues) (any, error)
 }
@@ -91,12 +93,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -108,12 +114,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 }
 
 // Invoke implements tools.Tool.
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	newStatement, err := parameters.ResolveTemplateParams(t.Cfg.TemplateParameters, t.Cfg.Statement, paramsMap)
 	if err != nil {

--- a/internal/tools/clickhouse/clickhouseexecutesql/clickhouseexecutesql.go
+++ b/internal/tools/clickhouse/clickhouseexecutesql/clickhouseexecutesql.go
@@ -86,6 +86,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, token tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/clickhouse/clickhouseexecutesql/clickhouseexecutesql.go
+++ b/internal/tools/clickhouse/clickhouseexecutesql/clickhouseexecutesql.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -42,6 +43,7 @@ func newExecuteSQLConfig(ctx context.Context, name string, decoder *yaml.Decoder
 }
 
 type compatibleSource interface {
+	sources.Source
 	RunSQL(context.Context, string, parameters.ParamValues) (any, error)
 }
 
@@ -82,12 +84,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -98,12 +104,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, token tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	sql, ok := paramsMap["sql"].(string)
 	if !ok {

--- a/internal/tools/clickhouse/clickhouselistdatabases/clickhouselistdatabases.go
+++ b/internal/tools/clickhouse/clickhouselistdatabases/clickhouselistdatabases.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -42,6 +43,7 @@ func newListDatabasesConfig(ctx context.Context, name string, decoder *yaml.Deco
 }
 
 type compatibleSource interface {
+	sources.Source
 	RunSQL(context.Context, string, parameters.ParamValues) (any, error)
 }
 
@@ -85,12 +87,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -101,12 +107,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, token tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	// Query to list all databases
 	query := "SHOW DATABASES"
 

--- a/internal/tools/clickhouse/clickhouselistdatabases/clickhouselistdatabases.go
+++ b/internal/tools/clickhouse/clickhouselistdatabases/clickhouselistdatabases.go
@@ -89,6 +89,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, token tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/clickhouse/clickhouselisttables/clickhouselisttables.go
+++ b/internal/tools/clickhouse/clickhouselisttables/clickhouselisttables.go
@@ -102,6 +102,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, token tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/clickhouse/clickhouselisttables/clickhouselisttables.go
+++ b/internal/tools/clickhouse/clickhouselisttables/clickhouselisttables.go
@@ -21,6 +21,7 @@ import (
 	"regexp"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -52,6 +53,7 @@ func newListTablesConfig(ctx context.Context, name string, decoder *yaml.Decoder
 }
 
 type compatibleSource interface {
+	sources.Source
 	RunSQL(context.Context, string, parameters.ParamValues) (any, error)
 }
 
@@ -98,12 +100,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -114,12 +120,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, token tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	mapParams := params.AsMap()
 	database, ok := mapParams[databaseKey].(string)
 	if !ok {

--- a/internal/tools/clickhouse/clickhousesql/clickhousesql.go
+++ b/internal/tools/clickhouse/clickhousesql/clickhousesql.go
@@ -92,6 +92,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, token tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/clickhouse/clickhousesql/clickhousesql.go
+++ b/internal/tools/clickhouse/clickhousesql/clickhousesql.go
@@ -21,6 +21,7 @@ import (
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -43,6 +44,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	RunSQL(context.Context, string, parameters.ParamValues) (any, error)
 }
 
@@ -88,12 +90,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -104,12 +110,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, token tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	newStatement, err := parameters.ResolveTemplateParams(t.Cfg.TemplateParameters, t.Cfg.Statement, paramsMap)
 	if err != nil {

--- a/internal/tools/cloudgda/cloudgda.go
+++ b/internal/tools/cloudgda/cloudgda.go
@@ -22,6 +22,7 @@ import (
 
 	"cloud.google.com/go/geminidataanalytics/apiv1beta/geminidataanalyticspb"
 	"github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -60,6 +61,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	GetProjectID() string
 	UseClientAuthorization() bool
 	RunQuery(context.Context, string, *geminidataanalyticspb.QueryDataRequest) (*geminidataanalyticspb.QueryDataResponse, error)
@@ -155,12 +157,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -171,12 +177,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	query, ok := paramsMap["query"].(string)
 	if !ok {
@@ -185,6 +190,7 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 
 	// Parse the access token if provided
 	var tokenStr string
+	var err error
 	if source.UseClientAuthorization() {
 		var err error
 		tokenStr, err = accessToken.ParseBearerToken()
@@ -216,10 +222,10 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }

--- a/internal/tools/cloudgda/cloudgda.go
+++ b/internal/tools/cloudgda/cloudgda.go
@@ -159,6 +159,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/cloudgda/cloudgda_test.go
+++ b/internal/tools/cloudgda/cloudgda_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/googleapis/mcp-toolbox/internal/server"
-	"github.com/googleapis/mcp-toolbox/internal/server/primitives"
 	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/testutils"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
@@ -218,10 +217,6 @@ func TestInvoke(t *testing.T) {
 		response:       expectedResp,
 	}
 
-	srcs := map[string]sources.Source{
-		"mock-gda-source": fake,
-	}
-
 	// Initialize the tool config with context
 	toolCfg := cloudgdatool.Config{
 		ConfigBase: tools.ConfigBase{
@@ -268,12 +263,10 @@ func TestInvoke(t *testing.T) {
 		{Name: "query", Value: query},
 	}
 
-	primMgr := primitives.NewPrimitiveManager(srcs, nil, nil, nil, nil, nil, nil)
-
 	ctx := testutils.ContextWithUserAgent(context.Background(), "test-user-agent")
 
 	// Invoke the tool
-	result, err := tool.Invoke(ctx, primMgr, params, "")
+	result, err := tool.Invoke(ctx, fake, params, "")
 	if err != nil {
 		t.Fatalf("tool invocation failed: %v", err)
 	}

--- a/internal/tools/cloudhealthcare/cloudhealthcarefhirfetchpage/cloudhealthcarefhirfetchpage.go
+++ b/internal/tools/cloudhealthcare/cloudhealthcarefhirfetchpage/cloudhealthcarefhirfetchpage.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	"github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -45,6 +46,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	FHIRFetchPage(context.Context, string, string) (any, error)
 }
@@ -88,12 +90,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -104,18 +110,18 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	url, ok := params.AsMap()[pageURLKey].(string)
 	if !ok {
 		return nil, util.NewAgentError(fmt.Sprintf("invalid or missing '%s' parameter; expected a string", pageURLKey), nil)
 	}
 
 	var tokenStr string
+	var err error
 	if source.UseClientAuthorization() {
 		tokenStr, err = accessToken.ParseBearerToken()
 		if err != nil {
@@ -131,10 +137,10 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }

--- a/internal/tools/cloudhealthcare/cloudhealthcarefhirfetchpage/cloudhealthcarefhirfetchpage.go
+++ b/internal/tools/cloudhealthcare/cloudhealthcarefhirfetchpage/cloudhealthcarefhirfetchpage.go
@@ -92,6 +92,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/cloudhealthcare/cloudhealthcarefhirpatienteverything/cloudhealthcarefhirpatienteverything.go
+++ b/internal/tools/cloudhealthcare/cloudhealthcarefhirpatienteverything/cloudhealthcarefhirpatienteverything.go
@@ -97,6 +97,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/cloudhealthcare/cloudhealthcarefhirpatienteverything/cloudhealthcarefhirpatienteverything.go
+++ b/internal/tools/cloudhealthcare/cloudhealthcarefhirpatienteverything/cloudhealthcarefhirpatienteverything.go
@@ -51,6 +51,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	AllowedFHIRStores() map[string]struct{}
 	UseClientAuthorization() bool
 	FHIRPatientEverything(string, string, string, []googleapi.CallOption) (any, error)
@@ -93,12 +94,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -109,12 +114,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	storeID, err := common.ValidateAndFetchStoreID(params, source.AllowedFHIRStores())
 	if err != nil {
 		// ValidateAndFetchStoreID usually returns input validation errors
@@ -164,12 +168,12 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
 // buildParams builds the tool's parameters. When the source pins exactly one store
@@ -187,23 +191,22 @@ func buildParams(singleStore bool) parameters.Parameters {
 }
 
 // resolveParams builds the tool's parameters using the source's configured FHIR/DICOM stores.
-func (t Tool) resolveParams(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	s, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, err
+func (t Tool) resolveParams(source sources.Source) (parameters.Parameters, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-
 	return buildParams(len(s.AllowedFHIRStores()) == 1), nil
 }
 
 // GetParameters returns the tool's parameters, resolved against the source.
-func (t Tool) GetParameters(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	return t.resolveParams(srcs)
+func (t Tool) GetParameters(source sources.Source) (parameters.Parameters, error) {
+	return t.resolveParams(source)
 }
 
 // Manifest returns the tool's manifest, resolved against the source.
-func (t Tool) Manifest(srcs map[string]sources.Source) (tools.Manifest, error) {
-	allParameters, err := t.resolveParams(srcs)
+func (t Tool) Manifest(source sources.Source) (tools.Manifest, error) {
+	allParameters, err := t.resolveParams(source)
 	if err != nil {
 		return tools.Manifest{}, err
 	}

--- a/internal/tools/cloudhealthcare/cloudhealthcarefhirpatientsearch/cloudhealthcarefhirpatientsearch.go
+++ b/internal/tools/cloudhealthcare/cloudhealthcarefhirpatientsearch/cloudhealthcarefhirpatientsearch.go
@@ -113,6 +113,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/cloudhealthcare/cloudhealthcarefhirpatientsearch/cloudhealthcarefhirpatientsearch.go
+++ b/internal/tools/cloudhealthcare/cloudhealthcarefhirpatientsearch/cloudhealthcarefhirpatientsearch.go
@@ -67,6 +67,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	AllowedFHIRStores() map[string]struct{}
 	UseClientAuthorization() bool
 	FHIRPatientSearch(string, string, []googleapi.CallOption) (any, error)
@@ -109,12 +110,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -125,12 +130,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	storeID, err := common.ValidateAndFetchStoreID(params, source.AllowedFHIRStores())
 	if err != nil {
 		return nil, util.NewAgentError("failed to validate store ID", err)
@@ -217,12 +221,12 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
 // buildParams builds the tool's parameters. When the source pins exactly one store
@@ -256,23 +260,22 @@ func buildParams(singleStore bool) parameters.Parameters {
 }
 
 // resolveParams builds the tool's parameters using the source's configured FHIR/DICOM stores.
-func (t Tool) resolveParams(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	s, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, err
+func (t Tool) resolveParams(source sources.Source) (parameters.Parameters, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-
 	return buildParams(len(s.AllowedFHIRStores()) == 1), nil
 }
 
 // GetParameters returns the tool's parameters, resolved against the source.
-func (t Tool) GetParameters(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	return t.resolveParams(srcs)
+func (t Tool) GetParameters(source sources.Source) (parameters.Parameters, error) {
+	return t.resolveParams(source)
 }
 
 // Manifest returns the tool's manifest, resolved against the source.
-func (t Tool) Manifest(srcs map[string]sources.Source) (tools.Manifest, error) {
-	allParameters, err := t.resolveParams(srcs)
+func (t Tool) Manifest(source sources.Source) (tools.Manifest, error) {
+	allParameters, err := t.resolveParams(source)
 	if err != nil {
 		return tools.Manifest{}, err
 	}

--- a/internal/tools/cloudhealthcare/cloudhealthcaregetdataset/cloudhealthcaregetdataset.go
+++ b/internal/tools/cloudhealthcare/cloudhealthcaregetdataset/cloudhealthcaregetdataset.go
@@ -89,6 +89,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/cloudhealthcare/cloudhealthcaregetdataset/cloudhealthcaregetdataset.go
+++ b/internal/tools/cloudhealthcare/cloudhealthcaregetdataset/cloudhealthcaregetdataset.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	"github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -43,6 +44,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	GetDataset(string) (*healthcare.Dataset, error)
 }
@@ -85,12 +87,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -101,12 +107,13 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
 	var tokenStr string
+	var err error
 	if source.UseClientAuthorization() {
 		tokenStr, err = accessToken.ParseBearerToken()
 		if err != nil {
@@ -120,10 +127,10 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }

--- a/internal/tools/cloudhealthcare/cloudhealthcaregetdicomstore/cloudhealthcaregetdicomstore.go
+++ b/internal/tools/cloudhealthcare/cloudhealthcaregetdicomstore/cloudhealthcaregetdicomstore.go
@@ -45,6 +45,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	AllowedDICOMStores() map[string]struct{}
 	UseClientAuthorization() bool
 	GetDICOMStore(string, string) (*healthcare.DicomStore, error)
@@ -87,12 +88,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -103,10 +108,10 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
 	storeID, err := common.ValidateAndFetchStoreID(params, source.AllowedDICOMStores())
 	if err != nil {
@@ -126,12 +131,12 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
 // buildParams builds the tool's parameters. When the source pins exactly one store
@@ -145,23 +150,22 @@ func buildParams(singleStore bool) parameters.Parameters {
 }
 
 // resolveParams builds the tool's parameters using the source's configured FHIR/DICOM stores.
-func (t Tool) resolveParams(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	s, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, err
+func (t Tool) resolveParams(source sources.Source) (parameters.Parameters, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-
 	return buildParams(len(s.AllowedDICOMStores()) == 1), nil
 }
 
 // GetParameters returns the tool's parameters, resolved against the source.
-func (t Tool) GetParameters(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	return t.resolveParams(srcs)
+func (t Tool) GetParameters(source sources.Source) (parameters.Parameters, error) {
+	return t.resolveParams(source)
 }
 
 // Manifest returns the tool's manifest, resolved against the source.
-func (t Tool) Manifest(srcs map[string]sources.Source) (tools.Manifest, error) {
-	allParameters, err := t.resolveParams(srcs)
+func (t Tool) Manifest(source sources.Source) (tools.Manifest, error) {
+	allParameters, err := t.resolveParams(source)
 	if err != nil {
 		return tools.Manifest{}, err
 	}

--- a/internal/tools/cloudhealthcare/cloudhealthcaregetdicomstore/cloudhealthcaregetdicomstore.go
+++ b/internal/tools/cloudhealthcare/cloudhealthcaregetdicomstore/cloudhealthcaregetdicomstore.go
@@ -91,6 +91,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/cloudhealthcare/cloudhealthcaregetdicomstoremetrics/cloudhealthcaregetdicomstoremetrics.go
+++ b/internal/tools/cloudhealthcare/cloudhealthcaregetdicomstoremetrics/cloudhealthcaregetdicomstoremetrics.go
@@ -45,6 +45,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	AllowedDICOMStores() map[string]struct{}
 	UseClientAuthorization() bool
 	GetDICOMStoreMetrics(string, string) (*healthcare.DicomStoreMetrics, error)
@@ -87,12 +88,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -103,10 +108,10 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
 	storeID, err := common.ValidateAndFetchStoreID(params, source.AllowedDICOMStores())
 	if err != nil {
@@ -126,12 +131,12 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
 // buildParams builds the tool's parameters. When the source pins exactly one store
@@ -145,23 +150,22 @@ func buildParams(singleStore bool) parameters.Parameters {
 }
 
 // resolveParams builds the tool's parameters using the source's configured FHIR/DICOM stores.
-func (t Tool) resolveParams(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	s, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, err
+func (t Tool) resolveParams(source sources.Source) (parameters.Parameters, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-
 	return buildParams(len(s.AllowedDICOMStores()) == 1), nil
 }
 
 // GetParameters returns the tool's parameters, resolved against the source.
-func (t Tool) GetParameters(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	return t.resolveParams(srcs)
+func (t Tool) GetParameters(source sources.Source) (parameters.Parameters, error) {
+	return t.resolveParams(source)
 }
 
 // Manifest returns the tool's manifest, resolved against the source.
-func (t Tool) Manifest(srcs map[string]sources.Source) (tools.Manifest, error) {
-	allParameters, err := t.resolveParams(srcs)
+func (t Tool) Manifest(source sources.Source) (tools.Manifest, error) {
+	allParameters, err := t.resolveParams(source)
 	if err != nil {
 		return tools.Manifest{}, err
 	}

--- a/internal/tools/cloudhealthcare/cloudhealthcaregetdicomstoremetrics/cloudhealthcaregetdicomstoremetrics.go
+++ b/internal/tools/cloudhealthcare/cloudhealthcaregetdicomstoremetrics/cloudhealthcaregetdicomstoremetrics.go
@@ -91,6 +91,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/cloudhealthcare/cloudhealthcaregetfhirresource/cloudhealthcaregetfhirresource.go
+++ b/internal/tools/cloudhealthcare/cloudhealthcaregetfhirresource/cloudhealthcaregetfhirresource.go
@@ -48,6 +48,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	AllowedFHIRStores() map[string]struct{}
 	UseClientAuthorization() bool
 	GetFHIRResource(string, string, string, string) (any, error)
@@ -90,12 +91,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -106,12 +111,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	storeID, err := common.ValidateAndFetchStoreID(params, source.AllowedFHIRStores())
 	if err != nil {
 		return nil, util.NewAgentError("failed to validate store ID", err)
@@ -138,12 +142,12 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
 // buildParams builds the tool's parameters. When the source pins exactly one store
@@ -160,23 +164,22 @@ func buildParams(singleStore bool) parameters.Parameters {
 }
 
 // resolveParams builds the tool's parameters using the source's configured FHIR/DICOM stores.
-func (t Tool) resolveParams(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	s, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, err
+func (t Tool) resolveParams(source sources.Source) (parameters.Parameters, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-
 	return buildParams(len(s.AllowedFHIRStores()) == 1), nil
 }
 
 // GetParameters returns the tool's parameters, resolved against the source.
-func (t Tool) GetParameters(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	return t.resolveParams(srcs)
+func (t Tool) GetParameters(source sources.Source) (parameters.Parameters, error) {
+	return t.resolveParams(source)
 }
 
 // Manifest returns the tool's manifest, resolved against the source.
-func (t Tool) Manifest(srcs map[string]sources.Source) (tools.Manifest, error) {
-	allParameters, err := t.resolveParams(srcs)
+func (t Tool) Manifest(source sources.Source) (tools.Manifest, error) {
+	allParameters, err := t.resolveParams(source)
 	if err != nil {
 		return tools.Manifest{}, err
 	}

--- a/internal/tools/cloudhealthcare/cloudhealthcaregetfhirresource/cloudhealthcaregetfhirresource.go
+++ b/internal/tools/cloudhealthcare/cloudhealthcaregetfhirresource/cloudhealthcaregetfhirresource.go
@@ -94,6 +94,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/cloudhealthcare/cloudhealthcaregetfhirstore/cloudhealthcaregetfhirstore.go
+++ b/internal/tools/cloudhealthcare/cloudhealthcaregetfhirstore/cloudhealthcaregetfhirstore.go
@@ -45,6 +45,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	AllowedFHIRStores() map[string]struct{}
 	UseClientAuthorization() bool
 	GetFHIRStore(string, string) (*healthcare.FhirStore, error)
@@ -87,12 +88,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -103,10 +108,10 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
 	storeID, err := common.ValidateAndFetchStoreID(params, source.AllowedFHIRStores())
 	if err != nil {
@@ -126,12 +131,12 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
 // buildParams builds the tool's parameters. When the source pins exactly one store
@@ -145,23 +150,22 @@ func buildParams(singleStore bool) parameters.Parameters {
 }
 
 // resolveParams builds the tool's parameters using the source's configured FHIR/DICOM stores.
-func (t Tool) resolveParams(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	s, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, err
+func (t Tool) resolveParams(source sources.Source) (parameters.Parameters, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-
 	return buildParams(len(s.AllowedFHIRStores()) == 1), nil
 }
 
 // GetParameters returns the tool's parameters, resolved against the source.
-func (t Tool) GetParameters(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	return t.resolveParams(srcs)
+func (t Tool) GetParameters(source sources.Source) (parameters.Parameters, error) {
+	return t.resolveParams(source)
 }
 
 // Manifest returns the tool's manifest, resolved against the source.
-func (t Tool) Manifest(srcs map[string]sources.Source) (tools.Manifest, error) {
-	allParameters, err := t.resolveParams(srcs)
+func (t Tool) Manifest(source sources.Source) (tools.Manifest, error) {
+	allParameters, err := t.resolveParams(source)
 	if err != nil {
 		return tools.Manifest{}, err
 	}

--- a/internal/tools/cloudhealthcare/cloudhealthcaregetfhirstore/cloudhealthcaregetfhirstore.go
+++ b/internal/tools/cloudhealthcare/cloudhealthcaregetfhirstore/cloudhealthcaregetfhirstore.go
@@ -91,6 +91,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/cloudhealthcare/cloudhealthcaregetfhirstoremetrics/cloudhealthcaregetfhirstoremetrics.go
+++ b/internal/tools/cloudhealthcare/cloudhealthcaregetfhirstoremetrics/cloudhealthcaregetfhirstoremetrics.go
@@ -45,6 +45,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	AllowedFHIRStores() map[string]struct{}
 	UseClientAuthorization() bool
 	GetFHIRStoreMetrics(string, string) (*healthcare.FhirStoreMetrics, error)
@@ -87,12 +88,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -103,10 +108,10 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
 	storeID, err := common.ValidateAndFetchStoreID(params, source.AllowedFHIRStores())
 	if err != nil {
@@ -126,12 +131,12 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
 // buildParams builds the tool's parameters. When the source pins exactly one store
@@ -145,23 +150,22 @@ func buildParams(singleStore bool) parameters.Parameters {
 }
 
 // resolveParams builds the tool's parameters using the source's configured FHIR/DICOM stores.
-func (t Tool) resolveParams(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	s, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, err
+func (t Tool) resolveParams(source sources.Source) (parameters.Parameters, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-
 	return buildParams(len(s.AllowedFHIRStores()) == 1), nil
 }
 
 // GetParameters returns the tool's parameters, resolved against the source.
-func (t Tool) GetParameters(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	return t.resolveParams(srcs)
+func (t Tool) GetParameters(source sources.Source) (parameters.Parameters, error) {
+	return t.resolveParams(source)
 }
 
 // Manifest returns the tool's manifest, resolved against the source.
-func (t Tool) Manifest(srcs map[string]sources.Source) (tools.Manifest, error) {
-	allParameters, err := t.resolveParams(srcs)
+func (t Tool) Manifest(source sources.Source) (tools.Manifest, error) {
+	allParameters, err := t.resolveParams(source)
 	if err != nil {
 		return tools.Manifest{}, err
 	}

--- a/internal/tools/cloudhealthcare/cloudhealthcaregetfhirstoremetrics/cloudhealthcaregetfhirstoremetrics.go
+++ b/internal/tools/cloudhealthcare/cloudhealthcaregetfhirstoremetrics/cloudhealthcaregetfhirstoremetrics.go
@@ -91,6 +91,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/cloudhealthcare/cloudhealthcarelistdicomstores/cloudhealthcarelistdicomstores.go
+++ b/internal/tools/cloudhealthcare/cloudhealthcarelistdicomstores/cloudhealthcarelistdicomstores.go
@@ -89,6 +89,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/cloudhealthcare/cloudhealthcarelistdicomstores/cloudhealthcarelistdicomstores.go
+++ b/internal/tools/cloudhealthcare/cloudhealthcarelistdicomstores/cloudhealthcarelistdicomstores.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	"github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -43,6 +44,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	ListDICOMStores(tokenStr string) ([]*healthcare.DicomStore, error)
 }
@@ -85,12 +87,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -101,12 +107,13 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
 	var tokenStr string
+	var err error
 	if source.UseClientAuthorization() {
 		tokenStr, err = accessToken.ParseBearerToken()
 		if err != nil {
@@ -120,10 +127,10 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }

--- a/internal/tools/cloudhealthcare/cloudhealthcarelistfhirstores/cloudhealthcarelistfhirstores.go
+++ b/internal/tools/cloudhealthcare/cloudhealthcarelistfhirstores/cloudhealthcarelistfhirstores.go
@@ -89,6 +89,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/cloudhealthcare/cloudhealthcarelistfhirstores/cloudhealthcarelistfhirstores.go
+++ b/internal/tools/cloudhealthcare/cloudhealthcarelistfhirstores/cloudhealthcarelistfhirstores.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	"github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -43,6 +44,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	ListFHIRStores(string) ([]*healthcare.FhirStore, error)
 }
@@ -85,12 +87,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -101,12 +107,13 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
 	var tokenStr string
+	var err error
 	if source.UseClientAuthorization() {
 		tokenStr, err = accessToken.ParseBearerToken()
 		if err != nil {
@@ -120,10 +127,10 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }

--- a/internal/tools/cloudhealthcare/cloudhealthcareretrieverendereddicominstance/cloudhealthcareretrieverendereddicominstance.go
+++ b/internal/tools/cloudhealthcare/cloudhealthcareretrieverendereddicominstance/cloudhealthcareretrieverendereddicominstance.go
@@ -96,6 +96,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/cloudhealthcare/cloudhealthcareretrieverendereddicominstance/cloudhealthcareretrieverendereddicominstance.go
+++ b/internal/tools/cloudhealthcare/cloudhealthcareretrieverendereddicominstance/cloudhealthcareretrieverendereddicominstance.go
@@ -50,6 +50,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	AllowedDICOMStores() map[string]struct{}
 	UseClientAuthorization() bool
 	RetrieveRenderedDICOMInstance(string, string, string, string, int, string) (any, error)
@@ -92,12 +93,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -108,12 +113,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	storeID, err := common.ValidateAndFetchStoreID(params, source.AllowedDICOMStores())
 	if err != nil {
 		return nil, util.NewAgentError("failed to validate store ID", err)
@@ -148,12 +152,12 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
 // buildParams builds the tool's parameters. When the source pins exactly one store
@@ -172,23 +176,22 @@ func buildParams(singleStore bool) parameters.Parameters {
 }
 
 // resolveParams builds the tool's parameters using the source's configured FHIR/DICOM stores.
-func (t Tool) resolveParams(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	s, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, err
+func (t Tool) resolveParams(source sources.Source) (parameters.Parameters, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-
 	return buildParams(len(s.AllowedDICOMStores()) == 1), nil
 }
 
 // GetParameters returns the tool's parameters, resolved against the source.
-func (t Tool) GetParameters(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	return t.resolveParams(srcs)
+func (t Tool) GetParameters(source sources.Source) (parameters.Parameters, error) {
+	return t.resolveParams(source)
 }
 
 // Manifest returns the tool's manifest, resolved against the source.
-func (t Tool) Manifest(srcs map[string]sources.Source) (tools.Manifest, error) {
-	allParameters, err := t.resolveParams(srcs)
+func (t Tool) Manifest(source sources.Source) (tools.Manifest, error) {
+	allParameters, err := t.resolveParams(source)
 	if err != nil {
 		return tools.Manifest{}, err
 	}

--- a/internal/tools/cloudhealthcare/cloudhealthcaresearchdicominstances/cloudhealthcaresearchdicominstances.go
+++ b/internal/tools/cloudhealthcare/cloudhealthcaresearchdicominstances/cloudhealthcaresearchdicominstances.go
@@ -103,6 +103,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/cloudhealthcare/cloudhealthcaresearchdicominstances/cloudhealthcaresearchdicominstances.go
+++ b/internal/tools/cloudhealthcare/cloudhealthcaresearchdicominstances/cloudhealthcaresearchdicominstances.go
@@ -57,6 +57,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	AllowedDICOMStores() map[string]struct{}
 	UseClientAuthorization() bool
 	SearchDICOM(string, string, string, string, []googleapi.CallOption) (any, error)
@@ -99,12 +100,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -115,10 +120,10 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
 	storeID, err := common.ValidateAndFetchStoreID(params, source.AllowedDICOMStores())
 	if err != nil {
@@ -167,12 +172,12 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
 // buildParams builds the tool's parameters. When the source pins exactly one store
@@ -198,23 +203,22 @@ func buildParams(singleStore bool) parameters.Parameters {
 }
 
 // resolveParams builds the tool's parameters using the source's configured FHIR/DICOM stores.
-func (t Tool) resolveParams(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	s, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, err
+func (t Tool) resolveParams(source sources.Source) (parameters.Parameters, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-
 	return buildParams(len(s.AllowedDICOMStores()) == 1), nil
 }
 
 // GetParameters returns the tool's parameters, resolved against the source.
-func (t Tool) GetParameters(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	return t.resolveParams(srcs)
+func (t Tool) GetParameters(source sources.Source) (parameters.Parameters, error) {
+	return t.resolveParams(source)
 }
 
 // Manifest returns the tool's manifest, resolved against the source.
-func (t Tool) Manifest(srcs map[string]sources.Source) (tools.Manifest, error) {
-	allParameters, err := t.resolveParams(srcs)
+func (t Tool) Manifest(source sources.Source) (tools.Manifest, error) {
+	allParameters, err := t.resolveParams(source)
 	if err != nil {
 		return tools.Manifest{}, err
 	}

--- a/internal/tools/cloudhealthcare/cloudhealthcaresearchdicomseries/cloudhealthcaresearchdicomseries.go
+++ b/internal/tools/cloudhealthcare/cloudhealthcaresearchdicomseries/cloudhealthcaresearchdicomseries.go
@@ -55,6 +55,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	AllowedDICOMStores() map[string]struct{}
 	UseClientAuthorization() bool
 	SearchDICOM(string, string, string, string, []googleapi.CallOption) (any, error)
@@ -97,12 +98,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -113,12 +118,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	storeID, err := common.ValidateAndFetchStoreID(params, source.AllowedDICOMStores())
 	if err != nil {
 		return nil, util.NewAgentError("failed to validate store ID", err)
@@ -153,12 +157,12 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
 // buildParams builds the tool's parameters. When the source pins exactly one store
@@ -183,23 +187,22 @@ func buildParams(singleStore bool) parameters.Parameters {
 }
 
 // resolveParams builds the tool's parameters using the source's configured FHIR/DICOM stores.
-func (t Tool) resolveParams(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	s, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, err
+func (t Tool) resolveParams(source sources.Source) (parameters.Parameters, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-
 	return buildParams(len(s.AllowedDICOMStores()) == 1), nil
 }
 
 // GetParameters returns the tool's parameters, resolved against the source.
-func (t Tool) GetParameters(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	return t.resolveParams(srcs)
+func (t Tool) GetParameters(source sources.Source) (parameters.Parameters, error) {
+	return t.resolveParams(source)
 }
 
 // Manifest returns the tool's manifest, resolved against the source.
-func (t Tool) Manifest(srcs map[string]sources.Source) (tools.Manifest, error) {
-	allParameters, err := t.resolveParams(srcs)
+func (t Tool) Manifest(source sources.Source) (tools.Manifest, error) {
+	allParameters, err := t.resolveParams(source)
 	if err != nil {
 		return tools.Manifest{}, err
 	}

--- a/internal/tools/cloudhealthcare/cloudhealthcaresearchdicomseries/cloudhealthcaresearchdicomseries.go
+++ b/internal/tools/cloudhealthcare/cloudhealthcaresearchdicomseries/cloudhealthcaresearchdicomseries.go
@@ -101,6 +101,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/cloudhealthcare/cloudhealthcaresearchdicomstudies/cloudhealthcaresearchdicomstudies.go
+++ b/internal/tools/cloudhealthcare/cloudhealthcaresearchdicomstudies/cloudhealthcaresearchdicomstudies.go
@@ -99,6 +99,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/cloudhealthcare/cloudhealthcaresearchdicomstudies/cloudhealthcaresearchdicomstudies.go
+++ b/internal/tools/cloudhealthcare/cloudhealthcaresearchdicomstudies/cloudhealthcaresearchdicomstudies.go
@@ -53,6 +53,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	AllowedDICOMStores() map[string]struct{}
 	UseClientAuthorization() bool
 	SearchDICOM(string, string, string, string, []googleapi.CallOption) (any, error)
@@ -95,12 +96,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -111,10 +116,10 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
 	storeID, err := common.ValidateAndFetchStoreID(params, source.AllowedDICOMStores())
 	if err != nil {
@@ -139,12 +144,12 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
 // buildParams builds the tool's parameters. When the source pins exactly one store
@@ -167,23 +172,22 @@ func buildParams(singleStore bool) parameters.Parameters {
 }
 
 // resolveParams builds the tool's parameters using the source's configured FHIR/DICOM stores.
-func (t Tool) resolveParams(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	s, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, err
+func (t Tool) resolveParams(source sources.Source) (parameters.Parameters, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-
 	return buildParams(len(s.AllowedDICOMStores()) == 1), nil
 }
 
 // GetParameters returns the tool's parameters, resolved against the source.
-func (t Tool) GetParameters(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	return t.resolveParams(srcs)
+func (t Tool) GetParameters(source sources.Source) (parameters.Parameters, error) {
+	return t.resolveParams(source)
 }
 
 // Manifest returns the tool's manifest, resolved against the source.
-func (t Tool) Manifest(srcs map[string]sources.Source) (tools.Manifest, error) {
-	allParameters, err := t.resolveParams(srcs)
+func (t Tool) Manifest(source sources.Source) (tools.Manifest, error) {
+	allParameters, err := t.resolveParams(source)
 	if err != nil {
 		return tools.Manifest{}, err
 	}

--- a/internal/tools/cloudloggingadmin/cloudloggingadminlistlognames/cloudloggingadminlistlognames.go
+++ b/internal/tools/cloudloggingadmin/cloudloggingadminlistlognames/cloudloggingadminlistlognames.go
@@ -130,6 +130,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) EmbedParams(ctx context.Context, paramValues parameters.ParamValues, embeddingModelsMap map[string]embeddingmodels.EmbeddingModel) (parameters.ParamValues, error) {
 	return paramValues, nil
 }

--- a/internal/tools/cloudloggingadmin/cloudloggingadminlistlognames/cloudloggingadminlistlognames.go
+++ b/internal/tools/cloudloggingadmin/cloudloggingadminlistlognames/cloudloggingadminlistlognames.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -44,6 +45,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	ListLogNames(ctx context.Context, limit int, accessToken string) ([]string, error)
 }
@@ -89,12 +91,11 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	limit := defaultLimit
 	paramsMap := params.AsMap()
 	if val, ok := paramsMap["limit"].(int); ok && val > 0 {
@@ -104,6 +105,7 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	}
 
 	tokenString := ""
+	var err error
 	if source.UseClientAuthorization() {
 		tokenString, err = accessToken.ParseBearerToken()
 		if err != nil {
@@ -118,12 +120,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
+}
+
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
 }
 
 func (t Tool) ToConfig() tools.ToolConfig {
@@ -131,7 +137,7 @@ func (t Tool) ToConfig() tools.ToolConfig {
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/cloudloggingadmin/cloudloggingadminlistresourcetypes/cloudloggingadminlistresourcetypes.go
+++ b/internal/tools/cloudloggingadmin/cloudloggingadminlistresourcetypes/cloudloggingadminlistresourcetypes.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -42,6 +43,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	ListResourceTypes(ctx context.Context, accessToken string) ([]string, error)
 }
@@ -85,13 +87,13 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	tokenString := ""
+	var err error
 	if source.UseClientAuthorization() {
 		tokenString, err = accessToken.ParseBearerToken()
 		if err != nil {
@@ -106,12 +108,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
+}
+
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
 }
 
 func (t Tool) ToConfig() tools.ToolConfig {
@@ -119,7 +125,7 @@ func (t Tool) ToConfig() tools.ToolConfig {
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/cloudloggingadmin/cloudloggingadminlistresourcetypes/cloudloggingadminlistresourcetypes.go
+++ b/internal/tools/cloudloggingadmin/cloudloggingadminlistresourcetypes/cloudloggingadminlistresourcetypes.go
@@ -118,6 +118,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) EmbedParams(ctx context.Context, paramValues parameters.ParamValues, embeddingModelsMap map[string]embeddingmodels.EmbeddingModel) (parameters.ParamValues, error) {
 	return paramValues, nil
 }

--- a/internal/tools/cloudloggingadmin/cloudloggingadminquerylogs/cloudloggingadminquerylogs.go
+++ b/internal/tools/cloudloggingadmin/cloudloggingadminquerylogs/cloudloggingadminquerylogs.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	cla "github.com/googleapis/mcp-toolbox/internal/sources/cloudloggingadmin"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -49,6 +50,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	QueryLogs(ctx context.Context, params cla.QueryLogsParams, accessToken string) ([]map[string]any, error)
 }
@@ -102,12 +104,11 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	// Parse parameters
 	limit := defaultLimit
 	paramsMap := params.AsMap()
@@ -153,6 +154,7 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	}
 
 	tokenString := ""
+	var err error
 	if source.UseClientAuthorization() {
 		tokenString, err = accessToken.ParseBearerToken()
 		if err != nil {
@@ -176,12 +178,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
+}
+
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
 }
 
 func (t Tool) ToConfig() tools.ToolConfig {
@@ -189,7 +195,7 @@ func (t Tool) ToConfig() tools.ToolConfig {
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/cloudloggingadmin/cloudloggingadminquerylogs/cloudloggingadminquerylogs.go
+++ b/internal/tools/cloudloggingadmin/cloudloggingadminquerylogs/cloudloggingadminquerylogs.go
@@ -188,6 +188,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) EmbedParams(ctx context.Context, paramValues parameters.ParamValues, embeddingModelsMap map[string]embeddingmodels.EmbeddingModel) (parameters.ParamValues, error) {
 	return paramValues, nil
 }

--- a/internal/tools/cloudmonitoring/cloudmonitoring.go
+++ b/internal/tools/cloudmonitoring/cloudmonitoring.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	"github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -42,6 +43,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	Client() *http.Client
 	RunQuery(projectID, query string) (any, error)
 }
@@ -88,12 +90,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -104,12 +110,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	projectID, ok := paramsMap["projectId"].(string)
 	if !ok {

--- a/internal/tools/cloudmonitoring/cloudmonitoring.go
+++ b/internal/tools/cloudmonitoring/cloudmonitoring.go
@@ -92,6 +92,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/cloudsql/cloudsqlcloneinstance/cloudsqlcloneinstance.go
+++ b/internal/tools/cloudsql/cloudsqlcloneinstance/cloudsqlcloneinstance.go
@@ -92,6 +92,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 // Invoke executes the tool's logic.
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)

--- a/internal/tools/cloudsql/cloudsqlcloneinstance/cloudsqlcloneinstance.go
+++ b/internal/tools/cloudsql/cloudsqlcloneinstance/cloudsqlcloneinstance.go
@@ -44,6 +44,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	GetDefaultProject() string
 	GetService(context.Context, string) (*sqladmin.Service, error)
 	UseClientAuthorization() bool
@@ -88,12 +89,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -105,10 +110,10 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 }
 
 // Invoke executes the tool's logic.
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
 	paramsMap := params.AsMap()
 
@@ -141,13 +146,12 @@ func (t Tool) Authorized(verifiedAuthServices []string) bool {
 	return true
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
 // buildParams builds the tool's parameters. A non-empty project means the source has a
@@ -168,22 +172,22 @@ func buildParams(project string) parameters.Parameters {
 }
 
 // resolveParams builds the tool's parameters using the source's configured default GCP project.
-func (t Tool) resolveParams(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	s, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, err
+func (t Tool) resolveParams(source sources.Source) (parameters.Parameters, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
 	return buildParams(s.GetDefaultProject()), nil
 }
 
 // GetParameters returns the tool's parameters, resolved against the source.
-func (t Tool) GetParameters(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	return t.resolveParams(srcs)
+func (t Tool) GetParameters(source sources.Source) (parameters.Parameters, error) {
+	return t.resolveParams(source)
 }
 
 // Manifest returns the tool's manifest, resolved against the source.
-func (t Tool) Manifest(srcs map[string]sources.Source) (tools.Manifest, error) {
-	allParameters, err := t.resolveParams(srcs)
+func (t Tool) Manifest(source sources.Source) (tools.Manifest, error) {
+	allParameters, err := t.resolveParams(source)
 	if err != nil {
 		return tools.Manifest{}, err
 	}

--- a/internal/tools/cloudsql/cloudsqlcreatebackup/cloudsqlcreatebackup.go
+++ b/internal/tools/cloudsql/cloudsqlcreatebackup/cloudsqlcreatebackup.go
@@ -32,6 +32,7 @@ const resourceType string = "cloud-sql-create-backup"
 var _ tools.ToolConfig = Config{}
 
 type compatibleSource interface {
+	sources.Source
 	GetDefaultProject() string
 	GetService(context.Context, string) (*sqladmin.Service, error)
 	UseClientAuthorization() bool
@@ -87,12 +88,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -103,10 +108,10 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
 	paramsMap := params.AsMap()
 
@@ -134,13 +139,12 @@ func (t Tool) Authorized(verifiedAuthServices []string) bool {
 	return true
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
 // buildParams builds the tool's parameters. A non-empty project means the source has a
@@ -159,22 +163,22 @@ func buildParams(project string) parameters.Parameters {
 }
 
 // resolveParams builds the tool's parameters using the source's configured default GCP project.
-func (t Tool) resolveParams(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	s, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, err
+func (t Tool) resolveParams(source sources.Source) (parameters.Parameters, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
 	return buildParams(s.GetDefaultProject()), nil
 }
 
 // GetParameters returns the tool's parameters, resolved against the source.
-func (t Tool) GetParameters(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	return t.resolveParams(srcs)
+func (t Tool) GetParameters(source sources.Source) (parameters.Parameters, error) {
+	return t.resolveParams(source)
 }
 
 // Manifest returns the tool's manifest, resolved against the source.
-func (t Tool) Manifest(srcs map[string]sources.Source) (tools.Manifest, error) {
-	allParameters, err := t.resolveParams(srcs)
+func (t Tool) Manifest(source sources.Source) (tools.Manifest, error) {
+	allParameters, err := t.resolveParams(source)
 	if err != nil {
 		return tools.Manifest{}, err
 	}

--- a/internal/tools/cloudsql/cloudsqlcreatebackup/cloudsqlcreatebackup.go
+++ b/internal/tools/cloudsql/cloudsqlcreatebackup/cloudsqlcreatebackup.go
@@ -91,6 +91,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/cloudsql/cloudsqlcreatedatabase/cloudsqlcreatedatabase.go
+++ b/internal/tools/cloudsql/cloudsqlcreatedatabase/cloudsqlcreatedatabase.go
@@ -43,6 +43,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	GetDefaultProject() string
 	UseClientAuthorization() bool
 	CreateDatabase(context.Context, string, string, string, string) (any, error)
@@ -86,12 +87,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -103,12 +108,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 }
 
 // Invoke executes the tool's logic.
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 
 	project, ok := paramsMap["project"].(string)
@@ -135,12 +139,12 @@ func (t Tool) Authorized(verifiedAuthServices []string) bool {
 	return true
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
 // buildParams builds the tool's parameters. A non-empty project means the source has a
@@ -158,22 +162,22 @@ func buildParams(project string) parameters.Parameters {
 }
 
 // resolveParams builds the tool's parameters using the source's configured default GCP project.
-func (t Tool) resolveParams(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	s, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, err
+func (t Tool) resolveParams(source sources.Source) (parameters.Parameters, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
 	return buildParams(s.GetDefaultProject()), nil
 }
 
 // GetParameters returns the tool's parameters, resolved against the source.
-func (t Tool) GetParameters(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	return t.resolveParams(srcs)
+func (t Tool) GetParameters(source sources.Source) (parameters.Parameters, error) {
+	return t.resolveParams(source)
 }
 
 // Manifest returns the tool's manifest, resolved against the source.
-func (t Tool) Manifest(srcs map[string]sources.Source) (tools.Manifest, error) {
-	allParameters, err := t.resolveParams(srcs)
+func (t Tool) Manifest(source sources.Source) (tools.Manifest, error) {
+	allParameters, err := t.resolveParams(source)
 	if err != nil {
 		return tools.Manifest{}, err
 	}

--- a/internal/tools/cloudsql/cloudsqlcreatedatabase/cloudsqlcreatedatabase.go
+++ b/internal/tools/cloudsql/cloudsqlcreatedatabase/cloudsqlcreatedatabase.go
@@ -90,6 +90,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 // Invoke executes the tool's logic.
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)

--- a/internal/tools/cloudsql/cloudsqlcreateusers/cloudsqlcreateusers.go
+++ b/internal/tools/cloudsql/cloudsqlcreateusers/cloudsqlcreateusers.go
@@ -90,6 +90,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 // Invoke executes the tool's logic.
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)

--- a/internal/tools/cloudsql/cloudsqlcreateusers/cloudsqlcreateusers.go
+++ b/internal/tools/cloudsql/cloudsqlcreateusers/cloudsqlcreateusers.go
@@ -43,6 +43,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	GetDefaultProject() string
 	UseClientAuthorization() bool
 	CreateUsers(context.Context, string, string, string, string, bool, string) (any, error)
@@ -86,12 +87,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -103,12 +108,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 }
 
 // Invoke executes the tool's logic.
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 
 	project, ok := paramsMap["project"].(string)
@@ -142,12 +146,12 @@ func (t Tool) Authorized(verifiedAuthServices []string) bool {
 	return true
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
 // buildParams builds the tool's parameters. A non-empty project means the source has a
@@ -167,22 +171,22 @@ func buildParams(project string) parameters.Parameters {
 }
 
 // resolveParams builds the tool's parameters using the source's configured default GCP project.
-func (t Tool) resolveParams(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	s, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, err
+func (t Tool) resolveParams(source sources.Source) (parameters.Parameters, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
 	return buildParams(s.GetDefaultProject()), nil
 }
 
 // GetParameters returns the tool's parameters, resolved against the source.
-func (t Tool) GetParameters(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	return t.resolveParams(srcs)
+func (t Tool) GetParameters(source sources.Source) (parameters.Parameters, error) {
+	return t.resolveParams(source)
 }
 
 // Manifest returns the tool's manifest, resolved against the source.
-func (t Tool) Manifest(srcs map[string]sources.Source) (tools.Manifest, error) {
-	allParameters, err := t.resolveParams(srcs)
+func (t Tool) Manifest(source sources.Source) (tools.Manifest, error) {
+	allParameters, err := t.resolveParams(source)
 	if err != nil {
 		return tools.Manifest{}, err
 	}

--- a/internal/tools/cloudsql/cloudsqlgetinstances/cloudsqlgetinstances.go
+++ b/internal/tools/cloudsql/cloudsqlgetinstances/cloudsqlgetinstances.go
@@ -125,6 +125,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 // Invoke executes the tool's logic.
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)

--- a/internal/tools/cloudsql/cloudsqlgetinstances/cloudsqlgetinstances.go
+++ b/internal/tools/cloudsql/cloudsqlgetinstances/cloudsqlgetinstances.go
@@ -43,6 +43,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	GetDefaultProject() string
 	UseClientAuthorization() bool
 	GetInstance(context.Context, string, string, string) (any, error)
@@ -94,22 +95,22 @@ func buildParams(project string) parameters.Parameters {
 }
 
 // resolveParams builds the tool's parameters using the source's configured default GCP project.
-func (t Tool) resolveParams(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	s, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, err
+func (t Tool) resolveParams(source sources.Source) (parameters.Parameters, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
 	return buildParams(s.GetDefaultProject()), nil
 }
 
 // GetParameters returns the tool's parameters, resolved against the source.
-func (t Tool) GetParameters(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	return t.resolveParams(srcs)
+func (t Tool) GetParameters(source sources.Source) (parameters.Parameters, error) {
+	return t.resolveParams(source)
 }
 
 // Manifest returns the tool's manifest, resolved against the source.
-func (t Tool) Manifest(srcs map[string]sources.Source) (tools.Manifest, error) {
-	allParameters, err := t.resolveParams(srcs)
+func (t Tool) Manifest(source sources.Source) (tools.Manifest, error) {
+	allParameters, err := t.resolveParams(source)
 	if err != nil {
 		return tools.Manifest{}, err
 	}
@@ -121,12 +122,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -138,12 +143,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 }
 
 // Invoke executes the tool's logic.
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 
 	projectId, ok := paramsMap["projectId"].(string)
@@ -166,10 +170,10 @@ func (t Tool) Authorized(verifiedAuthServices []string) bool {
 	return true
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }

--- a/internal/tools/cloudsql/cloudsqllistdatabases/cloudsqllistdatabases.go
+++ b/internal/tools/cloudsql/cloudsqllistdatabases/cloudsqllistdatabases.go
@@ -43,6 +43,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	GetDefaultProject() string
 	UseClientAuthorization() bool
 	ListDatabase(context.Context, string, string, string) (any, error)
@@ -86,12 +87,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -103,12 +108,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 }
 
 // Invoke executes the tool's logic.
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 
 	project, ok := paramsMap["project"].(string)
@@ -131,12 +135,12 @@ func (t Tool) Authorized(verifiedAuthServices []string) bool {
 	return true
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
 // buildParams builds the tool's parameters. A non-empty project means the source has a
@@ -153,22 +157,22 @@ func buildParams(project string) parameters.Parameters {
 }
 
 // resolveParams builds the tool's parameters using the source's configured default GCP project.
-func (t Tool) resolveParams(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	s, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, err
+func (t Tool) resolveParams(source sources.Source) (parameters.Parameters, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
 	return buildParams(s.GetDefaultProject()), nil
 }
 
 // GetParameters returns the tool's parameters, resolved against the source.
-func (t Tool) GetParameters(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	return t.resolveParams(srcs)
+func (t Tool) GetParameters(source sources.Source) (parameters.Parameters, error) {
+	return t.resolveParams(source)
 }
 
 // Manifest returns the tool's manifest, resolved against the source.
-func (t Tool) Manifest(srcs map[string]sources.Source) (tools.Manifest, error) {
-	allParameters, err := t.resolveParams(srcs)
+func (t Tool) Manifest(source sources.Source) (tools.Manifest, error) {
+	allParameters, err := t.resolveParams(source)
 	if err != nil {
 		return tools.Manifest{}, err
 	}

--- a/internal/tools/cloudsql/cloudsqllistdatabases/cloudsqllistdatabases.go
+++ b/internal/tools/cloudsql/cloudsqllistdatabases/cloudsqllistdatabases.go
@@ -90,6 +90,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 // Invoke executes the tool's logic.
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)

--- a/internal/tools/cloudsql/cloudsqllistinstances/cloudsqllistinstances.go
+++ b/internal/tools/cloudsql/cloudsqllistinstances/cloudsqllistinstances.go
@@ -43,6 +43,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	GetDefaultProject() string
 	UseClientAuthorization() bool
 	ListInstance(context.Context, string, string) (any, error)
@@ -86,12 +87,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -103,12 +108,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 }
 
 // Invoke executes the tool's logic.
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 
 	project, ok := paramsMap["project"].(string)
@@ -127,12 +131,12 @@ func (t Tool) Authorized(verifiedAuthServices []string) bool {
 	return true
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
 // buildParams builds the tool's parameters. A non-empty project means the source has a
@@ -148,22 +152,22 @@ func buildParams(project string) parameters.Parameters {
 }
 
 // resolveParams builds the tool's parameters using the source's configured default GCP project.
-func (t Tool) resolveParams(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	s, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, err
+func (t Tool) resolveParams(source sources.Source) (parameters.Parameters, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
 	return buildParams(s.GetDefaultProject()), nil
 }
 
 // GetParameters returns the tool's parameters, resolved against the source.
-func (t Tool) GetParameters(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	return t.resolveParams(srcs)
+func (t Tool) GetParameters(source sources.Source) (parameters.Parameters, error) {
+	return t.resolveParams(source)
 }
 
 // Manifest returns the tool's manifest, resolved against the source.
-func (t Tool) Manifest(srcs map[string]sources.Source) (tools.Manifest, error) {
-	allParameters, err := t.resolveParams(srcs)
+func (t Tool) Manifest(source sources.Source) (tools.Manifest, error) {
+	allParameters, err := t.resolveParams(source)
 	if err != nil {
 		return tools.Manifest{}, err
 	}

--- a/internal/tools/cloudsql/cloudsqllistinstances/cloudsqllistinstances.go
+++ b/internal/tools/cloudsql/cloudsqllistinstances/cloudsqllistinstances.go
@@ -90,6 +90,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 // Invoke executes the tool's logic.
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)

--- a/internal/tools/cloudsql/cloudsqlrestorebackup/cloudsqlrestorebackup.go
+++ b/internal/tools/cloudsql/cloudsqlrestorebackup/cloudsqlrestorebackup.go
@@ -129,6 +129,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/cloudsql/cloudsqlrestorebackup/cloudsqlrestorebackup.go
+++ b/internal/tools/cloudsql/cloudsqlrestorebackup/cloudsqlrestorebackup.go
@@ -32,6 +32,7 @@ const resourceType string = "cloud-sql-restore-backup"
 var _ tools.ToolConfig = Config{}
 
 type compatibleSource interface {
+	sources.Source
 	GetDefaultProject() string
 	GetService(context.Context, string) (*sqladmin.Service, error)
 	UseClientAuthorization() bool
@@ -98,22 +99,22 @@ func buildParams(project string) parameters.Parameters {
 }
 
 // resolveParams builds the tool's parameters using the source's configured default GCP project.
-func (t Tool) resolveParams(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	s, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, err
+func (t Tool) resolveParams(source sources.Source) (parameters.Parameters, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
 	return buildParams(s.GetDefaultProject()), nil
 }
 
 // GetParameters returns the tool's parameters, resolved against the source.
-func (t Tool) GetParameters(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	return t.resolveParams(srcs)
+func (t Tool) GetParameters(source sources.Source) (parameters.Parameters, error) {
+	return t.resolveParams(source)
 }
 
 // Manifest returns the tool's manifest, resolved against the source.
-func (t Tool) Manifest(srcs map[string]sources.Source) (tools.Manifest, error) {
-	allParameters, err := t.resolveParams(srcs)
+func (t Tool) Manifest(source sources.Source) (tools.Manifest, error) {
+	allParameters, err := t.resolveParams(source)
 	if err != nil {
 		return tools.Manifest{}, err
 	}
@@ -125,12 +126,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -141,10 +146,10 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
 	paramsMap := params.AsMap()
 
@@ -175,11 +180,10 @@ func (t Tool) Authorized(verifiedAuthServices []string) bool {
 	return true
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }

--- a/internal/tools/cloudsql/cloudsqlwaitforoperation/cloudsqlwaitforoperation.go
+++ b/internal/tools/cloudsql/cloudsqlwaitforoperation/cloudsqlwaitforoperation.go
@@ -86,6 +86,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	GetDefaultProject() string
 	GetService(context.Context, string) (*sqladmin.Service, error)
 	UseClientAuthorization() bool
@@ -181,12 +182,16 @@ type Tool struct {
 	MaxRetries int
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -198,12 +203,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 }
 
 // Invoke executes the tool's logic.
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 
 	project, ok := paramsMap["project"].(string)
@@ -258,12 +262,12 @@ func (t Tool) Authorized(verifiedAuthServices []string) bool {
 	return true
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
 // buildParams builds the tool's parameters. A non-empty project means the source has a
@@ -280,22 +284,22 @@ func buildParams(project string) parameters.Parameters {
 }
 
 // resolveParams builds the tool's parameters using the source's configured default GCP project.
-func (t Tool) resolveParams(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	s, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, err
+func (t Tool) resolveParams(source sources.Source) (parameters.Parameters, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
 	return buildParams(s.GetDefaultProject()), nil
 }
 
 // GetParameters returns the tool's parameters, resolved against the source.
-func (t Tool) GetParameters(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	return t.resolveParams(srcs)
+func (t Tool) GetParameters(source sources.Source) (parameters.Parameters, error) {
+	return t.resolveParams(source)
 }
 
 // Manifest returns the tool's manifest, resolved against the source.
-func (t Tool) Manifest(srcs map[string]sources.Source) (tools.Manifest, error) {
-	allParameters, err := t.resolveParams(srcs)
+func (t Tool) Manifest(source sources.Source) (tools.Manifest, error) {
+	allParameters, err := t.resolveParams(source)
 	if err != nil {
 		return tools.Manifest{}, err
 	}

--- a/internal/tools/cloudsql/cloudsqlwaitforoperation/cloudsqlwaitforoperation.go
+++ b/internal/tools/cloudsql/cloudsqlwaitforoperation/cloudsqlwaitforoperation.go
@@ -185,6 +185,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 // Invoke executes the tool's logic.
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)

--- a/internal/tools/cloudsqladmin/cloudsqladminexecutemany/cloudsqladminexecutemany.go
+++ b/internal/tools/cloudsqladmin/cloudsqladminexecutemany/cloudsqladminexecutemany.go
@@ -128,3 +128,15 @@ func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bo
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/cloudsqladmin/cloudsqladminexecutemany/cloudsqladminexecutemany.go
+++ b/internal/tools/cloudsqladmin/cloudsqladminexecutemany/cloudsqladminexecutemany.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -42,6 +43,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	ExecuteSql(ctx context.Context, project, instance, database, sql string, accessToken string) (any, error)
 	UseClientAuthorization() bool
 }
@@ -89,13 +91,12 @@ type Tool struct {
 }
 
 // Invoke executes the SQL statement on the given database.
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	// Check source compatibility
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
+	// Check source compatibility
 	// Extract parameters from the parameter values map.
 	paramsMap := params.AsMap()
 	project, _ := paramsMap["project"].(string)
@@ -117,12 +118,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
+}
+
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
 }
 
 func (t Tool) ToConfig() tools.ToolConfig {
@@ -130,7 +135,7 @@ func (t Tool) ToConfig() tools.ToolConfig {
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/cloudsqladmin/cloudsqladminsqlmany/cloudsqladminsqlmany.go
+++ b/internal/tools/cloudsqladmin/cloudsqladminsqlmany/cloudsqladminsqlmany.go
@@ -140,3 +140,15 @@ func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bo
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/cloudsqladmin/cloudsqladminsqlmany/cloudsqladminsqlmany.go
+++ b/internal/tools/cloudsqladmin/cloudsqladminsqlmany/cloudsqladminsqlmany.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -42,6 +43,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	ExecuteSql(ctx context.Context, project, instance, database, sql string, accessToken string) (any, error)
 	UseClientAuthorization() bool
 }
@@ -97,13 +99,12 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	// Check source compatibility
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
+	// Check source compatibility
 	// Extract parameters from the parameter values map.
 	paramsMap := params.AsMap()
 	project, _ := paramsMap["project"].(string)
@@ -129,12 +130,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
+}
+
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
 }
 
 func (t Tool) ToConfig() tools.ToolConfig {
@@ -142,7 +147,7 @@ func (t Tool) ToConfig() tools.ToolConfig {
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/cloudsqlmssql/cloudsqlmssqlcreateinstance/cloudsqlmssqlcreateinstance.go
+++ b/internal/tools/cloudsqlmssql/cloudsqlmssqlcreateinstance/cloudsqlmssqlcreateinstance.go
@@ -45,6 +45,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	GetDefaultProject() string
 	UseClientAuthorization() bool
 	CreateInstance(context.Context, string, string, string, string, sqladmin.Settings, string) (any, error)
@@ -89,12 +90,11 @@ type Tool struct {
 }
 
 // Invoke executes the tool's logic.
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 
 	project, ok := paramsMap["project"].(string)
@@ -147,12 +147,16 @@ func (t Tool) Authorized(verifiedAuthServices []string) bool {
 	return true
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
+}
+
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
 }
 
 func (t Tool) ToConfig() tools.ToolConfig {
@@ -160,7 +164,7 @@ func (t Tool) ToConfig() tools.ToolConfig {
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -188,22 +192,22 @@ func buildParams(project string) parameters.Parameters {
 }
 
 // resolveParams builds the tool's parameters using the source's configured default GCP project.
-func (t Tool) resolveParams(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	s, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, err
+func (t Tool) resolveParams(source sources.Source) (parameters.Parameters, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
 	return buildParams(s.GetDefaultProject()), nil
 }
 
 // GetParameters returns the tool's parameters, resolved against the source.
-func (t Tool) GetParameters(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	return t.resolveParams(srcs)
+func (t Tool) GetParameters(source sources.Source) (parameters.Parameters, error) {
+	return t.resolveParams(source)
 }
 
 // Manifest returns the tool's manifest, resolved against the source.
-func (t Tool) Manifest(srcs map[string]sources.Source) (tools.Manifest, error) {
-	allParameters, err := t.resolveParams(srcs)
+func (t Tool) Manifest(source sources.Source) (tools.Manifest, error) {
+	allParameters, err := t.resolveParams(source)
 	if err != nil {
 		return tools.Manifest{}, err
 	}

--- a/internal/tools/cloudsqlmssql/cloudsqlmssqlcreateinstance/cloudsqlmssqlcreateinstance.go
+++ b/internal/tools/cloudsqlmssql/cloudsqlmssqlcreateinstance/cloudsqlmssqlcreateinstance.go
@@ -159,6 +159,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 // buildParams builds the tool's parameters. A non-empty project means the source has a
 // configured default project, which is baked into the project param; otherwise the plain form is used.
 func buildParams(project string) parameters.Parameters {

--- a/internal/tools/cloudsqlmysql/cloudsqlmysqlcreateinstance/cloudsqlmysqlcreateinstance.go
+++ b/internal/tools/cloudsqlmysql/cloudsqlmysqlcreateinstance/cloudsqlmysqlcreateinstance.go
@@ -45,6 +45,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	GetDefaultProject() string
 	UseClientAuthorization() bool
 	CreateInstance(context.Context, string, string, string, string, sqladmin.Settings, string) (any, error)
@@ -89,12 +90,11 @@ type Tool struct {
 }
 
 // Invoke executes the tool's logic.
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 
 	project, ok := paramsMap["project"].(string)
@@ -149,12 +149,16 @@ func (t Tool) Authorized(verifiedAuthServices []string) bool {
 	return true
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
+}
+
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
 }
 
 func (t Tool) ToConfig() tools.ToolConfig {
@@ -162,7 +166,7 @@ func (t Tool) ToConfig() tools.ToolConfig {
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -190,22 +194,22 @@ func buildParams(project string) parameters.Parameters {
 }
 
 // resolveParams builds the tool's parameters using the source's configured default GCP project.
-func (t Tool) resolveParams(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	s, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, err
+func (t Tool) resolveParams(source sources.Source) (parameters.Parameters, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
 	return buildParams(s.GetDefaultProject()), nil
 }
 
 // GetParameters returns the tool's parameters, resolved against the source.
-func (t Tool) GetParameters(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	return t.resolveParams(srcs)
+func (t Tool) GetParameters(source sources.Source) (parameters.Parameters, error) {
+	return t.resolveParams(source)
 }
 
 // Manifest returns the tool's manifest, resolved against the source.
-func (t Tool) Manifest(srcs map[string]sources.Source) (tools.Manifest, error) {
-	allParameters, err := t.resolveParams(srcs)
+func (t Tool) Manifest(source sources.Source) (tools.Manifest, error) {
+	allParameters, err := t.resolveParams(source)
 	if err != nil {
 		return tools.Manifest{}, err
 	}

--- a/internal/tools/cloudsqlmysql/cloudsqlmysqlcreateinstance/cloudsqlmysqlcreateinstance.go
+++ b/internal/tools/cloudsqlmysql/cloudsqlmysqlcreateinstance/cloudsqlmysqlcreateinstance.go
@@ -161,6 +161,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 // buildParams builds the tool's parameters. A non-empty project means the source has a
 // configured default project, which is baked into the project param; otherwise the plain form is used.
 func buildParams(project string) parameters.Parameters {

--- a/internal/tools/cloudsqlpg/cloudsqlpgcreateinstances/cloudsqlpgcreateinstances.go
+++ b/internal/tools/cloudsqlpg/cloudsqlpgcreateinstances/cloudsqlpgcreateinstances.go
@@ -45,6 +45,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	GetDefaultProject() string
 	UseClientAuthorization() bool
 	CreateInstance(context.Context, string, string, string, string, sqladmin.Settings, string) (any, error)
@@ -88,12 +89,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -105,12 +110,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 }
 
 // Invoke executes the tool's logic.
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 
 	project, ok := paramsMap["project"].(string)
@@ -163,12 +167,12 @@ func (t Tool) Authorized(verifiedAuthServices []string) bool {
 	return true
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
 // buildParams builds the tool's parameters. A non-empty project means the source has a
@@ -188,22 +192,22 @@ func buildParams(project string) parameters.Parameters {
 }
 
 // resolveParams builds the tool's parameters using the source's configured default GCP project.
-func (t Tool) resolveParams(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	s, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, err
+func (t Tool) resolveParams(source sources.Source) (parameters.Parameters, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
 	return buildParams(s.GetDefaultProject()), nil
 }
 
 // GetParameters returns the tool's parameters, resolved against the source.
-func (t Tool) GetParameters(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	return t.resolveParams(srcs)
+func (t Tool) GetParameters(source sources.Source) (parameters.Parameters, error) {
+	return t.resolveParams(source)
 }
 
 // Manifest returns the tool's manifest, resolved against the source.
-func (t Tool) Manifest(srcs map[string]sources.Source) (tools.Manifest, error) {
-	allParameters, err := t.resolveParams(srcs)
+func (t Tool) Manifest(source sources.Source) (tools.Manifest, error) {
+	allParameters, err := t.resolveParams(source)
 	if err != nil {
 		return tools.Manifest{}, err
 	}

--- a/internal/tools/cloudsqlpg/cloudsqlpgcreateinstances/cloudsqlpgcreateinstances.go
+++ b/internal/tools/cloudsqlpg/cloudsqlpgcreateinstances/cloudsqlpgcreateinstances.go
@@ -92,6 +92,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 // Invoke executes the tool's logic.
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)

--- a/internal/tools/cloudsqlpg/cloudsqlpgupgradeprecheck/cloudsqlpgupgradeprecheck.go
+++ b/internal/tools/cloudsqlpg/cloudsqlpgupgradeprecheck/cloudsqlpgupgradeprecheck.go
@@ -125,6 +125,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 // Invoke executes the tool's logic.
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)

--- a/internal/tools/cloudsqlpg/cloudsqlpgupgradeprecheck/cloudsqlpgupgradeprecheck.go
+++ b/internal/tools/cloudsqlpg/cloudsqlpgupgradeprecheck/cloudsqlpgupgradeprecheck.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -44,6 +45,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	GetService(context.Context, string) (*sqladmin.Service, error)
 	UseClientAuthorization() bool
 }
@@ -121,12 +123,16 @@ func convertResults(items []*sqladmin.PreCheckResponse) []PreCheckResultItem {
 	return results
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -138,12 +144,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 }
 
 // Invoke executes the tool's logic.
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 
 	project, ok := paramsMap["project"].(string)
@@ -217,10 +222,10 @@ func (t Tool) Authorized(verifiedAuthServices []string) bool {
 	return true
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }

--- a/internal/tools/cloudsqlpg/vectorassistapplyspec/vectorassistapplyspec.go
+++ b/internal/tools/cloudsqlpg/vectorassistapplyspec/vectorassistapplyspec.go
@@ -118,3 +118,15 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/cloudsqlpg/vectorassistapplyspec/vectorassistapplyspec.go
+++ b/internal/tools/cloudsqlpg/vectorassistapplyspec/vectorassistapplyspec.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -49,6 +50,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	PostgresPool() *pgxpool.Pool
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -94,10 +96,10 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
 	paramsMap := params.AsMap()
 
@@ -115,12 +117,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/cloudsqlpg/vectorassistdefinespec/vectorassistdefinespec.go
+++ b/internal/tools/cloudsqlpg/vectorassistdefinespec/vectorassistdefinespec.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -56,6 +57,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	PostgresPool() *pgxpool.Pool
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -114,10 +116,10 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
 	paramsMap := params.AsMap()
 
@@ -135,12 +137,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/cloudsqlpg/vectorassistdefinespec/vectorassistdefinespec.go
+++ b/internal/tools/cloudsqlpg/vectorassistdefinespec/vectorassistdefinespec.go
@@ -138,3 +138,15 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/cloudsqlpg/vectorassistdeletespec/vectorassistdeletespec.go
+++ b/internal/tools/cloudsqlpg/vectorassistdeletespec/vectorassistdeletespec.go
@@ -95,6 +95,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/cloudsqlpg/vectorassistdeletespec/vectorassistdeletespec.go
+++ b/internal/tools/cloudsqlpg/vectorassistdeletespec/vectorassistdeletespec.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -48,6 +49,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	PostgresPool() *pgxpool.Pool
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -91,12 +93,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -107,10 +113,10 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
 	paramsMap := params.AsMap()
 

--- a/internal/tools/cloudsqlpg/vectorassistgeneratequery/vectorassistgeneratequery.go
+++ b/internal/tools/cloudsqlpg/vectorassistgeneratequery/vectorassistgeneratequery.go
@@ -133,3 +133,15 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/cloudsqlpg/vectorassistgeneratequery/vectorassistgeneratequery.go
+++ b/internal/tools/cloudsqlpg/vectorassistgeneratequery/vectorassistgeneratequery.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -57,6 +58,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	PostgresPool() *pgxpool.Pool
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -109,10 +111,10 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
 	paramsMap := params.AsMap()
 
@@ -130,12 +132,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/cloudsqlpg/vectorassistgetspec/vectorassistgetspec.go
+++ b/internal/tools/cloudsqlpg/vectorassistgetspec/vectorassistgetspec.go
@@ -96,6 +96,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/cloudsqlpg/vectorassistgetspec/vectorassistgetspec.go
+++ b/internal/tools/cloudsqlpg/vectorassistgetspec/vectorassistgetspec.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -49,6 +50,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	PostgresPool() *pgxpool.Pool
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -92,12 +94,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -108,10 +114,10 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
 	paramsMap := params.AsMap()
 

--- a/internal/tools/cloudsqlpg/vectorassistimprovequeryrecall/vectorassistimprovequeryrecall.go
+++ b/internal/tools/cloudsqlpg/vectorassistimprovequeryrecall/vectorassistimprovequeryrecall.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -70,6 +71,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	PostgresPool() *pgxpool.Pool
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -119,12 +121,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -135,10 +141,10 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
 	paramsMap := params.AsMap()
 

--- a/internal/tools/cloudsqlpg/vectorassistimprovequeryrecall/vectorassistimprovequeryrecall.go
+++ b/internal/tools/cloudsqlpg/vectorassistimprovequeryrecall/vectorassistimprovequeryrecall.go
@@ -123,6 +123,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/cloudsqlpg/vectorassistlistspecs/vectorassistlistspecs.go
+++ b/internal/tools/cloudsqlpg/vectorassistlistspecs/vectorassistlistspecs.go
@@ -97,6 +97,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/cloudsqlpg/vectorassistlistspecs/vectorassistlistspecs.go
+++ b/internal/tools/cloudsqlpg/vectorassistlistspecs/vectorassistlistspecs.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -49,6 +50,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	PostgresPool() *pgxpool.Pool
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -93,12 +95,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -109,10 +115,10 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
 	paramsMap := params.AsMap()
 

--- a/internal/tools/cloudsqlpg/vectorassistmodifyspec/vectorassistmodifyspec.go
+++ b/internal/tools/cloudsqlpg/vectorassistmodifyspec/vectorassistmodifyspec.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -56,6 +57,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	PostgresPool() *pgxpool.Pool
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -114,10 +116,10 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
 	paramsMap := params.AsMap()
 
@@ -135,12 +137,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/cloudsqlpg/vectorassistmodifyspec/vectorassistmodifyspec.go
+++ b/internal/tools/cloudsqlpg/vectorassistmodifyspec/vectorassistmodifyspec.go
@@ -138,3 +138,15 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/cloudstorage/cloudstoragecopyobject/cloudstoragecopyobject.go
+++ b/internal/tools/cloudstorage/cloudstoragecopyobject/cloudstoragecopyobject.go
@@ -111,6 +111,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/cloudstorage/cloudstoragecopyobject/cloudstoragecopyobject.go
+++ b/internal/tools/cloudstorage/cloudstoragecopyobject/cloudstoragecopyobject.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/tools/cloudstorage/cloudstoragecommon"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -50,6 +51,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	CopyObject(ctx context.Context, sourceBucket, sourceObject, destinationBucket, destinationObject string) (map[string]any, error)
 }
 
@@ -107,12 +109,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -123,12 +129,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	mapParams := params.AsMap()
 	sourceBucket := cloudstoragecommon.ResolveString(t.Cfg.SourceBucket, mapParams, sourceBucketKey)
 	if sourceBucket == "" {

--- a/internal/tools/cloudstorage/cloudstoragecopyobject/cloudstoragecopyobject_test.go
+++ b/internal/tools/cloudstorage/cloudstoragecopyobject/cloudstoragecopyobject_test.go
@@ -161,7 +161,7 @@ func TestConfiguredBucketsHiddenAndForwarded(t *testing.T) {
 		{Name: "source_object", Value: "src"},
 		{Name: "destination_object", Value: "dst"},
 	}
-	if _, err := tool.Invoke(context.Background(), &mockSourceProvider{source: src}, params, ""); err != nil {
+	if _, err := tool.Invoke(context.Background(), src, params, ""); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if src.gotSourceBucket != "source-bucket" || src.gotSourceObject != "src" || src.gotDestinationBucket != "destination-bucket" || src.gotDestinationObject != "dst" {
@@ -235,15 +235,6 @@ func (m *mockSource) CopyObject(ctx context.Context, sourceBucket, sourceObject,
 	return map[string]any{"sourceBucket": sourceBucket, "sourceObject": sourceObject, "destinationBucket": destinationBucket, "destinationObject": destinationObject}, nil
 }
 
-type mockSourceProvider struct {
-	tools.SourceProvider
-	source *mockSource
-}
-
-func (m *mockSourceProvider) GetSource(name string) (sources.Source, bool) {
-	return m.source, true
-}
-
 func TestInvokeValidation(t *testing.T) {
 	cfg := cloudstoragecopyobject.Config{
 		ConfigBase: tools.ConfigBase{
@@ -277,14 +268,13 @@ func TestInvokeValidation(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
 			src := &mockSource{}
-			primitiveMgr := &mockSourceProvider{source: src}
 			params := parameters.ParamValues{
 				{Name: "source_bucket", Value: tc.sourceBucket},
 				{Name: "source_object", Value: tc.sourceObject},
 				{Name: "destination_bucket", Value: tc.destinationBucket},
 				{Name: "destination_object", Value: tc.destinationObject},
 			}
-			_, toolErr := tool.Invoke(context.Background(), primitiveMgr, params, "")
+			_, toolErr := tool.Invoke(context.Background(), src, params, "")
 			if tc.wantErr {
 				if toolErr == nil {
 					t.Fatalf("expected error, got nil")

--- a/internal/tools/cloudstorage/cloudstoragecreatebucket/cloudstoragecreatebucket.go
+++ b/internal/tools/cloudstorage/cloudstoragecreatebucket/cloudstoragecreatebucket.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/tools/cloudstorage/cloudstoragecommon"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -50,6 +51,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	CreateBucket(ctx context.Context, bucket, project, location string, uniformBucketLevelAccess bool) (map[string]any, error)
 }
 
@@ -102,12 +104,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -118,12 +124,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	mapParams := params.AsMap()
 	bucket, ok := mapParams[bucketKey].(string)
 	if !ok || bucket == "" {

--- a/internal/tools/cloudstorage/cloudstoragecreatebucket/cloudstoragecreatebucket.go
+++ b/internal/tools/cloudstorage/cloudstoragecreatebucket/cloudstoragecreatebucket.go
@@ -106,6 +106,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/cloudstorage/cloudstoragecreatebucket/cloudstoragecreatebucket_test.go
+++ b/internal/tools/cloudstorage/cloudstoragecreatebucket/cloudstoragecreatebucket_test.go
@@ -150,15 +150,6 @@ func (m *mockSource) CreateBucket(ctx context.Context, bucket, project, location
 	return map[string]any{"bucket": bucket, "created": true}, nil
 }
 
-type mockSourceProvider struct {
-	tools.SourceProvider
-	source *mockSource
-}
-
-func (m *mockSourceProvider) GetSource(name string) (sources.Source, bool) {
-	return m.source, true
-}
-
 func initTool(t *testing.T) tools.Tool {
 	t.Helper()
 	cfg := cloudstoragecreatebucket.Config{
@@ -199,7 +190,6 @@ func TestInvokeValidationAndForwarding(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			tool := initTool(t)
 			src := &mockSource{}
-			primitiveMgr := &mockSourceProvider{source: src}
 			params := parameters.ParamValues{
 				{Name: "bucket", Value: tc.bucket},
 				{Name: "project", Value: tc.project},
@@ -208,7 +198,7 @@ func TestInvokeValidationAndForwarding(t *testing.T) {
 			if tc.location != nil {
 				params = append(params, parameters.ParamValue{Name: "location", Value: tc.location})
 			}
-			_, toolErr := tool.Invoke(context.Background(), primitiveMgr, params, "")
+			_, toolErr := tool.Invoke(context.Background(), src, params, "")
 			if tc.wantErr {
 				if toolErr == nil {
 					t.Fatalf("expected error, got nil")
@@ -261,7 +251,7 @@ func TestConfiguredParametersHiddenAndForwarded(t *testing.T) {
 
 	src := &mockSource{}
 	params := parameters.ParamValues{{Name: "bucket", Value: "b"}}
-	if _, err := tool.Invoke(context.Background(), &mockSourceProvider{source: src}, params, ""); err != nil {
+	if _, err := tool.Invoke(context.Background(), src, params, ""); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if src.gotProject != "baked-project" || src.gotLocation != "US" || !src.gotUniformBucketLevelAccess {
@@ -304,7 +294,7 @@ func TestEmptyConfiguredProjectHiddenAndForwarded(t *testing.T) {
 		{Name: "location", Value: ""},
 		{Name: "uniform_bucket_level_access", Value: false},
 	}
-	if _, err := tool.Invoke(context.Background(), &mockSourceProvider{source: src}, params, ""); err != nil {
+	if _, err := tool.Invoke(context.Background(), src, params, ""); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if src.gotProject != "" {

--- a/internal/tools/cloudstorage/cloudstoragedeletebucket/cloudstoragedeletebucket.go
+++ b/internal/tools/cloudstorage/cloudstoragedeletebucket/cloudstoragedeletebucket.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/tools/cloudstorage/cloudstoragecommon"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -45,6 +46,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	DeleteBucket(ctx context.Context, bucket string) (map[string]any, error)
 }
 
@@ -85,12 +87,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -101,12 +107,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	mapParams := params.AsMap()
 	bucket, ok := mapParams[bucketKey].(string)
 	if !ok || bucket == "" {

--- a/internal/tools/cloudstorage/cloudstoragedeletebucket/cloudstoragedeletebucket.go
+++ b/internal/tools/cloudstorage/cloudstoragedeletebucket/cloudstoragedeletebucket.go
@@ -89,6 +89,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/cloudstorage/cloudstoragedeletebucket/cloudstoragedeletebucket_test.go
+++ b/internal/tools/cloudstorage/cloudstoragedeletebucket/cloudstoragedeletebucket_test.go
@@ -109,15 +109,6 @@ func (m *mockSource) DeleteBucket(ctx context.Context, bucket string) (map[strin
 	return map[string]any{"bucket": bucket, "deleted": true}, nil
 }
 
-type mockSourceProvider struct {
-	tools.SourceProvider
-	source *mockSource
-}
-
-func (m *mockSourceProvider) GetSource(name string) (sources.Source, bool) {
-	return m.source, true
-}
-
 func TestInvokeValidation(t *testing.T) {
 	cfg := cloudstoragedeletebucket.Config{
 		ConfigBase: tools.ConfigBase{
@@ -145,9 +136,8 @@ func TestInvokeValidation(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
 			src := &mockSource{}
-			primitiveMgr := &mockSourceProvider{source: src}
 			params := parameters.ParamValues{{Name: "bucket", Value: tc.bucket}}
-			_, toolErr := tool.Invoke(context.Background(), primitiveMgr, params, "")
+			_, toolErr := tool.Invoke(context.Background(), src, params, "")
 			if tc.wantErr {
 				if toolErr == nil {
 					t.Fatalf("expected error, got nil")

--- a/internal/tools/cloudstorage/cloudstoragedeleteobject/cloudstoragedeleteobject.go
+++ b/internal/tools/cloudstorage/cloudstoragedeleteobject/cloudstoragedeleteobject.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/tools/cloudstorage/cloudstoragecommon"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -48,6 +49,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	DeleteObject(ctx context.Context, bucket, object string) (map[string]any, error)
 }
 
@@ -96,12 +98,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -112,12 +118,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	mapParams := params.AsMap()
 	bucket := cloudstoragecommon.ResolveString(t.Cfg.Bucket, mapParams, bucketKey)
 	if bucket == "" {

--- a/internal/tools/cloudstorage/cloudstoragedeleteobject/cloudstoragedeleteobject.go
+++ b/internal/tools/cloudstorage/cloudstoragedeleteobject/cloudstoragedeleteobject.go
@@ -100,6 +100,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/cloudstorage/cloudstoragedeleteobject/cloudstoragedeleteobject_test.go
+++ b/internal/tools/cloudstorage/cloudstoragedeleteobject/cloudstoragedeleteobject_test.go
@@ -153,7 +153,7 @@ func TestConfiguredBucketHiddenAndForwarded(t *testing.T) {
 
 	src := &mockSource{}
 	params := parameters.ParamValues{{Name: "object", Value: "o"}}
-	if _, err := tool.Invoke(context.Background(), &mockSourceProvider{source: src}, params, ""); err != nil {
+	if _, err := tool.Invoke(context.Background(), src, params, ""); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if src.gotBucket != "baked-bucket" || src.gotObject != "o" {
@@ -211,15 +211,6 @@ func (m *mockSource) DeleteObject(ctx context.Context, bucket, object string) (m
 	return map[string]any{"bucket": bucket, "object": object, "deleted": true}, nil
 }
 
-type mockSourceProvider struct {
-	tools.SourceProvider
-	source *mockSource
-}
-
-func (m *mockSourceProvider) GetSource(name string) (sources.Source, bool) {
-	return m.source, true
-}
-
 func TestInvokeValidation(t *testing.T) {
 	cfg := cloudstoragedeleteobject.Config{
 		ConfigBase: tools.ConfigBase{
@@ -249,12 +240,11 @@ func TestInvokeValidation(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
 			src := &mockSource{}
-			primitiveMgr := &mockSourceProvider{source: src}
 			params := parameters.ParamValues{
 				{Name: "bucket", Value: tc.bucket},
 				{Name: "object", Value: tc.object},
 			}
-			_, toolErr := tool.Invoke(context.Background(), primitiveMgr, params, "")
+			_, toolErr := tool.Invoke(context.Background(), src, params, "")
 			if tc.wantErr {
 				if toolErr == nil {
 					t.Fatalf("expected error, got nil")

--- a/internal/tools/cloudstorage/cloudstoragedownloadobject/cloudstoragedownloadobject.go
+++ b/internal/tools/cloudstorage/cloudstoragedownloadobject/cloudstoragedownloadobject.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/tools/cloudstorage/cloudstoragecommon"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -50,6 +51,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	DownloadObject(ctx context.Context, bucket, object, destination string, overwrite bool) (map[string]any, error)
 }
 
@@ -118,12 +120,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -134,12 +140,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	mapParams := params.AsMap()
 	bucket := cloudstoragecommon.ResolveString(t.Cfg.Bucket, mapParams, bucketKey)
 	if bucket == "" {

--- a/internal/tools/cloudstorage/cloudstoragedownloadobject/cloudstoragedownloadobject.go
+++ b/internal/tools/cloudstorage/cloudstoragedownloadobject/cloudstoragedownloadobject.go
@@ -122,6 +122,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/cloudstorage/cloudstoragedownloadobject/cloudstoragedownloadobject_test.go
+++ b/internal/tools/cloudstorage/cloudstoragedownloadobject/cloudstoragedownloadobject_test.go
@@ -151,15 +151,6 @@ func (m *mockSource) DownloadObject(ctx context.Context, bucket, object, destina
 	return map[string]any{"destination": destination, "bytes": int64(11), "contentType": "text/plain"}, nil
 }
 
-type mockSourceProvider struct {
-	tools.SourceProvider
-	source *mockSource
-}
-
-func (m *mockSourceProvider) GetSource(name string) (sources.Source, bool) {
-	return m.source, true
-}
-
 func TestInvokeValidation(t *testing.T) {
 	cfg := cloudstoragedownloadobject.Config{
 		ConfigBase: tools.ConfigBase{
@@ -195,7 +186,6 @@ func TestInvokeValidation(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
 			src := &mockSource{}
-			primitiveMgr := &mockSourceProvider{source: src}
 			ov := false
 			if b, ok := tc.overwrite.(bool); ok {
 				ov = b
@@ -206,7 +196,7 @@ func TestInvokeValidation(t *testing.T) {
 				{Name: "destination", Value: tc.dest},
 				{Name: "overwrite", Value: ov},
 			}
-			_, toolErr := tool.Invoke(context.Background(), primitiveMgr, params, "")
+			_, toolErr := tool.Invoke(context.Background(), src, params, "")
 			if tc.wantErr {
 				if toolErr == nil {
 					t.Fatalf("expected error, got nil")
@@ -263,7 +253,7 @@ func TestConfiguredParametersHiddenAndForwarded(t *testing.T) {
 		{Name: "object", Value: "path/to/object.txt"},
 		{Name: "destination", Value: filepath.Join("nested", "out.txt")},
 	}
-	if _, err := tool.Invoke(context.Background(), &mockSourceProvider{source: src}, params, ""); err != nil {
+	if _, err := tool.Invoke(context.Background(), src, params, ""); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	wantDest := filepath.Join(destDir, "nested", "out.txt")
@@ -344,7 +334,7 @@ func TestConfiguredDestinationDirRejectsEscapingDestination(t *testing.T) {
 		{Name: "destination", Value: filepath.Join("..", "escape.txt")},
 		{Name: "overwrite", Value: false},
 	}
-	_, toolErr := tool.Invoke(context.Background(), &mockSourceProvider{source: src}, params, "")
+	_, toolErr := tool.Invoke(context.Background(), src, params, "")
 	if toolErr == nil || !strings.Contains(toolErr.Error(), "destination") {
 		t.Fatalf("Invoke() error = %v, want destination error", toolErr)
 	}

--- a/internal/tools/cloudstorage/cloudstoragegetbucketiampolicy/cloudstoragegetbucketiampolicy.go
+++ b/internal/tools/cloudstorage/cloudstoragegetbucketiampolicy/cloudstoragegetbucketiampolicy.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/tools/cloudstorage/cloudstoragecommon"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -45,6 +46,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	GetBucketIAMPolicy(ctx context.Context, bucket string) (map[string]any, error)
 }
 
@@ -91,12 +93,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -107,12 +113,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	mapParams := params.AsMap()
 	bucket := cloudstoragecommon.ResolveString(t.Cfg.Bucket, mapParams, bucketKey)
 	if bucket == "" {

--- a/internal/tools/cloudstorage/cloudstoragegetbucketiampolicy/cloudstoragegetbucketiampolicy.go
+++ b/internal/tools/cloudstorage/cloudstoragegetbucketiampolicy/cloudstoragegetbucketiampolicy.go
@@ -95,6 +95,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/cloudstorage/cloudstoragegetbucketiampolicy/cloudstoragegetbucketiampolicy_test.go
+++ b/internal/tools/cloudstorage/cloudstoragegetbucketiampolicy/cloudstoragegetbucketiampolicy_test.go
@@ -136,15 +136,6 @@ func (m *mockSource) GetBucketIAMPolicy(ctx context.Context, bucket string) (map
 	return map[string]any{"bucket": bucket, "bindings": []any{}}, nil
 }
 
-type mockSourceProvider struct {
-	tools.SourceProvider
-	source *mockSource
-}
-
-func (m *mockSourceProvider) GetSource(name string) (sources.Source, bool) {
-	return m.source, true
-}
-
 func TestInvokeValidation(t *testing.T) {
 	cfg := cloudstoragegetbucketiampolicy.Config{
 		ConfigBase: tools.ConfigBase{
@@ -172,9 +163,8 @@ func TestInvokeValidation(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
 			src := &mockSource{}
-			primitiveMgr := &mockSourceProvider{source: src}
 			params := parameters.ParamValues{{Name: "bucket", Value: tc.bucket}}
-			_, toolErr := tool.Invoke(context.Background(), primitiveMgr, params, "")
+			_, toolErr := tool.Invoke(context.Background(), src, params, "")
 			if tc.wantErr {
 				if toolErr == nil {
 					t.Fatalf("expected error, got nil")
@@ -220,7 +210,7 @@ func TestConfiguredBucketHiddenAndForwarded(t *testing.T) {
 	}
 
 	src := &mockSource{}
-	if _, err := tool.Invoke(context.Background(), &mockSourceProvider{source: src}, nil, ""); err != nil {
+	if _, err := tool.Invoke(context.Background(), src, nil, ""); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if src.gotBucket != "baked-bucket" {

--- a/internal/tools/cloudstorage/cloudstoragegetbucketmetadata/cloudstoragegetbucketmetadata.go
+++ b/internal/tools/cloudstorage/cloudstoragegetbucketmetadata/cloudstoragegetbucketmetadata.go
@@ -96,6 +96,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/cloudstorage/cloudstoragegetbucketmetadata/cloudstoragegetbucketmetadata.go
+++ b/internal/tools/cloudstorage/cloudstoragegetbucketmetadata/cloudstoragegetbucketmetadata.go
@@ -21,6 +21,7 @@ import (
 
 	"cloud.google.com/go/storage"
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/tools/cloudstorage/cloudstoragecommon"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -46,6 +47,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	GetBucketMetadata(ctx context.Context, bucket string) (*storage.BucketAttrs, error)
 }
 
@@ -92,12 +94,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -108,12 +114,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	mapParams := params.AsMap()
 	bucket := cloudstoragecommon.ResolveString(t.Cfg.Bucket, mapParams, bucketKey)
 	if bucket == "" {

--- a/internal/tools/cloudstorage/cloudstoragegetbucketmetadata/cloudstoragegetbucketmetadata_test.go
+++ b/internal/tools/cloudstorage/cloudstoragegetbucketmetadata/cloudstoragegetbucketmetadata_test.go
@@ -137,15 +137,6 @@ func (m *mockSource) GetBucketMetadata(ctx context.Context, bucket string) (*sto
 	return &storage.BucketAttrs{Name: bucket, Location: "US"}, nil
 }
 
-type mockSourceProvider struct {
-	tools.SourceProvider
-	source *mockSource
-}
-
-func (m *mockSourceProvider) GetSource(name string) (sources.Source, bool) {
-	return m.source, true
-}
-
 func TestInvokeValidation(t *testing.T) {
 	cfg := cloudstoragegetbucketmetadata.Config{
 		ConfigBase: tools.ConfigBase{
@@ -173,9 +164,8 @@ func TestInvokeValidation(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
 			src := &mockSource{}
-			primitiveMgr := &mockSourceProvider{source: src}
 			params := parameters.ParamValues{{Name: "bucket", Value: tc.bucket}}
-			_, toolErr := tool.Invoke(context.Background(), primitiveMgr, params, "")
+			_, toolErr := tool.Invoke(context.Background(), src, params, "")
 			if tc.wantErr {
 				if toolErr == nil {
 					t.Fatalf("expected error, got nil")
@@ -221,7 +211,7 @@ func TestConfiguredBucketHiddenAndForwarded(t *testing.T) {
 	}
 
 	src := &mockSource{}
-	if _, err := tool.Invoke(context.Background(), &mockSourceProvider{source: src}, nil, ""); err != nil {
+	if _, err := tool.Invoke(context.Background(), src, nil, ""); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if src.gotBucket != "baked-bucket" {

--- a/internal/tools/cloudstorage/cloudstoragegetobjectmetadata/cloudstoragegetobjectmetadata.go
+++ b/internal/tools/cloudstorage/cloudstoragegetobjectmetadata/cloudstoragegetobjectmetadata.go
@@ -103,6 +103,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/cloudstorage/cloudstoragegetobjectmetadata/cloudstoragegetobjectmetadata.go
+++ b/internal/tools/cloudstorage/cloudstoragegetobjectmetadata/cloudstoragegetobjectmetadata.go
@@ -21,6 +21,7 @@ import (
 
 	"cloud.google.com/go/storage"
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/tools/cloudstorage/cloudstoragecommon"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -49,6 +50,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	GetObjectMetadata(ctx context.Context, bucket, object string) (*storage.ObjectAttrs, error)
 }
 
@@ -99,12 +101,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -115,12 +121,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	mapParams := params.AsMap()
 	bucket := cloudstoragecommon.ResolveString(t.Cfg.Bucket, mapParams, bucketKey)
 	if bucket == "" {

--- a/internal/tools/cloudstorage/cloudstoragegetobjectmetadata/cloudstoragegetobjectmetadata_test.go
+++ b/internal/tools/cloudstorage/cloudstoragegetobjectmetadata/cloudstoragegetobjectmetadata_test.go
@@ -139,15 +139,6 @@ func (m *mockSource) GetObjectMetadata(ctx context.Context, bucket, object strin
 	return &storage.ObjectAttrs{Bucket: bucket, Name: object, ContentType: "text/plain", Size: 11}, nil
 }
 
-type mockSourceProvider struct {
-	tools.SourceProvider
-	source *mockSource
-}
-
-func (m *mockSourceProvider) GetSource(name string) (sources.Source, bool) {
-	return m.source, true
-}
-
 func TestInvokeValidation(t *testing.T) {
 	cfg := cloudstoragegetobjectmetadata.Config{
 		ConfigBase: tools.ConfigBase{
@@ -177,12 +168,11 @@ func TestInvokeValidation(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
 			src := &mockSource{}
-			primitiveMgr := &mockSourceProvider{source: src}
 			params := parameters.ParamValues{
 				{Name: "bucket", Value: tc.bucket},
 				{Name: "object", Value: tc.object},
 			}
-			_, toolErr := tool.Invoke(context.Background(), primitiveMgr, params, "")
+			_, toolErr := tool.Invoke(context.Background(), src, params, "")
 			if tc.wantErr {
 				if toolErr == nil {
 					t.Fatalf("expected error, got nil")
@@ -230,7 +220,7 @@ func TestConfiguredBucketHiddenAndForwarded(t *testing.T) {
 
 	src := &mockSource{}
 	params := parameters.ParamValues{{Name: "object", Value: "o"}}
-	if _, err := tool.Invoke(context.Background(), &mockSourceProvider{source: src}, params, ""); err != nil {
+	if _, err := tool.Invoke(context.Background(), src, params, ""); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if src.gotBucket != "baked-bucket" || src.gotObject != "o" {

--- a/internal/tools/cloudstorage/cloudstoragelistbuckets/cloudstoragelistbuckets.go
+++ b/internal/tools/cloudstorage/cloudstoragelistbuckets/cloudstoragelistbuckets.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/tools/cloudstorage/cloudstoragecommon"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -54,6 +55,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	ListBuckets(ctx context.Context, project, prefix string, maxResults int, pageToken string) (map[string]any, error)
 }
 
@@ -106,12 +108,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -122,12 +128,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	mapParams := params.AsMap()
 	project := cloudstoragecommon.ResolveString(t.Cfg.Project, mapParams, projectKey)
 	prefix := cloudstoragecommon.ResolveString(t.Cfg.Prefix, mapParams, prefixKey)

--- a/internal/tools/cloudstorage/cloudstoragelistbuckets/cloudstoragelistbuckets.go
+++ b/internal/tools/cloudstorage/cloudstoragelistbuckets/cloudstoragelistbuckets.go
@@ -110,6 +110,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/cloudstorage/cloudstoragelistbuckets/cloudstoragelistbuckets_test.go
+++ b/internal/tools/cloudstorage/cloudstoragelistbuckets/cloudstoragelistbuckets_test.go
@@ -140,15 +140,6 @@ func (m *mockSource) ListBuckets(ctx context.Context, project, prefix string, ma
 	return map[string]any{"buckets": []any{}, "nextPageToken": ""}, nil
 }
 
-type mockSourceProvider struct {
-	tools.SourceProvider
-	source *mockSource
-}
-
-func (m *mockSourceProvider) GetSource(name string) (sources.Source, bool) {
-	return m.source, true
-}
-
 func initTool(t *testing.T) tools.Tool {
 	t.Helper()
 	cfg := cloudstoragelistbuckets.Config{
@@ -179,7 +170,6 @@ func TestInvokeMaxResultsValidation(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			tool := initTool(t)
 			src := &mockSource{}
-			primitiveMgr := &mockSourceProvider{source: src}
 
 			params := parameters.ParamValues{
 				{Name: "project", Value: ""},
@@ -188,7 +178,7 @@ func TestInvokeMaxResultsValidation(t *testing.T) {
 				{Name: "page_token", Value: ""},
 			}
 
-			_, toolErr := tool.Invoke(context.Background(), primitiveMgr, params, "")
+			_, toolErr := tool.Invoke(context.Background(), src, params, "")
 			if toolErr == nil {
 				t.Fatalf("expected error for max_results=%d, got nil", tc.maxResults)
 			}
@@ -221,14 +211,13 @@ func TestInvokeProjectPassthrough(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
 			src := &mockSource{}
-			primitiveMgr := &mockSourceProvider{source: src}
 			params := parameters.ParamValues{
 				{Name: "project", Value: tc.project},
 				{Name: "prefix", Value: ""},
 				{Name: "max_results", Value: 0},
 				{Name: "page_token", Value: ""},
 			}
-			if _, err := tool.Invoke(context.Background(), primitiveMgr, params, ""); err != nil {
+			if _, err := tool.Invoke(context.Background(), src, params, ""); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			if !src.listCalled {
@@ -268,7 +257,7 @@ func TestConfiguredParametersHiddenAndForwarded(t *testing.T) {
 		{Name: "max_results", Value: 0},
 		{Name: "page_token", Value: ""},
 	}
-	if _, err := tool.Invoke(context.Background(), &mockSourceProvider{source: src}, params, ""); err != nil {
+	if _, err := tool.Invoke(context.Background(), src, params, ""); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if src.gotProject != "baked-project" || src.gotPrefix != "logs-" {
@@ -311,7 +300,7 @@ func TestEmptyConfiguredProjectHiddenAndForwarded(t *testing.T) {
 		{Name: "max_results", Value: 0},
 		{Name: "page_token", Value: ""},
 	}
-	if _, err := tool.Invoke(context.Background(), &mockSourceProvider{source: src}, params, ""); err != nil {
+	if _, err := tool.Invoke(context.Background(), src, params, ""); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if src.gotProject != "" {

--- a/internal/tools/cloudstorage/cloudstoragelistobjects/cloudstoragelistobjects.go
+++ b/internal/tools/cloudstorage/cloudstoragelistobjects/cloudstoragelistobjects.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/tools/cloudstorage/cloudstoragecommon"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -55,6 +56,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	ListObjects(ctx context.Context, bucket, prefix, delimiter string, maxResults int, pageToken string) (map[string]any, error)
 }
 
@@ -114,12 +116,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -130,12 +136,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	mapParams := params.AsMap()
 	bucket := cloudstoragecommon.ResolveString(t.Cfg.Bucket, mapParams, bucketKey)
 	if bucket == "" {

--- a/internal/tools/cloudstorage/cloudstoragelistobjects/cloudstoragelistobjects.go
+++ b/internal/tools/cloudstorage/cloudstoragelistobjects/cloudstoragelistobjects.go
@@ -118,6 +118,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/cloudstorage/cloudstoragelistobjects/cloudstoragelistobjects_test.go
+++ b/internal/tools/cloudstorage/cloudstoragelistobjects/cloudstoragelistobjects_test.go
@@ -145,15 +145,6 @@ func (m *mockSource) ListObjects(ctx context.Context, bucket, prefix, delimiter 
 	return map[string]any{"objects": []any{}, "prefixes": []string{}, "nextPageToken": ""}, nil
 }
 
-type mockSourceProvider struct {
-	tools.SourceProvider
-	source *mockSource
-}
-
-func (m *mockSourceProvider) GetSource(name string) (sources.Source, bool) {
-	return m.source, true
-}
-
 func TestInvokeMaxResultsValidation(t *testing.T) {
 	tcs := []struct {
 		desc        string
@@ -179,7 +170,6 @@ func TestInvokeMaxResultsValidation(t *testing.T) {
 			}
 
 			src := &mockSource{}
-			primitiveMgr := &mockSourceProvider{source: src}
 
 			params := parameters.ParamValues{
 				{Name: "bucket", Value: "my-bucket"},
@@ -189,7 +179,7 @@ func TestInvokeMaxResultsValidation(t *testing.T) {
 				{Name: "page_token", Value: ""},
 			}
 
-			_, toolErr := tool.Invoke(context.Background(), primitiveMgr, params, "")
+			_, toolErr := tool.Invoke(context.Background(), src, params, "")
 			if toolErr == nil {
 				t.Fatalf("expected error for max_results=%d, got nil", tc.maxResults)
 			}
@@ -235,7 +225,7 @@ func TestConfiguredParametersHiddenAndForwarded(t *testing.T) {
 		{Name: "max_results", Value: 0},
 		{Name: "page_token", Value: ""},
 	}
-	if _, err := tool.Invoke(context.Background(), &mockSourceProvider{source: src}, params, ""); err != nil {
+	if _, err := tool.Invoke(context.Background(), src, params, ""); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if src.gotBucket != "baked-bucket" || src.gotPrefix != "logs/" || src.gotDelimiter != "/" {

--- a/internal/tools/cloudstorage/cloudstoragemoveobject/cloudstoragemoveobject.go
+++ b/internal/tools/cloudstorage/cloudstoragemoveobject/cloudstoragemoveobject.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/tools/cloudstorage/cloudstoragecommon"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -49,6 +50,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	MoveObject(ctx context.Context, bucket, sourceObject, destinationObject string) (map[string]any, error)
 }
 
@@ -98,12 +100,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -114,12 +120,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	mapParams := params.AsMap()
 	bucket := cloudstoragecommon.ResolveString(t.Cfg.Bucket, mapParams, bucketKey)
 	if bucket == "" {

--- a/internal/tools/cloudstorage/cloudstoragemoveobject/cloudstoragemoveobject.go
+++ b/internal/tools/cloudstorage/cloudstoragemoveobject/cloudstoragemoveobject.go
@@ -102,6 +102,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/cloudstorage/cloudstoragemoveobject/cloudstoragemoveobject_test.go
+++ b/internal/tools/cloudstorage/cloudstoragemoveobject/cloudstoragemoveobject_test.go
@@ -157,7 +157,7 @@ func TestConfiguredBucketHiddenAndForwarded(t *testing.T) {
 		{Name: "source_object", Value: "src"},
 		{Name: "destination_object", Value: "dst"},
 	}
-	if _, err := tool.Invoke(context.Background(), &mockSourceProvider{source: src}, params, ""); err != nil {
+	if _, err := tool.Invoke(context.Background(), src, params, ""); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if src.gotBucket != "baked-bucket" || src.gotSourceObject != "src" || src.gotDestinationObject != "dst" {
@@ -216,15 +216,6 @@ func (m *mockSource) MoveObject(ctx context.Context, bucket, sourceObject, desti
 	return map[string]any{"bucket": bucket, "sourceObject": sourceObject, "destinationObject": destinationObject}, nil
 }
 
-type mockSourceProvider struct {
-	tools.SourceProvider
-	source *mockSource
-}
-
-func (m *mockSourceProvider) GetSource(name string) (sources.Source, bool) {
-	return m.source, true
-}
-
 func TestInvokeValidation(t *testing.T) {
 	cfg := cloudstoragemoveobject.Config{
 		ConfigBase: tools.ConfigBase{
@@ -256,13 +247,12 @@ func TestInvokeValidation(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
 			src := &mockSource{}
-			primitiveMgr := &mockSourceProvider{source: src}
 			params := parameters.ParamValues{
 				{Name: "bucket", Value: tc.bucket},
 				{Name: "source_object", Value: tc.sourceObject},
 				{Name: "destination_object", Value: tc.destinationObject},
 			}
-			_, toolErr := tool.Invoke(context.Background(), primitiveMgr, params, "")
+			_, toolErr := tool.Invoke(context.Background(), src, params, "")
 			if tc.wantErr {
 				if toolErr == nil {
 					t.Fatalf("expected error, got nil")

--- a/internal/tools/cloudstorage/cloudstoragereadobject/cloudstoragereadobject.go
+++ b/internal/tools/cloudstorage/cloudstoragereadobject/cloudstoragereadobject.go
@@ -106,6 +106,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/cloudstorage/cloudstoragereadobject/cloudstoragereadobject.go
+++ b/internal/tools/cloudstorage/cloudstoragereadobject/cloudstoragereadobject.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/tools/cloudstorage/cloudstoragecommon"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -51,6 +52,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	ReadObject(ctx context.Context, bucket, object string, offset, length int64) (map[string]any, error)
 }
 
@@ -102,12 +104,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -118,12 +124,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	mapParams := params.AsMap()
 	bucket := cloudstoragecommon.ResolveString(t.Cfg.Bucket, mapParams, bucketKey)
 	if bucket == "" {

--- a/internal/tools/cloudstorage/cloudstoragereadobject/cloudstoragereadobject_test.go
+++ b/internal/tools/cloudstorage/cloudstoragereadobject/cloudstoragereadobject_test.go
@@ -140,15 +140,6 @@ func (m *mockSource) ReadObject(ctx context.Context, bucket, object string, offs
 	return map[string]any{"content": "hello", "contentType": "text/plain", "size": 5}, nil
 }
 
-type mockSourceProvider struct {
-	tools.SourceProvider
-	source *mockSource
-}
-
-func (m *mockSourceProvider) GetSource(name string) (sources.Source, bool) {
-	return m.source, true
-}
-
 func TestConfiguredBucketHiddenAndForwarded(t *testing.T) {
 	cfg := Config{
 		ConfigBase: tools.ConfigBase{
@@ -174,7 +165,7 @@ func TestConfiguredBucketHiddenAndForwarded(t *testing.T) {
 		{Name: "object", Value: "o"},
 		{Name: "range", Value: "bytes=5-9"},
 	}
-	if _, err := tool.Invoke(context.Background(), &mockSourceProvider{source: src}, params, ""); err != nil {
+	if _, err := tool.Invoke(context.Background(), src, params, ""); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if src.gotBucket != "baked-bucket" || src.gotObject != "o" || src.gotOffset != 5 || src.gotLength != 5 {

--- a/internal/tools/cloudstorage/cloudstorageuploadobject/cloudstorageuploadobject.go
+++ b/internal/tools/cloudstorage/cloudstorageuploadobject/cloudstorageuploadobject.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/tools/cloudstorage/cloudstoragecommon"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -50,6 +51,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UploadObject(ctx context.Context, bucket, object, source, contentType string) (map[string]any, error)
 }
 
@@ -102,12 +104,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -118,12 +124,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	mapParams := params.AsMap()
 	bucket := cloudstoragecommon.ResolveString(t.Cfg.Bucket, mapParams, bucketKey)
 	if bucket == "" {

--- a/internal/tools/cloudstorage/cloudstorageuploadobject/cloudstorageuploadobject.go
+++ b/internal/tools/cloudstorage/cloudstorageuploadobject/cloudstorageuploadobject.go
@@ -106,6 +106,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/cloudstorage/cloudstorageuploadobject/cloudstorageuploadobject_test.go
+++ b/internal/tools/cloudstorage/cloudstorageuploadobject/cloudstorageuploadobject_test.go
@@ -143,15 +143,6 @@ func (m *mockSource) UploadObject(ctx context.Context, bucket, object, source, c
 	return map[string]any{"bucket": bucket, "object": object, "bytes": int64(0), "contentType": contentType}, nil
 }
 
-type mockSourceProvider struct {
-	tools.SourceProvider
-	source *mockSource
-}
-
-func (m *mockSourceProvider) GetSource(name string) (sources.Source, bool) {
-	return m.source, true
-}
-
 func TestInvokeValidation(t *testing.T) {
 	cfg := cloudstorageuploadobject.Config{
 		ConfigBase: tools.ConfigBase{
@@ -189,7 +180,6 @@ func TestInvokeValidation(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
 			src := &mockSource{}
-			primitiveMgr := &mockSourceProvider{source: src}
 			ct := ""
 			if s, ok := tc.contentType.(string); ok {
 				ct = s
@@ -200,7 +190,7 @@ func TestInvokeValidation(t *testing.T) {
 				{Name: "source", Value: tc.src},
 				{Name: "content_type", Value: ct},
 			}
-			_, toolErr := tool.Invoke(context.Background(), primitiveMgr, params, "")
+			_, toolErr := tool.Invoke(context.Background(), src, params, "")
 			if tc.wantErr {
 				if toolErr == nil {
 					t.Fatalf("expected error, got nil")
@@ -256,7 +246,7 @@ func TestConfiguredBucketHiddenAndForwarded(t *testing.T) {
 		{Name: "source", Value: localSource},
 		{Name: "content_type", Value: "text/csv"},
 	}
-	if _, err := tool.Invoke(context.Background(), &mockSourceProvider{source: src}, params, ""); err != nil {
+	if _, err := tool.Invoke(context.Background(), src, params, ""); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if src.gotBucket != "baked-bucket" || src.gotObject != "o" || src.gotSource != localSource || src.gotContentType != "text/csv" {

--- a/internal/tools/cloudstorage/cloudstoragewriteobject/cloudstoragewriteobject.go
+++ b/internal/tools/cloudstorage/cloudstoragewriteobject/cloudstoragewriteobject.go
@@ -104,6 +104,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/cloudstorage/cloudstoragewriteobject/cloudstoragewriteobject.go
+++ b/internal/tools/cloudstorage/cloudstoragewriteobject/cloudstoragewriteobject.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/tools/cloudstorage/cloudstoragecommon"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -50,6 +51,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	WriteObject(ctx context.Context, bucket, object, content, contentType string) (map[string]any, error)
 }
 
@@ -100,12 +102,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -116,12 +122,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	mapParams := params.AsMap()
 	bucket := cloudstoragecommon.ResolveString(t.Cfg.Bucket, mapParams, bucketKey)
 	if bucket == "" {

--- a/internal/tools/cloudstorage/cloudstoragewriteobject/cloudstoragewriteobject_test.go
+++ b/internal/tools/cloudstorage/cloudstoragewriteobject/cloudstoragewriteobject_test.go
@@ -159,7 +159,7 @@ func TestConfiguredBucketHiddenAndForwarded(t *testing.T) {
 		{Name: "content", Value: "body"},
 		{Name: "content_type", Value: "text/plain"},
 	}
-	if _, err := tool.Invoke(context.Background(), &mockSourceProvider{source: src}, params, ""); err != nil {
+	if _, err := tool.Invoke(context.Background(), src, params, ""); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if src.gotBucket != "baked-bucket" || src.gotObject != "o" || src.gotContent != "body" || src.gotContentType != "text/plain" {
@@ -219,15 +219,6 @@ func (m *mockSource) WriteObject(ctx context.Context, bucket, object, content, c
 	return map[string]any{"bucket": bucket, "object": object, "bytes": len(content), "contentType": contentType}, nil
 }
 
-type mockSourceProvider struct {
-	tools.SourceProvider
-	source *mockSource
-}
-
-func (m *mockSourceProvider) GetSource(name string) (sources.Source, bool) {
-	return m.source, true
-}
-
 func TestInvokeValidation(t *testing.T) {
 	cfg := cloudstoragewriteobject.Config{
 		ConfigBase: tools.ConfigBase{
@@ -262,7 +253,6 @@ func TestInvokeValidation(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
 			src := &mockSource{}
-			primitiveMgr := &mockSourceProvider{source: src}
 			ct, _ := tc.contentType.(string)
 			params := parameters.ParamValues{
 				{Name: "bucket", Value: tc.bucket},
@@ -270,7 +260,7 @@ func TestInvokeValidation(t *testing.T) {
 				{Name: "content", Value: tc.content},
 				{Name: "content_type", Value: ct},
 			}
-			_, toolErr := tool.Invoke(context.Background(), primitiveMgr, params, "")
+			_, toolErr := tool.Invoke(context.Background(), src, params, "")
 			if tc.wantErr {
 				if toolErr == nil {
 					t.Fatalf("expected error, got nil")

--- a/internal/tools/cockroachdb/cockroachdbexecutesql/cockroachdbexecutesql.go
+++ b/internal/tools/cockroachdb/cockroachdbexecutesql/cockroachdbexecutesql.go
@@ -45,6 +45,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error)
 }
 
@@ -85,12 +86,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -101,31 +106,27 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) validate(srcs map[string]sources.Source) error {
-	_, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	return err
+func (t Tool) GetParameters(source sources.Source) (parameters.Parameters, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return t.BaseTool.GetParameters(s)
 }
 
-func (t Tool) GetParameters(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	if err := t.validate(srcs); err != nil {
-		return nil, err
+func (t Tool) Manifest(source sources.Source) (tools.Manifest, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return tools.Manifest{}, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return t.BaseTool.GetParameters(srcs)
+	return t.BaseTool.Manifest(s)
 }
 
-func (t Tool) Manifest(srcs map[string]sources.Source) (tools.Manifest, error) {
-	if err := t.validate(srcs); err != nil {
-		return tools.Manifest{}, err
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-	return t.BaseTool.Manifest(srcs)
-}
-
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
-	}
-
 	paramsMap := params.AsMap()
 	sql, ok := paramsMap["sql"].(string)
 	if !ok {

--- a/internal/tools/cockroachdb/cockroachdbexecutesql/cockroachdbexecutesql.go
+++ b/internal/tools/cockroachdb/cockroachdbexecutesql/cockroachdbexecutesql.go
@@ -89,6 +89,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) validate(srcs map[string]sources.Source) error {
 	_, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	return err

--- a/internal/tools/cockroachdb/cockroachdblistschemas/cockroachdblistschemas.go
+++ b/internal/tools/cockroachdb/cockroachdblistschemas/cockroachdblistschemas.go
@@ -57,6 +57,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error)
 }
 
@@ -99,12 +100,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -115,31 +120,27 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) validate(srcs map[string]sources.Source) error {
-	_, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	return err
+func (t Tool) GetParameters(source sources.Source) (parameters.Parameters, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return t.BaseTool.GetParameters(s)
 }
 
-func (t Tool) GetParameters(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	if err := t.validate(srcs); err != nil {
-		return nil, err
+func (t Tool) Manifest(source sources.Source) (tools.Manifest, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return tools.Manifest{}, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return t.BaseTool.GetParameters(srcs)
+	return t.BaseTool.Manifest(s)
 }
 
-func (t Tool) Manifest(srcs map[string]sources.Source) (tools.Manifest, error) {
-	if err := t.validate(srcs); err != nil {
-		return tools.Manifest{}, err
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-	return t.BaseTool.Manifest(srcs)
-}
-
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
-	}
-
 	results, err := source.Query(ctx, listSchemasStatement)
 	if err != nil {
 		return nil, util.ProcessGeneralError(fmt.Errorf("unable to execute query: %w", err))

--- a/internal/tools/cockroachdb/cockroachdblistschemas/cockroachdblistschemas.go
+++ b/internal/tools/cockroachdb/cockroachdblistschemas/cockroachdblistschemas.go
@@ -103,6 +103,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) validate(srcs map[string]sources.Source) error {
 	_, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	return err

--- a/internal/tools/cockroachdb/cockroachdblisttables/cockroachdblisttables.go
+++ b/internal/tools/cockroachdb/cockroachdblisttables/cockroachdblisttables.go
@@ -117,6 +117,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error)
 }
 
@@ -162,12 +163,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -178,31 +183,27 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) validate(srcs map[string]sources.Source) error {
-	_, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	return err
+func (t Tool) GetParameters(source sources.Source) (parameters.Parameters, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return t.BaseTool.GetParameters(s)
 }
 
-func (t Tool) GetParameters(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	if err := t.validate(srcs); err != nil {
-		return nil, err
+func (t Tool) Manifest(source sources.Source) (tools.Manifest, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return tools.Manifest{}, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return t.BaseTool.GetParameters(srcs)
+	return t.BaseTool.Manifest(s)
 }
 
-func (t Tool) Manifest(srcs map[string]sources.Source) (tools.Manifest, error) {
-	if err := t.validate(srcs); err != nil {
-		return tools.Manifest{}, err
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-	return t.BaseTool.Manifest(srcs)
-}
-
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
-	}
-
 	paramsMap := params.AsMap()
 
 	tableNames, ok := paramsMap["table_names"].(string)

--- a/internal/tools/cockroachdb/cockroachdblisttables/cockroachdblisttables.go
+++ b/internal/tools/cockroachdb/cockroachdblisttables/cockroachdblisttables.go
@@ -166,6 +166,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) validate(srcs map[string]sources.Source) error {
 	_, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	return err

--- a/internal/tools/cockroachdb/cockroachdbsql/cockroachdbsql.go
+++ b/internal/tools/cockroachdb/cockroachdbsql/cockroachdbsql.go
@@ -46,6 +46,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error)
 }
 
@@ -93,12 +94,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -109,31 +114,27 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) validate(srcs map[string]sources.Source) error {
-	_, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	return err
+func (t Tool) GetParameters(source sources.Source) (parameters.Parameters, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return t.BaseTool.GetParameters(s)
 }
 
-func (t Tool) GetParameters(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	if err := t.validate(srcs); err != nil {
-		return nil, err
+func (t Tool) Manifest(source sources.Source) (tools.Manifest, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return tools.Manifest{}, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return t.BaseTool.GetParameters(srcs)
+	return t.BaseTool.Manifest(s)
 }
 
-func (t Tool) Manifest(srcs map[string]sources.Source) (tools.Manifest, error) {
-	if err := t.validate(srcs); err != nil {
-		return tools.Manifest{}, err
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-	return t.BaseTool.Manifest(srcs)
-}
-
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
-	}
-
 	paramsMap := params.AsMap()
 	newStatement, err := parameters.ResolveTemplateParams(t.Cfg.TemplateParameters, t.Cfg.Statement, paramsMap)
 	if err != nil {

--- a/internal/tools/cockroachdb/cockroachdbsql/cockroachdbsql.go
+++ b/internal/tools/cockroachdb/cockroachdbsql/cockroachdbsql.go
@@ -97,6 +97,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) validate(srcs map[string]sources.Source) error {
 	_, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	return err

--- a/internal/tools/conversationalanalytics/conversationalanalyticsaskdataagent/conversationalanalyticsaskdataagent.go
+++ b/internal/tools/conversationalanalytics/conversationalanalyticsaskdataagent/conversationalanalyticsaskdataagent.go
@@ -51,6 +51,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	GoogleCloudTokenSourceWithScope(ctx context.Context, scope string) (oauth2.TokenSource, error)
 	GetProjectID() string
 	UseClientAuthorization() bool
@@ -133,12 +134,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -149,33 +154,29 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) validate(srcs map[string]sources.Source) error {
-	_, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	return err
+func (t Tool) GetParameters(source sources.Source) (parameters.Parameters, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return t.BaseTool.GetParameters(s)
 }
 
-func (t Tool) GetParameters(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	if err := t.validate(srcs); err != nil {
-		return nil, err
+func (t Tool) Manifest(source sources.Source) (tools.Manifest, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return tools.Manifest{}, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return t.BaseTool.GetParameters(srcs)
+	return t.BaseTool.Manifest(s)
 }
 
-func (t Tool) Manifest(srcs map[string]sources.Source) (tools.Manifest, error) {
-	if err := t.validate(srcs); err != nil {
-		return tools.Manifest{}, err
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-	return t.BaseTool.Manifest(srcs)
-}
-
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
-	}
-
 	var tokenSource oauth2.TokenSource
-
+	var err error
 	// Get credentials for the API call
 	if source.UseClientAuthorization() {
 		// Use client-side access token
@@ -239,12 +240,12 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return response, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
 func getStream(client *http.Client, url string, payload CAPayload, headers map[string]string, maxRows int) (string, error) {

--- a/internal/tools/conversationalanalytics/conversationalanalyticsaskdataagent/conversationalanalyticsaskdataagent.go
+++ b/internal/tools/conversationalanalytics/conversationalanalyticsaskdataagent/conversationalanalyticsaskdataagent.go
@@ -137,6 +137,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) validate(srcs map[string]sources.Source) error {
 	_, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	return err

--- a/internal/tools/conversationalanalytics/conversationalanalyticsgetdataagentinfo/conversationalanalyticsgetdataagentinfo.go
+++ b/internal/tools/conversationalanalytics/conversationalanalyticsgetdataagentinfo/conversationalanalyticsgetdataagentinfo.go
@@ -106,6 +106,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) validate(srcs map[string]sources.Source) error {
 	_, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	return err

--- a/internal/tools/conversationalanalytics/conversationalanalyticsgetdataagentinfo/conversationalanalyticsgetdataagentinfo.go
+++ b/internal/tools/conversationalanalytics/conversationalanalyticsgetdataagentinfo/conversationalanalyticsgetdataagentinfo.go
@@ -50,6 +50,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	GoogleCloudTokenSourceWithScope(ctx context.Context, scope string) (oauth2.TokenSource, error)
 	GetProjectID() string
 	UseClientAuthorization() bool
@@ -102,12 +103,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -118,33 +123,29 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) validate(srcs map[string]sources.Source) error {
-	_, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	return err
+func (t Tool) GetParameters(source sources.Source) (parameters.Parameters, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return t.BaseTool.GetParameters(s)
 }
 
-func (t Tool) GetParameters(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	if err := t.validate(srcs); err != nil {
-		return nil, err
+func (t Tool) Manifest(source sources.Source) (tools.Manifest, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return tools.Manifest{}, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return t.BaseTool.GetParameters(srcs)
+	return t.BaseTool.Manifest(s)
 }
 
-func (t Tool) Manifest(srcs map[string]sources.Source) (tools.Manifest, error) {
-	if err := t.validate(srcs); err != nil {
-		return tools.Manifest{}, err
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-	return t.BaseTool.Manifest(srcs)
-}
-
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
-	}
-
 	var tokenSource oauth2.TokenSource
-
+	var err error
 	// Get credentials for the API call
 	if source.UseClientAuthorization() {
 		// Use client-side access token
@@ -207,10 +208,10 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return result, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }

--- a/internal/tools/conversationalanalytics/conversationalanalyticslistaccessibledataagents/conversationalanalyticslistaccessibledataagents.go
+++ b/internal/tools/conversationalanalytics/conversationalanalyticslistaccessibledataagents/conversationalanalyticslistaccessibledataagents.go
@@ -49,6 +49,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	GoogleCloudTokenSourceWithScope(ctx context.Context, scope string) (oauth2.TokenSource, error)
 	GetProjectID() string
 	UseClientAuthorization() bool
@@ -100,12 +101,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -116,33 +121,29 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) validate(srcs map[string]sources.Source) error {
-	_, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	return err
+func (t Tool) GetParameters(source sources.Source) (parameters.Parameters, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return t.BaseTool.GetParameters(s)
 }
 
-func (t Tool) GetParameters(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	if err := t.validate(srcs); err != nil {
-		return nil, err
+func (t Tool) Manifest(source sources.Source) (tools.Manifest, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return tools.Manifest{}, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return t.BaseTool.GetParameters(srcs)
+	return t.BaseTool.Manifest(s)
 }
 
-func (t Tool) Manifest(srcs map[string]sources.Source) (tools.Manifest, error) {
-	if err := t.validate(srcs); err != nil {
-		return tools.Manifest{}, err
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-	return t.BaseTool.Manifest(srcs)
-}
-
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
-	}
-
 	var tokenSource oauth2.TokenSource
-
+	var err error
 	// Get credentials for the API call
 	if source.UseClientAuthorization() {
 		// Use client-side access token
@@ -201,10 +202,10 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return result, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }

--- a/internal/tools/conversationalanalytics/conversationalanalyticslistaccessibledataagents/conversationalanalyticslistaccessibledataagents.go
+++ b/internal/tools/conversationalanalytics/conversationalanalyticslistaccessibledataagents/conversationalanalyticslistaccessibledataagents.go
@@ -104,6 +104,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) validate(srcs map[string]sources.Source) error {
 	_, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	return err

--- a/internal/tools/couchbase/couchbase.go
+++ b/internal/tools/couchbase/couchbase.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/couchbase/gocb/v2"
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -43,6 +44,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	CouchbaseScope() *gocb.Scope
 	RunSQL(string, parameters.ParamValues) (any, error)
 }
@@ -89,12 +91,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -105,12 +111,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	namedParamsMap := params.AsMap()
 	newStatement, err := parameters.ResolveTemplateParams(t.Cfg.TemplateParameters, t.Cfg.Statement, namedParamsMap)
 	if err != nil {

--- a/internal/tools/couchbase/couchbase.go
+++ b/internal/tools/couchbase/couchbase.go
@@ -93,6 +93,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/dataform/dataformcompilelocal/dataformcompilelocal.go
+++ b/internal/tools/dataform/dataformcompilelocal/dataformcompilelocal.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -80,23 +81,19 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return ""
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
-	if !ok {
-		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
-	}
-	_, ok = source.(compatibleSource)
-	if !ok {
-		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
-	}
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	paramsMap := params.AsMap()
 
 	projectDir, ok := paramsMap["project_dir"].(string)

--- a/internal/tools/dataform/dataformcompilelocal/dataformcompilelocal.go
+++ b/internal/tools/dataform/dataformcompilelocal/dataformcompilelocal.go
@@ -84,6 +84,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	paramsMap := params.AsMap()
 

--- a/internal/tools/datalineage/datalineagesearchlineage/datalineagesearchlineage.go
+++ b/internal/tools/datalineage/datalineagesearchlineage/datalineagesearchlineage.go
@@ -22,6 +22,7 @@ import (
 
 	lineagepb "cloud.google.com/go/datacatalog/lineage/apiv1/lineagepb"
 	"github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -44,6 +45,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	SearchLineageStreaming(
 		ctx context.Context,
 		parentLocation string,
@@ -136,12 +138,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -152,12 +158,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 
 	// Parse locations

--- a/internal/tools/datalineage/datalineagesearchlineage/datalineagesearchlineage.go
+++ b/internal/tools/datalineage/datalineagesearchlineage/datalineagesearchlineage.go
@@ -140,6 +140,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/datalineage/datalineagesearchlineage/datalineagesearchlineage_test.go
+++ b/internal/tools/datalineage/datalineagesearchlineage/datalineagesearchlineage_test.go
@@ -117,15 +117,6 @@ func (m *mockSource) SearchLineageStreaming(
 	return m.retLinks, m.retUnreachable, m.retErr
 }
 
-type mockSourceProvider struct {
-	tools.SourceProvider
-	source *mockSource
-}
-
-func (m *mockSourceProvider) GetSource(name string) (sources.Source, bool) {
-	return m.source, true
-}
-
 func TestInvoke(t *testing.T) {
 	cfg := datalineagesearchlineage.Config{
 		ConfigBase: tools.ConfigBase{
@@ -321,7 +312,6 @@ func TestInvoke(t *testing.T) {
 				retUnreachable: tc.retUnreachable,
 				retErr:         tc.retErr,
 			}
-			primitiveMgr := &mockSourceProvider{source: src}
 
 			params := parameters.ParamValues{
 				{Name: "locations", Value: tc.locations},
@@ -341,7 +331,7 @@ func TestInvoke(t *testing.T) {
 				params = append(params, parameters.ParamValue{Name: "request_process_details", Value: tc.requestProcessDetails})
 			}
 
-			gotResp, toolErr := tool.Invoke(context.Background(), primitiveMgr, params, "")
+			gotResp, toolErr := tool.Invoke(context.Background(), src, params, "")
 			if tc.wantErr {
 				if toolErr == nil {
 					t.Fatalf("expected error, got nil")

--- a/internal/tools/dataplex/dataplexcheckdataquality/dataplexcheckdataquality.go
+++ b/internal/tools/dataplex/dataplexcheckdataquality/dataplexcheckdataquality.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	"github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/tools/dataplex/dataplexcommon"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -43,6 +44,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	ProjectID() string
 	GenerateDataQuality(ctx context.Context, location, resourcePath string, specJSON string, publish bool) (string, error)
 }
@@ -84,12 +86,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -100,12 +106,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	resourcePath, _ := paramsMap["resourcePath"].(string)
 	location, _ := paramsMap["location"].(string)

--- a/internal/tools/dataplex/dataplexcheckdataquality/dataplexcheckdataquality.go
+++ b/internal/tools/dataplex/dataplexcheckdataquality/dataplexcheckdataquality.go
@@ -88,6 +88,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/dataplex/dataplexcreatedataasset/dataplexcreatedataasset.go
+++ b/internal/tools/dataplex/dataplexcreatedataasset/dataplexcreatedataasset.go
@@ -101,6 +101,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/dataplex/dataplexcreatedataasset/dataplexcreatedataasset.go
+++ b/internal/tools/dataplex/dataplexcreatedataasset/dataplexcreatedataasset.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -42,6 +43,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	CreateDataAsset(
 		ctx context.Context,
 		locationID string,
@@ -97,12 +99,16 @@ type Tool struct {
 
 var _ tools.Tool = Tool{}
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -113,12 +119,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	locationID, ok := paramsMap["locationId"].(string)
 	if !ok || locationID == "" {

--- a/internal/tools/dataplex/dataplexcreatedataproduct/dataplexcreatedataproduct.go
+++ b/internal/tools/dataplex/dataplexcreatedataproduct/dataplexcreatedataproduct.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/sources/dataplex"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -43,6 +44,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	CreateDataProduct(
 		ctx context.Context,
 		locationId string,
@@ -115,12 +117,16 @@ type Tool struct {
 
 var _ tools.Tool = Tool{}
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -131,12 +137,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	prodLocID, ok := paramsMap["locationId"].(string)
 	if !ok || prodLocID == "" {

--- a/internal/tools/dataplex/dataplexcreatedataproduct/dataplexcreatedataproduct.go
+++ b/internal/tools/dataplex/dataplexcreatedataproduct/dataplexcreatedataproduct.go
@@ -119,6 +119,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/dataplex/dataplexdiscovermetadata/dataplexdiscovermetadata.go
+++ b/internal/tools/dataplex/dataplexdiscovermetadata/dataplexdiscovermetadata.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	"github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/tools/dataplex/dataplexcommon"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -43,6 +44,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	ProjectID() string
 	GenerateDataDiscovery(ctx context.Context, location, resourcePath string) (string, error)
 }
@@ -82,12 +84,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -98,12 +104,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	resourcePath, _ := paramsMap["resourcePath"].(string)
 	location, _ := paramsMap["location"].(string)

--- a/internal/tools/dataplex/dataplexdiscovermetadata/dataplexdiscovermetadata.go
+++ b/internal/tools/dataplex/dataplexdiscovermetadata/dataplexdiscovermetadata.go
@@ -86,6 +86,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/dataplex/dataplexgeneratedatainsights/dataplexgeneratedatainsights.go
+++ b/internal/tools/dataplex/dataplexgeneratedatainsights/dataplexgeneratedatainsights.go
@@ -87,6 +87,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/dataplex/dataplexgeneratedatainsights/dataplexgeneratedatainsights.go
+++ b/internal/tools/dataplex/dataplexgeneratedatainsights/dataplexgeneratedatainsights.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	"github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/tools/dataplex/dataplexcommon"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -43,6 +44,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	ProjectID() string
 	GenerateDataInsights(ctx context.Context, location, resourcePath string, publish bool) (string, error)
 }
@@ -83,12 +85,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -99,12 +105,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	resourcePath, _ := paramsMap["resourcePath"].(string)
 	location, _ := paramsMap["location"].(string)

--- a/internal/tools/dataplex/dataplexgeneratedataprofile/dataplexgeneratedataprofile.go
+++ b/internal/tools/dataplex/dataplexgeneratedataprofile/dataplexgeneratedataprofile.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	"github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/tools/dataplex/dataplexcommon"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -43,6 +44,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	ProjectID() string
 	GenerateDataProfile(ctx context.Context, location, resourcePath string, publish bool) (string, error)
 }
@@ -83,12 +85,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -99,12 +105,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	resourcePath, _ := paramsMap["resourcePath"].(string)
 	location, _ := paramsMap["location"].(string)

--- a/internal/tools/dataplex/dataplexgeneratedataprofile/dataplexgeneratedataprofile.go
+++ b/internal/tools/dataplex/dataplexgeneratedataprofile/dataplexgeneratedataprofile.go
@@ -87,6 +87,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/dataplex/dataplexgetdataasset/dataplexgetdataasset.go
+++ b/internal/tools/dataplex/dataplexgetdataasset/dataplexgetdataasset.go
@@ -90,6 +90,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/dataplex/dataplexgetdataasset/dataplexgetdataasset.go
+++ b/internal/tools/dataplex/dataplexgetdataasset/dataplexgetdataasset.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/sources/dataplex"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -43,6 +44,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	GetDataAsset(ctx context.Context, locationId string, dataProductId string, dataAssetId string) (*dataplex.DataAsset, error)
 }
 
@@ -86,12 +88,16 @@ type Tool struct {
 
 var _ tools.Tool = Tool{}
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -102,12 +108,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	locationId, ok := paramsMap["locationId"].(string)
 	if !ok || locationId == "" {

--- a/internal/tools/dataplex/dataplexgetdatainsights/dataplexgetdatainsights.go
+++ b/internal/tools/dataplex/dataplexgetdatainsights/dataplexgetdatainsights.go
@@ -88,6 +88,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/dataplex/dataplexgetdatainsights/dataplexgetdatainsights.go
+++ b/internal/tools/dataplex/dataplexgetdatainsights/dataplexgetdatainsights.go
@@ -22,6 +22,7 @@ import (
 
 	"cloud.google.com/go/dataplex/apiv1/dataplexpb"
 	"github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -45,6 +46,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	ProjectID() string
 	GetDataScan(ctx context.Context, location, scanID string) (*dataplexpb.DataScan, error)
 }
@@ -84,12 +86,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -100,12 +106,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	scanId, _ := paramsMap["scanId"].(string)
 	location, _ := paramsMap["location"].(string)

--- a/internal/tools/dataplex/dataplexgetdataproduct/dataplexgetdataproduct.go
+++ b/internal/tools/dataplex/dataplexgetdataproduct/dataplexgetdataproduct.go
@@ -90,6 +90,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/dataplex/dataplexgetdataproduct/dataplexgetdataproduct.go
+++ b/internal/tools/dataplex/dataplexgetdataproduct/dataplexgetdataproduct.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/sources/dataplex"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -43,6 +44,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	GetDataProduct(ctx context.Context, locationID string, dataProductID string) (*dataplex.DataProduct, error)
 }
 
@@ -86,12 +88,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -102,12 +108,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	locationID, ok := paramsMap["locationId"].(string)
 	if !ok || locationID == "" {

--- a/internal/tools/dataplex/dataplexgetdataprofile/dataplexgetdataprofile.go
+++ b/internal/tools/dataplex/dataplexgetdataprofile/dataplexgetdataprofile.go
@@ -88,6 +88,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/dataplex/dataplexgetdataprofile/dataplexgetdataprofile.go
+++ b/internal/tools/dataplex/dataplexgetdataprofile/dataplexgetdataprofile.go
@@ -22,6 +22,7 @@ import (
 
 	"cloud.google.com/go/dataplex/apiv1/dataplexpb"
 	"github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -45,6 +46,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	ProjectID() string
 	GetDataScan(ctx context.Context, location, scanID string) (*dataplexpb.DataScan, error)
 }
@@ -84,12 +86,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -100,12 +106,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	scanId, _ := paramsMap["scanId"].(string)
 	location, _ := paramsMap["location"].(string)

--- a/internal/tools/dataplex/dataplexgetdataqualityresults/dataplexgetdataqualityresults.go
+++ b/internal/tools/dataplex/dataplexgetdataqualityresults/dataplexgetdataqualityresults.go
@@ -88,6 +88,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/dataplex/dataplexgetdataqualityresults/dataplexgetdataqualityresults.go
+++ b/internal/tools/dataplex/dataplexgetdataqualityresults/dataplexgetdataqualityresults.go
@@ -22,6 +22,7 @@ import (
 
 	"cloud.google.com/go/dataplex/apiv1/dataplexpb"
 	"github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -45,6 +46,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	ProjectID() string
 	GetDataScan(ctx context.Context, location, scanID string) (*dataplexpb.DataScan, error)
 }
@@ -84,12 +86,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -100,12 +106,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	scanId, _ := paramsMap["scanId"].(string)
 	location, _ := paramsMap["location"].(string)

--- a/internal/tools/dataplex/dataplexgetdiscoveryresults/dataplexgetdiscoveryresults.go
+++ b/internal/tools/dataplex/dataplexgetdiscoveryresults/dataplexgetdiscoveryresults.go
@@ -88,6 +88,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/dataplex/dataplexgetdiscoveryresults/dataplexgetdiscoveryresults.go
+++ b/internal/tools/dataplex/dataplexgetdiscoveryresults/dataplexgetdiscoveryresults.go
@@ -22,6 +22,7 @@ import (
 
 	"cloud.google.com/go/dataplex/apiv1/dataplexpb"
 	"github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -45,6 +46,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	ProjectID() string
 	GetDataScan(ctx context.Context, location, scanID string) (*dataplexpb.DataScan, error)
 }
@@ -84,12 +86,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -100,12 +106,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	scanId, _ := paramsMap["scanId"].(string)
 	location, _ := paramsMap["location"].(string)

--- a/internal/tools/dataplex/dataplexgetoperation/dataplexgetoperation.go
+++ b/internal/tools/dataplex/dataplexgetoperation/dataplexgetoperation.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 
 	"github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -43,6 +44,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	GetOperation(ctx context.Context, opName string) (map[string]any, error)
 }
 
@@ -80,12 +82,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -96,12 +102,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	operationName, _ := paramsMap["operationName"].(string)
 

--- a/internal/tools/dataplex/dataplexgetoperation/dataplexgetoperation.go
+++ b/internal/tools/dataplex/dataplexgetoperation/dataplexgetoperation.go
@@ -84,6 +84,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/dataplex/dataplexgetrunstatus/dataplexgetrunstatus.go
+++ b/internal/tools/dataplex/dataplexgetrunstatus/dataplexgetrunstatus.go
@@ -89,6 +89,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/dataplex/dataplexgetrunstatus/dataplexgetrunstatus.go
+++ b/internal/tools/dataplex/dataplexgetrunstatus/dataplexgetrunstatus.go
@@ -22,6 +22,7 @@ import (
 
 	"cloud.google.com/go/dataplex/apiv1/dataplexpb"
 	"github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -45,6 +46,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	ProjectID() string
 	GetJobStatus(ctx context.Context, location, scanID, jobID string) (*dataplexpb.DataScanJob, error)
 }
@@ -85,12 +87,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -101,12 +107,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	scanId, _ := paramsMap["scanId"].(string)
 	location, _ := paramsMap["location"].(string)

--- a/internal/tools/dataplex/dataplexlistdataassets/dataplexlistdataassets.go
+++ b/internal/tools/dataplex/dataplexlistdataassets/dataplexlistdataassets.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/sources/dataplex"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -43,6 +44,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	ListDataAssets(ctx context.Context, locationId string, dataProductId string, filter string, pageSize int, orderBy string) ([]*dataplex.DataAsset, error)
 }
 
@@ -102,12 +104,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -118,12 +124,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	locationId, ok := paramsMap["locationId"].(string)
 	if !ok || locationId == "" {

--- a/internal/tools/dataplex/dataplexlistdataassets/dataplexlistdataassets.go
+++ b/internal/tools/dataplex/dataplexlistdataassets/dataplexlistdataassets.go
@@ -106,6 +106,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/dataplex/dataplexlistdataproducts/dataplexlistdataproducts.go
+++ b/internal/tools/dataplex/dataplexlistdataproducts/dataplexlistdataproducts.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	"github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/sources/dataplex"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -43,6 +44,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	ListDataProducts(ctx context.Context, filter string, pageSize int, orderBy string) ([]*dataplex.DataProductSummary, error)
 }
 
@@ -99,12 +101,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -115,12 +121,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	filter, _ := paramsMap["filter"].(string)
 	pageSize, _ := paramsMap["pageSize"].(int)

--- a/internal/tools/dataplex/dataplexlistdataproducts/dataplexlistdataproducts.go
+++ b/internal/tools/dataplex/dataplexlistdataproducts/dataplexlistdataproducts.go
@@ -103,6 +103,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/dataplex/dataplexlookupcontext/dataplexlookupcontext.go
+++ b/internal/tools/dataplex/dataplexlookupcontext/dataplexlookupcontext.go
@@ -22,6 +22,7 @@ import (
 
 	"cloud.google.com/go/dataplex/apiv1/dataplexpb"
 	"github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -44,6 +45,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	LookupContext(context.Context, string, []string) (*dataplexpb.LookupContextResponse, error)
 	ProjectID() string
 }
@@ -89,12 +91,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -105,12 +111,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	resourcesSlice, err := parameters.ConvertAnySliceToTyped(paramsMap["resources"].([]any), "string")
 	if err != nil {

--- a/internal/tools/dataplex/dataplexlookupcontext/dataplexlookupcontext.go
+++ b/internal/tools/dataplex/dataplexlookupcontext/dataplexlookupcontext.go
@@ -93,6 +93,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/dataplex/dataplexlookupentry/dataplexlookupentry.go
+++ b/internal/tools/dataplex/dataplexlookupentry/dataplexlookupentry.go
@@ -22,6 +22,7 @@ import (
 
 	dataplexpb "cloud.google.com/go/dataplex/apiv1/dataplexpb"
 	"github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -44,6 +45,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	LookupEntry(context.Context, string, int, []string, string) (*dataplexpb.Entry, error)
 }
 
@@ -100,12 +102,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -116,12 +122,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	entry, _ := paramsMap["entry"].(string)
 	view, _ := paramsMap["view"].(int)

--- a/internal/tools/dataplex/dataplexlookupentry/dataplexlookupentry.go
+++ b/internal/tools/dataplex/dataplexlookupentry/dataplexlookupentry.go
@@ -104,6 +104,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/dataplex/dataplexsearchaspecttypes/dataplexsearchaspecttypes.go
+++ b/internal/tools/dataplex/dataplexsearchaspecttypes/dataplexsearchaspecttypes.go
@@ -87,6 +87,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/dataplex/dataplexsearchaspecttypes/dataplexsearchaspecttypes.go
+++ b/internal/tools/dataplex/dataplexsearchaspecttypes/dataplexsearchaspecttypes.go
@@ -21,6 +21,7 @@ import (
 
 	"cloud.google.com/go/dataplex/apiv1/dataplexpb"
 	"github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -43,6 +44,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	SearchAspectTypes(context.Context, string, int, string) ([]*dataplexpb.AspectType, error)
 }
 
@@ -83,12 +85,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -99,10 +105,10 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
 	paramsMap := params.AsMap()
 	query, ok := paramsMap["query"].(string)

--- a/internal/tools/dataplex/dataplexsearchdqscans/dataplexsearchdqscans.go
+++ b/internal/tools/dataplex/dataplexsearchdqscans/dataplexsearchdqscans.go
@@ -90,6 +90,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/dataplex/dataplexsearchdqscans/dataplexsearchdqscans.go
+++ b/internal/tools/dataplex/dataplexsearchdqscans/dataplexsearchdqscans.go
@@ -22,6 +22,7 @@ import (
 
 	"cloud.google.com/go/dataplex/apiv1/dataplexpb"
 	"github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -44,6 +45,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	SearchDataQualityScans(context.Context, string, int, string) ([]*dataplexpb.DataScan, error)
 }
 
@@ -86,12 +88,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -102,10 +108,10 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
 	paramsMap := params.AsMap()
 	filter, _ := paramsMap["filter"].(string)

--- a/internal/tools/dataplex/dataplexsearchentries/dataplexsearchentries.go
+++ b/internal/tools/dataplex/dataplexsearchentries/dataplexsearchentries.go
@@ -93,6 +93,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/dataplex/dataplexsearchentries/dataplexsearchentries.go
+++ b/internal/tools/dataplex/dataplexsearchentries/dataplexsearchentries.go
@@ -21,6 +21,7 @@ import (
 
 	"cloud.google.com/go/dataplex/apiv1/dataplexpb"
 	"github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -43,6 +44,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	SearchEntries(context.Context, string, int, string, string) ([]*dataplexpb.SearchEntriesResult, error)
 }
 
@@ -89,12 +91,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -105,10 +111,10 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
 	paramsMap := params.AsMap()
 	query, ok := paramsMap["query"].(string)

--- a/internal/tools/dataplex/dataplexupdatedataasset/dataplexupdatedataasset.go
+++ b/internal/tools/dataplex/dataplexupdatedataasset/dataplexupdatedataasset.go
@@ -101,6 +101,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/dataplex/dataplexupdatedataasset/dataplexupdatedataasset.go
+++ b/internal/tools/dataplex/dataplexupdatedataasset/dataplexupdatedataasset.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -42,6 +43,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UpdateDataAsset(
 		ctx context.Context,
 		locationId string,
@@ -97,12 +99,16 @@ type Tool struct {
 
 var _ tools.Tool = Tool{}
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -113,12 +119,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	locationId, ok := paramsMap["locationId"].(string)
 	if !ok || locationId == "" {

--- a/internal/tools/dataplex/dataplexupdatedataproduct/dataplexupdatedataproduct.go
+++ b/internal/tools/dataplex/dataplexupdatedataproduct/dataplexupdatedataproduct.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/sources/dataplex"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -43,6 +44,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UpdateDataProduct(
 		ctx context.Context,
 		locationId string,
@@ -123,12 +125,16 @@ type Tool struct {
 
 var _ tools.Tool = Tool{}
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -139,12 +145,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	locationId, ok := paramsMap["locationId"].(string)
 	if !ok || locationId == "" {

--- a/internal/tools/dataplex/dataplexupdatedataproduct/dataplexupdatedataproduct.go
+++ b/internal/tools/dataplex/dataplexupdatedataproduct/dataplexupdatedataproduct.go
@@ -127,6 +127,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/dataproc/dataprocgetcluster/dataprocgetcluster.go
+++ b/internal/tools/dataproc/dataprocgetcluster/dataprocgetcluster.go
@@ -87,12 +87,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -103,36 +107,33 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) validate(srcs map[string]sources.Source) error {
-	_, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	return err
+func (t Tool) GetParameters(source sources.Source) (parameters.Parameters, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return t.BaseTool.GetParameters(s)
 }
 
-func (t Tool) GetParameters(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	if err := t.validate(srcs); err != nil {
-		return nil, err
+func (t Tool) Manifest(source sources.Source) (tools.Manifest, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return tools.Manifest{}, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return t.BaseTool.GetParameters(srcs)
-}
-
-func (t Tool) Manifest(srcs map[string]sources.Source) (tools.Manifest, error) {
-	if err := t.validate(srcs); err != nil {
-		return tools.Manifest{}, err
-	}
-	return t.BaseTool.Manifest(srcs)
+	return t.BaseTool.Manifest(s)
 }
 
 type compatibleSource interface {
+	sources.Source
 	GetCluster(context.Context, string) (any, error)
 }
 
 // Invoke executes the tool's operation.
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, kind)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramMap := params.AsMap()
 	name, ok := paramMap["clusterName"].(string)
 	if !ok {

--- a/internal/tools/dataproc/dataprocgetcluster/dataprocgetcluster.go
+++ b/internal/tools/dataproc/dataprocgetcluster/dataprocgetcluster.go
@@ -91,6 +91,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) validate(srcs map[string]sources.Source) error {
 	_, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	return err

--- a/internal/tools/dataproc/dataprocgetjob/dataprocgetjob.go
+++ b/internal/tools/dataproc/dataprocgetjob/dataprocgetjob.go
@@ -90,6 +90,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) validate(srcs map[string]sources.Source) error {
 	_, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	return err

--- a/internal/tools/dataproc/dataprocgetjob/dataprocgetjob.go
+++ b/internal/tools/dataproc/dataprocgetjob/dataprocgetjob.go
@@ -86,12 +86,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -102,36 +106,33 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) validate(srcs map[string]sources.Source) error {
-	_, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	return err
+func (t Tool) GetParameters(source sources.Source) (parameters.Parameters, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return t.BaseTool.GetParameters(s)
 }
 
-func (t Tool) GetParameters(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	if err := t.validate(srcs); err != nil {
-		return nil, err
+func (t Tool) Manifest(source sources.Source) (tools.Manifest, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return tools.Manifest{}, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return t.BaseTool.GetParameters(srcs)
-}
-
-func (t Tool) Manifest(srcs map[string]sources.Source) (tools.Manifest, error) {
-	if err := t.validate(srcs); err != nil {
-		return tools.Manifest{}, err
-	}
-	return t.BaseTool.Manifest(srcs)
+	return t.BaseTool.Manifest(s)
 }
 
 type compatibleSource interface {
+	sources.Source
 	GetJob(context.Context, string) (any, error)
 }
 
 // Invoke executes the tool's operation.
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, kind)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramMap := params.AsMap()
 	jobId, ok := paramMap["jobId"].(string)
 	if !ok {

--- a/internal/tools/dataproc/dataproclistclusters/dataproclistclusters.go
+++ b/internal/tools/dataproc/dataproclistclusters/dataproclistclusters.go
@@ -92,6 +92,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) validate(srcs map[string]sources.Source) error {
 	_, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	return err

--- a/internal/tools/dataproc/dataproclistclusters/dataproclistclusters.go
+++ b/internal/tools/dataproc/dataproclistclusters/dataproclistclusters.go
@@ -88,12 +88,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -104,36 +108,33 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) validate(srcs map[string]sources.Source) error {
-	_, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	return err
+func (t Tool) GetParameters(source sources.Source) (parameters.Parameters, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return t.BaseTool.GetParameters(s)
 }
 
-func (t Tool) GetParameters(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	if err := t.validate(srcs); err != nil {
-		return nil, err
+func (t Tool) Manifest(source sources.Source) (tools.Manifest, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return tools.Manifest{}, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return t.BaseTool.GetParameters(srcs)
-}
-
-func (t Tool) Manifest(srcs map[string]sources.Source) (tools.Manifest, error) {
-	if err := t.validate(srcs); err != nil {
-		return tools.Manifest{}, err
-	}
-	return t.BaseTool.Manifest(srcs)
+	return t.BaseTool.Manifest(s)
 }
 
 type compatibleSource interface {
+	sources.Source
 	ListClusters(context.Context, *int, string, string) (any, error)
 }
 
 // Invoke executes the tool's operation.
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, kind)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramMap := params.AsMap()
 	var pageSize *int
 	if ps, ok := paramMap["pageSize"]; ok && ps != nil {

--- a/internal/tools/dataproc/dataproclistjobs/dataproclistjobs.go
+++ b/internal/tools/dataproc/dataproclistjobs/dataproclistjobs.go
@@ -89,12 +89,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -105,36 +109,33 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) validate(srcs map[string]sources.Source) error {
-	_, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	return err
+func (t Tool) GetParameters(source sources.Source) (parameters.Parameters, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return t.BaseTool.GetParameters(s)
 }
 
-func (t Tool) GetParameters(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	if err := t.validate(srcs); err != nil {
-		return nil, err
+func (t Tool) Manifest(source sources.Source) (tools.Manifest, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return tools.Manifest{}, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return t.BaseTool.GetParameters(srcs)
-}
-
-func (t Tool) Manifest(srcs map[string]sources.Source) (tools.Manifest, error) {
-	if err := t.validate(srcs); err != nil {
-		return tools.Manifest{}, err
-	}
-	return t.BaseTool.Manifest(srcs)
+	return t.BaseTool.Manifest(s)
 }
 
 type compatibleSource interface {
+	sources.Source
 	ListJobs(context.Context, *int, string, string, string) (any, error)
 }
 
 // Invoke executes the tool's operation.
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, kind)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramMap := params.AsMap()
 	var pageSize *int
 	if ps, ok := paramMap["pageSize"]; ok && ps != nil {

--- a/internal/tools/dataproc/dataproclistjobs/dataproclistjobs.go
+++ b/internal/tools/dataproc/dataproclistjobs/dataproclistjobs.go
@@ -93,6 +93,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) validate(srcs map[string]sources.Source) error {
 	_, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	return err

--- a/internal/tools/dgraph/dgraph.go
+++ b/internal/tools/dgraph/dgraph.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/sources/dgraph"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -43,6 +44,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	DgraphClient() *dgraph.DgraphClient
 	RunSQL(string, parameters.ParamValues, bool, string) (any, error)
 }
@@ -87,12 +89,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -103,10 +109,10 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
 	resp, err := source.RunSQL(t.Cfg.Statement, params, t.Cfg.IsQuery, t.Cfg.Timeout)
 	if err != nil {

--- a/internal/tools/dgraph/dgraph.go
+++ b/internal/tools/dgraph/dgraph.go
@@ -91,6 +91,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/elasticsearch/elasticsearchesql/elasticsearchesql.go
+++ b/internal/tools/elasticsearch/elasticsearchesql/elasticsearchesql.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
 
@@ -37,6 +38,7 @@ func init() {
 }
 
 type compatibleSource interface {
+	sources.Source
 	ElasticsearchClient() es.EsClient
 	RunSQL(ctx context.Context, format, query string, params []map[string]any) (any, error)
 }
@@ -87,12 +89,16 @@ func (c Config) Initialize(context.Context) (tools.Tool, error) {
 	}, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -103,12 +109,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	var cancel context.CancelFunc
 	if t.Cfg.Timeout > 0 {
 		ctx, cancel = context.WithTimeout(ctx, time.Duration(t.Cfg.Timeout)*time.Second)

--- a/internal/tools/elasticsearch/elasticsearchesql/elasticsearchesql.go
+++ b/internal/tools/elasticsearch/elasticsearchesql/elasticsearchesql.go
@@ -91,6 +91,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/elasticsearch/elasticsearchexecuteesql/elasticsearchexecuteesql.go
+++ b/internal/tools/elasticsearch/elasticsearchexecuteesql/elasticsearchexecuteesql.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	es "github.com/googleapis/mcp-toolbox/internal/sources/elasticsearch"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -43,6 +44,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	ElasticsearchClient() es.EsClient
 	RunSQL(ctx context.Context, format, query string, params []map[string]any) (any, error)
 }
@@ -85,12 +87,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -101,12 +107,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	query, ok := paramsMap["query"].(string)
 	if !ok {

--- a/internal/tools/elasticsearch/elasticsearchexecuteesql/elasticsearchexecuteesql.go
+++ b/internal/tools/elasticsearch/elasticsearchexecuteesql/elasticsearchexecuteesql.go
@@ -89,6 +89,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/firebird/firebirdexecutesql/firebirdexecutesql.go
+++ b/internal/tools/firebird/firebirdexecutesql/firebirdexecutesql.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -43,6 +44,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	FirebirdDB() *sql.DB
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -84,12 +86,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -100,12 +106,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	sqlStr, ok := paramsMap["sql"].(string)
 	if !ok {

--- a/internal/tools/firebird/firebirdexecutesql/firebirdexecutesql.go
+++ b/internal/tools/firebird/firebirdexecutesql/firebirdexecutesql.go
@@ -88,6 +88,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/firebird/firebirdsql/firebirdsql.go
+++ b/internal/tools/firebird/firebirdsql/firebirdsql.go
@@ -96,6 +96,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/firebird/firebirdsql/firebirdsql.go
+++ b/internal/tools/firebird/firebirdsql/firebirdsql.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -44,6 +45,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	FirebirdDB() *sql.DB
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -92,12 +94,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -108,12 +114,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	statement, err := parameters.ResolveTemplateParams(t.Cfg.TemplateParameters, t.Cfg.Statement, paramsMap)
 	if err != nil {

--- a/internal/tools/firestore/firestoreadddocuments/firestoreadddocuments.go
+++ b/internal/tools/firestore/firestoreadddocuments/firestoreadddocuments.go
@@ -21,6 +21,7 @@ import (
 
 	firestoreapi "cloud.google.com/go/firestore"
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	fsUtil "github.com/googleapis/mcp-toolbox/internal/tools/firestore/util"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -47,6 +48,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	FirestoreClient() *firestoreapi.Client
 	AddDocuments(context.Context, string, any, bool) (map[string]any, error)
 }
@@ -121,12 +123,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -137,12 +143,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	mapParams := params.AsMap()
 	// Get collection path
 	collectionPath, ok := mapParams[collectionPathKey].(string)

--- a/internal/tools/firestore/firestoreadddocuments/firestoreadddocuments.go
+++ b/internal/tools/firestore/firestoreadddocuments/firestoreadddocuments.go
@@ -125,6 +125,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/firestore/firestoredeletedocuments/firestoredeletedocuments.go
+++ b/internal/tools/firestore/firestoredeletedocuments/firestoredeletedocuments.go
@@ -21,6 +21,7 @@ import (
 
 	firestoreapi "cloud.google.com/go/firestore"
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	fsUtil "github.com/googleapis/mcp-toolbox/internal/tools/firestore/util"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -45,6 +46,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	FirestoreClient() *firestoreapi.Client
 	DeleteDocuments(context.Context, []string) ([]any, error)
 }
@@ -88,12 +90,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -104,12 +110,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	mapParams := params.AsMap()
 	documentPathsRaw, ok := mapParams[documentPathsKey].([]any)
 	if !ok {

--- a/internal/tools/firestore/firestoredeletedocuments/firestoredeletedocuments.go
+++ b/internal/tools/firestore/firestoredeletedocuments/firestoredeletedocuments.go
@@ -92,6 +92,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/firestore/firestoregetdocuments/firestoregetdocuments.go
+++ b/internal/tools/firestore/firestoregetdocuments/firestoregetdocuments.go
@@ -21,6 +21,7 @@ import (
 
 	firestoreapi "cloud.google.com/go/firestore"
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	fsUtil "github.com/googleapis/mcp-toolbox/internal/tools/firestore/util"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -45,6 +46,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	FirestoreClient() *firestoreapi.Client
 	GetDocuments(context.Context, []string) ([]any, error)
 }
@@ -88,12 +90,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -104,12 +110,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	mapParams := params.AsMap()
 	documentPathsRaw, ok := mapParams[documentPathsKey].([]any)
 	if !ok {

--- a/internal/tools/firestore/firestoregetdocuments/firestoregetdocuments.go
+++ b/internal/tools/firestore/firestoregetdocuments/firestoregetdocuments.go
@@ -92,6 +92,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/firestore/firestoregetrules/firestoregetrules.go
+++ b/internal/tools/firestore/firestoregetrules/firestoregetrules.go
@@ -90,6 +90,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/firestore/firestoregetrules/firestoregetrules.go
+++ b/internal/tools/firestore/firestoregetrules/firestoregetrules.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -43,6 +44,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	FirebaseRulesClient() *firebaserules.Service
 	GetRules(context.Context) (any, error)
 }
@@ -86,12 +88,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -102,10 +108,10 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
 	resp, err := source.GetRules(ctx)
 	if err != nil {

--- a/internal/tools/firestore/firestorelistcollections/firestorelistcollections.go
+++ b/internal/tools/firestore/firestorelistcollections/firestorelistcollections.go
@@ -93,6 +93,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/firestore/firestorelistcollections/firestorelistcollections.go
+++ b/internal/tools/firestore/firestorelistcollections/firestorelistcollections.go
@@ -21,6 +21,7 @@ import (
 
 	firestoreapi "cloud.google.com/go/firestore"
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	fsUtil "github.com/googleapis/mcp-toolbox/internal/tools/firestore/util"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -45,6 +46,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	FirestoreClient() *firestoreapi.Client
 	ListCollections(context.Context, string) ([]any, error)
 }
@@ -89,12 +91,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -105,12 +111,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	mapParams := params.AsMap()
 
 	// Check if parentPath is provided

--- a/internal/tools/firestore/firestorequery/firestorequery.go
+++ b/internal/tools/firestore/firestorequery/firestorequery.go
@@ -117,6 +117,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 // OrderByConfig represents ordering configuration
 type OrderByConfig struct {
 	Field     string `json:"field"`

--- a/internal/tools/firestore/firestorequery/firestorequery.go
+++ b/internal/tools/firestore/firestorequery/firestorequery.go
@@ -24,6 +24,7 @@ import (
 
 	firestoreapi "cloud.google.com/go/firestore"
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	fsUtil "github.com/googleapis/mcp-toolbox/internal/tools/firestore/util"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -52,6 +53,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 
 // compatibleSource defines the interface for sources that can provide a Firestore client
 type compatibleSource interface {
+	sources.Source
 	FirestoreClient() *firestoreapi.Client
 	BuildQuery(string, firestoreapi.EntityFilter, []string, string, firestoreapi.Direction, int, bool) (*firestoreapi.Query, error)
 	ExecuteQuery(context.Context, *firestoreapi.Query, bool) (any, error)
@@ -113,12 +115,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -167,10 +173,10 @@ var validOperators = map[string]bool{
 }
 
 // Invoke executes the Firestore query based on the provided parameters
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
 	paramsMap := params.AsMap()
 	// Process collection path with template substitution

--- a/internal/tools/firestore/firestorequerycollection/firestorequerycollection.go
+++ b/internal/tools/firestore/firestorequerycollection/firestorequerycollection.go
@@ -23,6 +23,7 @@ import (
 
 	firestoreapi "cloud.google.com/go/firestore"
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	fsUtil "github.com/googleapis/mcp-toolbox/internal/tools/firestore/util"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -88,6 +89,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 
 // compatibleSource defines the interface for sources that can provide a Firestore client
 type compatibleSource interface {
+	sources.Source
 	FirestoreClient() *firestoreapi.Client
 	BuildQuery(string, firestoreapi.EntityFilter, []string, string, firestoreapi.Direction, int, bool) (*firestoreapi.Query, error)
 	ExecuteQuery(context.Context, *firestoreapi.Query, bool) (any, error)
@@ -128,12 +130,16 @@ func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
 	}, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -238,12 +244,11 @@ func (o *OrderByConfig) GetDirection() firestoreapi.Direction {
 }
 
 // Invoke executes the Firestore query based on the provided parameters
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	// Parse parameters
 	queryParams, err := t.parseQueryParameters(params)
 	if err != nil {

--- a/internal/tools/firestore/firestorequerycollection/firestorequerycollection.go
+++ b/internal/tools/firestore/firestorequerycollection/firestorequerycollection.go
@@ -132,6 +132,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 // createParameters creates the parameter definitions for the tool
 func createParameters() parameters.Parameters {
 	collectionPathParameter := parameters.NewStringParameter(

--- a/internal/tools/firestore/firestoreupdatedocument/firestoreupdatedocument.go
+++ b/internal/tools/firestore/firestoreupdatedocument/firestoreupdatedocument.go
@@ -22,6 +22,7 @@ import (
 
 	firestoreapi "cloud.google.com/go/firestore"
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	fsUtil "github.com/googleapis/mcp-toolbox/internal/tools/firestore/util"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -49,6 +50,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	FirestoreClient() *firestoreapi.Client
 	UpdateDocument(context.Context, string, []firestoreapi.Update, any, bool) (map[string]any, error)
 }
@@ -130,12 +132,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -146,12 +152,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	mapParams := params.AsMap()
 
 	// Get document path
@@ -189,6 +194,7 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	// Use selective field update with update mask
 	updates := make([]firestoreapi.Update, 0, len(updatePaths))
 	var documentData any
+	var err error
 	if len(updatePaths) > 0 {
 
 		// Convert document data without delete markers

--- a/internal/tools/firestore/firestoreupdatedocument/firestoreupdatedocument.go
+++ b/internal/tools/firestore/firestoreupdatedocument/firestoreupdatedocument.go
@@ -134,6 +134,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/firestore/firestorevalidaterules/firestorevalidaterules.go
+++ b/internal/tools/firestore/firestorevalidaterules/firestorevalidaterules.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -48,6 +49,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	FirebaseRulesClient() *firebaserules.Service
 	ValidateRules(context.Context, string) (any, error)
 }
@@ -101,12 +103,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -117,12 +123,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	mapParams := params.AsMap()
 
 	// Get source parameter

--- a/internal/tools/firestore/firestorevalidaterules/firestorevalidaterules.go
+++ b/internal/tools/firestore/firestorevalidaterules/firestorevalidaterules.go
@@ -105,6 +105,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/http/http.go
+++ b/internal/tools/http/http.go
@@ -118,6 +118,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 // Helper function to generate the HTTP request body upon Tool invocation.
 func getRequestBody(bodyParams parameters.Parameters, requestBodyPayload string, paramsMap map[string]any) (string, error) {
 	bodyParamValues, err := parameters.GetParams(bodyParams, paramsMap)

--- a/internal/tools/http/http.go
+++ b/internal/tools/http/http.go
@@ -25,6 +25,7 @@ import (
 	"text/template"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -47,6 +48,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	HttpDefaultHeaders() map[string]string
 	HttpBaseURL() string
 	HttpQueryParams() map[string]string
@@ -114,12 +116,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -267,12 +273,11 @@ func getHeaders(headerParams parameters.Parameters, defaultHeaders map[string]st
 	return allHeaders, nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	// Combine Source and Tool headers.
 	// In case of conflict, Tool header overrides Source header
 	combinedHeaders := make(map[string]string)

--- a/internal/tools/looker/lookeradddashboardelement/lookeradddashboardelement.go
+++ b/internal/tools/looker/lookeradddashboardelement/lookeradddashboardelement.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/tools/looker/lookercommon"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -46,6 +47,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
 	LookerApiSettings() *rtl.ApiSettings
@@ -117,12 +119,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -138,12 +144,11 @@ var (
 	visType  string = "vis"
 )
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, util.NewClientServerError("unable to get logger from ctx", http.StatusInternalServerError, err)
@@ -270,18 +275,18 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return data, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookeradddashboardelement/lookeradddashboardelement.go
+++ b/internal/tools/looker/lookeradddashboardelement/lookeradddashboardelement.go
@@ -121,6 +121,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 var (
 	dataType string = "data"
 	visType  string = "vis"

--- a/internal/tools/looker/lookeradddashboardfilter/lookeradddashboardfilter.go
+++ b/internal/tools/looker/lookeradddashboardfilter/lookeradddashboardfilter.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -45,6 +46,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
 	LookerApiSettings() *rtl.ApiSettings
@@ -111,12 +113,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -127,12 +133,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, util.NewClientServerError("unable to get logger from ctx", http.StatusInternalServerError, err)
@@ -231,18 +236,18 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return data, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookeradddashboardfilter/lookeradddashboardfilter.go
+++ b/internal/tools/looker/lookeradddashboardfilter/lookeradddashboardfilter.go
@@ -115,6 +115,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/looker/lookerconversationalanalytics/lookerconversationalanalytics.go
+++ b/internal/tools/looker/lookerconversationalanalytics/lookerconversationalanalytics.go
@@ -184,6 +184,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 // parseExploreReferences converts the raw explore_references parameter into typed
 // references. The parameter is declared as an array of free-form maps, so the values
 // the model supplies are not schema-validated; guard every field access instead of

--- a/internal/tools/looker/lookerconversationalanalytics/lookerconversationalanalytics.go
+++ b/internal/tools/looker/lookerconversationalanalytics/lookerconversationalanalytics.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -57,6 +58,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	GoogleCloudTokenSourceWithScope(ctx context.Context, scope string) (oauth2.TokenSource, error)
 	GoogleCloudProject() string
 	GoogleCloudLocation() string
@@ -180,12 +182,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -225,12 +231,11 @@ func parseExploreReferences(raw []any, lookerInstanceURI string) ([]LookerExplor
 	return refs, nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, util.NewClientServerError("unable to get logger from ctx", http.StatusInternalServerError, err)
@@ -323,12 +328,12 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return response, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
 // StreamMessage represents a single message object from the streaming API response.
@@ -570,10 +575,10 @@ func appendMessage(messages []map[string]any, newMessage map[string]any) []map[s
 	return append(messages, newMessage)
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookercreateagent/lookercreateagent.go
+++ b/internal/tools/looker/lookercreateagent/lookercreateagent.go
@@ -115,6 +115,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/looker/lookercreateagent/lookercreateagent.go
+++ b/internal/tools/looker/lookercreateagent/lookercreateagent.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -45,6 +46,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
 	LookerApiSettings() *rtl.ApiSettings
@@ -111,12 +113,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -127,12 +133,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, util.NewClientServerError("unable to get logger from ctx", http.StatusInternalServerError, err)
@@ -212,18 +217,18 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookercreateagent/lookercreateagent_test.go
+++ b/internal/tools/looker/lookercreateagent/lookercreateagent_test.go
@@ -132,15 +132,6 @@ func (m MockSource) GetLookerSDK(ctx context.Context, s string) (*v4.LookerSDK, 
 	return &v4.LookerSDK{}, nil
 }
 
-type MockSourceProvider struct {
-	tools.SourceProvider
-	source MockSource
-}
-
-func (m MockSourceProvider) GetSource(name string) (sources.Source, bool) {
-	return m.source, true
-}
-
 func TestInvokeValidation(t *testing.T) {
 	ctx, err := testutils.ContextWithNewLogger()
 	if err != nil {
@@ -160,8 +151,7 @@ func TestInvokeValidation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to initialize tool: %v", err)
 	}
-
-	primitiveMgr := MockSourceProvider{source: MockSource{}}
+	src := MockSource{}
 
 	tcs := []struct {
 		desc    string
@@ -193,7 +183,7 @@ func TestInvokeValidation(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
-			_, err := tool.Invoke(ctx, primitiveMgr, tc.params, "")
+			_, err := tool.Invoke(ctx, src, tc.params, "")
 			if err == nil {
 				t.Fatalf("expect error, got nil")
 			}

--- a/internal/tools/looker/lookercreategitbranch/lookercreategitbranch.go
+++ b/internal/tools/looker/lookercreategitbranch/lookercreategitbranch.go
@@ -104,6 +104,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/looker/lookercreategitbranch/lookercreategitbranch.go
+++ b/internal/tools/looker/lookercreategitbranch/lookercreategitbranch.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -45,6 +46,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
 	LookerApiSettings() *rtl.ApiSettings
@@ -100,12 +102,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -116,12 +122,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	sdk, err := source.GetLookerSDK(ctx, string(accessToken))
 	if err != nil {
 		return nil, util.NewClientServerError(fmt.Sprintf("error getting sdk: %v", err), http.StatusInternalServerError, err)
@@ -151,18 +156,18 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookercreateprojectdirectory/lookercreateprojectdirectory.go
+++ b/internal/tools/looker/lookercreateprojectdirectory/lookercreateprojectdirectory.go
@@ -97,6 +97,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/looker/lookercreateprojectdirectory/lookercreateprojectdirectory.go
+++ b/internal/tools/looker/lookercreateprojectdirectory/lookercreateprojectdirectory.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/tools/looker/lookercommon"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -46,6 +47,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
 	LookerApiSettings() *rtl.ApiSettings
@@ -93,12 +95,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -109,12 +115,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	sdk, err := source.GetLookerSDK(ctx, string(accessToken))
 	if err != nil {
 		return nil, util.NewClientServerError("error getting sdk", http.StatusInternalServerError, err)
@@ -141,18 +146,18 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return fmt.Sprintf("Created directory %s in project %s", directoryPath, projectId), nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookercreateprojectfile/lookercreateprojectfile.go
+++ b/internal/tools/looker/lookercreateprojectfile/lookercreateprojectfile.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/tools/looker/lookercommon"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -46,6 +47,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
 	LookerApiSettings() *rtl.ApiSettings
@@ -94,12 +96,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -110,12 +116,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	sdk, err := source.GetLookerSDK(ctx, string(accessToken))
 	if err != nil {
 		return nil, util.NewClientServerError("error getting sdk", http.StatusInternalServerError, err)
@@ -155,18 +160,18 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return data, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookercreateprojectfile/lookercreateprojectfile.go
+++ b/internal/tools/looker/lookercreateprojectfile/lookercreateprojectfile.go
@@ -98,6 +98,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/looker/lookercreateviewfromtable/lookercreateviewfromtable.go
+++ b/internal/tools/looker/lookercreateviewfromtable/lookercreateviewfromtable.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/tools/looker/lookercommon"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -46,6 +47,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
 	LookerApiSettings() *rtl.ApiSettings
@@ -105,12 +107,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -121,12 +127,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, util.NewClientServerError(fmt.Sprintf("error getting logger from context: %s", err), http.StatusInternalServerError, err)
@@ -236,18 +241,18 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	}, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookercreateviewfromtable/lookercreateviewfromtable.go
+++ b/internal/tools/looker/lookercreateviewfromtable/lookercreateviewfromtable.go
@@ -109,6 +109,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/looker/lookerdeleteagent/lookerdeleteagent.go
+++ b/internal/tools/looker/lookerdeleteagent/lookerdeleteagent.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -45,6 +46,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
 	LookerApiSettings() *rtl.ApiSettings
@@ -99,12 +101,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -115,12 +121,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, util.NewClientServerError("unable to get logger from ctx", http.StatusInternalServerError, err)
@@ -153,18 +158,18 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookerdeleteagent/lookerdeleteagent.go
+++ b/internal/tools/looker/lookerdeleteagent/lookerdeleteagent.go
@@ -103,6 +103,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/looker/lookerdeleteagent/lookerdeleteagent_test.go
+++ b/internal/tools/looker/lookerdeleteagent/lookerdeleteagent_test.go
@@ -132,15 +132,6 @@ func (m MockSource) GetLookerSDK(ctx context.Context, s string) (*v4.LookerSDK, 
 	return &v4.LookerSDK{}, nil
 }
 
-type MockSourceProvider struct {
-	tools.SourceProvider
-	source MockSource
-}
-
-func (m MockSourceProvider) GetSource(name string) (sources.Source, bool) {
-	return m.source, true
-}
-
 func TestInvokeValidation(t *testing.T) {
 	ctx, err := testutils.ContextWithNewLogger()
 	if err != nil {
@@ -160,8 +151,7 @@ func TestInvokeValidation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to initialize tool: %v", err)
 	}
-
-	primitiveMgr := MockSourceProvider{source: MockSource{}}
+	src := MockSource{}
 
 	tcs := []struct {
 		desc    string
@@ -177,7 +167,7 @@ func TestInvokeValidation(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
-			_, err := tool.Invoke(ctx, primitiveMgr, tc.params, "")
+			_, err := tool.Invoke(ctx, src, tc.params, "")
 			if err == nil {
 				t.Fatalf("expect error, got nil")
 			}

--- a/internal/tools/looker/lookerdeletegitbranch/lookerdeletegitbranch.go
+++ b/internal/tools/looker/lookerdeletegitbranch/lookerdeletegitbranch.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -45,6 +46,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
 	LookerApiSettings() *rtl.ApiSettings
@@ -101,12 +103,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -117,12 +123,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	sdk, err := source.GetLookerSDK(ctx, string(accessToken))
 	if err != nil {
 		return nil, util.NewClientServerError(fmt.Sprintf("error getting sdk: %v", err), http.StatusInternalServerError, err)
@@ -145,18 +150,18 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return fmt.Sprintf("Deleted branch %s", branch), nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookerdeletegitbranch/lookerdeletegitbranch.go
+++ b/internal/tools/looker/lookerdeletegitbranch/lookerdeletegitbranch.go
@@ -105,6 +105,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/looker/lookerdeleteprojectdirectory/lookerdeleteprojectdirectory.go
+++ b/internal/tools/looker/lookerdeleteprojectdirectory/lookerdeleteprojectdirectory.go
@@ -97,6 +97,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/looker/lookerdeleteprojectdirectory/lookerdeleteprojectdirectory.go
+++ b/internal/tools/looker/lookerdeleteprojectdirectory/lookerdeleteprojectdirectory.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/tools/looker/lookercommon"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -46,6 +47,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
 	LookerApiSettings() *rtl.ApiSettings
@@ -93,12 +95,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -109,12 +115,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	sdk, err := source.GetLookerSDK(ctx, string(accessToken))
 	if err != nil {
 		return nil, util.NewClientServerError("error getting sdk", http.StatusInternalServerError, err)
@@ -141,18 +146,18 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return fmt.Sprintf("Deleted directory %s in project %s", directoryPath, projectId), nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookerdeleteprojectfile/lookerdeleteprojectfile.go
+++ b/internal/tools/looker/lookerdeleteprojectfile/lookerdeleteprojectfile.go
@@ -97,6 +97,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/looker/lookerdeleteprojectfile/lookerdeleteprojectfile.go
+++ b/internal/tools/looker/lookerdeleteprojectfile/lookerdeleteprojectfile.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/tools/looker/lookercommon"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -46,6 +47,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
 	LookerApiSettings() *rtl.ApiSettings
@@ -93,12 +95,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -109,12 +115,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	sdk, err := source.GetLookerSDK(ctx, string(accessToken))
 	if err != nil {
 		return nil, util.NewClientServerError("error getting sdk", http.StatusInternalServerError, err)
@@ -145,18 +150,18 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return data, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookerdevmode/lookerdevmode.go
+++ b/internal/tools/looker/lookerdevmode/lookerdevmode.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -45,6 +46,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
 	LookerApiSettings() *rtl.ApiSettings
@@ -88,12 +90,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -104,12 +110,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, util.NewClientServerError("unable to get logger from ctx", http.StatusInternalServerError, err)
@@ -145,18 +150,18 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookerdevmode/lookerdevmode.go
+++ b/internal/tools/looker/lookerdevmode/lookerdevmode.go
@@ -92,6 +92,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/looker/lookergenerateembedurl/lookergenerateembedurl.go
+++ b/internal/tools/looker/lookergenerateembedurl/lookergenerateembedurl.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -46,6 +47,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
 	LookerApiSettings() *rtl.ApiSettings
@@ -98,12 +100,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -114,12 +120,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, util.NewClientServerError("unable to get logger from ctx", http.StatusInternalServerError, err)
@@ -166,18 +171,18 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookergenerateembedurl/lookergenerateembedurl.go
+++ b/internal/tools/looker/lookergenerateembedurl/lookergenerateembedurl.go
@@ -102,6 +102,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/looker/lookergetagent/lookergetagent.go
+++ b/internal/tools/looker/lookergetagent/lookergetagent.go
@@ -101,6 +101,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/looker/lookergetagent/lookergetagent.go
+++ b/internal/tools/looker/lookergetagent/lookergetagent.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -45,6 +46,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
 	LookerApiSettings() *rtl.ApiSettings
@@ -97,12 +99,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -113,12 +119,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, util.NewClientServerError("unable to get logger from ctx", http.StatusInternalServerError, err)
@@ -151,18 +156,18 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookergetagent/lookergetagent_test.go
+++ b/internal/tools/looker/lookergetagent/lookergetagent_test.go
@@ -132,15 +132,6 @@ func (m MockSource) GetLookerSDK(ctx context.Context, s string) (*v4.LookerSDK, 
 	return &v4.LookerSDK{}, nil
 }
 
-type MockSourceProvider struct {
-	tools.SourceProvider
-	source MockSource
-}
-
-func (m MockSourceProvider) GetSource(name string) (sources.Source, bool) {
-	return m.source, true
-}
-
 func TestInvokeValidation(t *testing.T) {
 	ctx, err := testutils.ContextWithNewLogger()
 	if err != nil {
@@ -160,8 +151,7 @@ func TestInvokeValidation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to initialize tool: %v", err)
 	}
-
-	primitiveMgr := MockSourceProvider{source: MockSource{}}
+	src := MockSource{}
 
 	tcs := []struct {
 		desc    string
@@ -177,7 +167,7 @@ func TestInvokeValidation(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
-			_, err := tool.Invoke(ctx, primitiveMgr, tc.params, "")
+			_, err := tool.Invoke(ctx, src, tc.params, "")
 			if err == nil {
 				t.Fatalf("expect error, got nil")
 			}

--- a/internal/tools/looker/lookergetconnectiondatabases/lookergetconnectiondatabases.go
+++ b/internal/tools/looker/lookergetconnectiondatabases/lookergetconnectiondatabases.go
@@ -95,6 +95,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/looker/lookergetconnectiondatabases/lookergetconnectiondatabases.go
+++ b/internal/tools/looker/lookergetconnectiondatabases/lookergetconnectiondatabases.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -45,6 +46,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
 	LookerApiSettings() *rtl.ApiSettings
@@ -91,12 +93,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -107,12 +113,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	mapParams := params.AsMap()
 	conn, ok := mapParams["conn"].(string)
 	if !ok {
@@ -134,18 +139,18 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookergetconnections/lookergetconnections.go
+++ b/internal/tools/looker/lookergetconnections/lookergetconnections.go
@@ -21,6 +21,7 @@ import (
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -46,6 +47,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
 	LookerApiSettings() *rtl.ApiSettings
@@ -91,12 +93,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -107,12 +113,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, util.NewClientServerError("unable to get logger from ctx", http.StatusInternalServerError, err)
@@ -158,18 +163,18 @@ func (t Tool) EmbedParams(ctx context.Context, paramValues parameters.ParamValue
 	return parameters.ParamValues{}, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookergetconnections/lookergetconnections.go
+++ b/internal/tools/looker/lookergetconnections/lookergetconnections.go
@@ -95,6 +95,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/looker/lookergetconnectionschemas/lookergetconnectionschemas.go
+++ b/internal/tools/looker/lookergetconnectionschemas/lookergetconnectionschemas.go
@@ -96,6 +96,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/looker/lookergetconnectionschemas/lookergetconnectionschemas.go
+++ b/internal/tools/looker/lookergetconnectionschemas/lookergetconnectionschemas.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -45,6 +46,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
 	LookerApiSettings() *rtl.ApiSettings
@@ -92,12 +94,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -108,12 +114,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	mapParams := params.AsMap()
 	conn, ok := mapParams["conn"].(string)
 	if !ok {
@@ -141,18 +146,18 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookergetconnectiontablecolumns/lookergetconnectiontablecolumns.go
+++ b/internal/tools/looker/lookergetconnectiontablecolumns/lookergetconnectiontablecolumns.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -45,6 +46,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
 	LookerApiSettings() *rtl.ApiSettings
@@ -94,12 +96,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -110,12 +116,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, util.NewClientServerError("unable to get logger from ctx", http.StatusInternalServerError, err)
@@ -177,18 +182,18 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return data, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookergetconnectiontablecolumns/lookergetconnectiontablecolumns.go
+++ b/internal/tools/looker/lookergetconnectiontablecolumns/lookergetconnectiontablecolumns.go
@@ -98,6 +98,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/looker/lookergetconnectiontables/lookergetconnectiontables.go
+++ b/internal/tools/looker/lookergetconnectiontables/lookergetconnectiontables.go
@@ -97,6 +97,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/looker/lookergetconnectiontables/lookergetconnectiontables.go
+++ b/internal/tools/looker/lookergetconnectiontables/lookergetconnectiontables.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -45,6 +46,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
 	LookerApiSettings() *rtl.ApiSettings
@@ -93,12 +95,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -109,12 +115,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, util.NewClientServerError("unable to get logger from ctx", http.StatusInternalServerError, err)
@@ -168,18 +173,18 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return data, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookergetdashboards/lookergetdashboards.go
+++ b/internal/tools/looker/lookergetdashboards/lookergetdashboards.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -45,6 +46,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
 	LookerApiSettings() *rtl.ApiSettings
@@ -99,12 +101,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -115,12 +121,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, util.NewClientServerError("unable to get logger from ctx", http.StatusInternalServerError, err)
@@ -179,18 +184,18 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return data, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookergetdashboards/lookergetdashboards.go
+++ b/internal/tools/looker/lookergetdashboards/lookergetdashboards.go
@@ -103,6 +103,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/looker/lookergetdimensions/lookergetdimensions.go
+++ b/internal/tools/looker/lookergetdimensions/lookergetdimensions.go
@@ -96,6 +96,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/looker/lookergetdimensions/lookergetdimensions.go
+++ b/internal/tools/looker/lookergetdimensions/lookergetdimensions.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/tools/looker/lookercommon"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -46,6 +47,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
 	LookerApiSettings() *rtl.ApiSettings
@@ -92,12 +94,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -108,12 +114,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, util.NewClientServerError("unable to get logger from ctx", http.StatusInternalServerError, err)
@@ -154,18 +159,18 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return data, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookergetexplores/lookergetexplores.go
+++ b/internal/tools/looker/lookergetexplores/lookergetexplores.go
@@ -96,6 +96,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/looker/lookergetexplores/lookergetexplores.go
+++ b/internal/tools/looker/lookergetexplores/lookergetexplores.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -45,6 +46,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
 	LookerApiSettings() *rtl.ApiSettings
@@ -92,12 +94,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -108,12 +114,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, util.NewClientServerError("unable to get logger from ctx", http.StatusInternalServerError, err)
@@ -163,18 +168,18 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return data, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookergetfilters/lookergetfilters.go
+++ b/internal/tools/looker/lookergetfilters/lookergetfilters.go
@@ -96,6 +96,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/looker/lookergetfilters/lookergetfilters.go
+++ b/internal/tools/looker/lookergetfilters/lookergetfilters.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/tools/looker/lookercommon"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -46,6 +47,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
 	LookerApiSettings() *rtl.ApiSettings
@@ -92,12 +94,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -108,12 +114,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, util.NewClientServerError("unable to get logger from ctx", http.StatusInternalServerError, err)
@@ -154,18 +159,18 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return data, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookergetgitbranch/lookergetgitbranch.go
+++ b/internal/tools/looker/lookergetgitbranch/lookergetgitbranch.go
@@ -95,6 +95,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/looker/lookergetgitbranch/lookergetgitbranch.go
+++ b/internal/tools/looker/lookergetgitbranch/lookergetgitbranch.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -45,6 +46,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
 	LookerApiSettings() *rtl.ApiSettings
@@ -91,12 +93,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -107,12 +113,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	sdk, err := source.GetLookerSDK(ctx, string(accessToken))
 	if err != nil {
 		return nil, util.NewClientServerError(fmt.Sprintf("error getting sdk: %v", err), http.StatusInternalServerError, err)
@@ -131,18 +136,18 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookergetlookmltests/lookergetlookmltests.go
+++ b/internal/tools/looker/lookergetlookmltests/lookergetlookmltests.go
@@ -97,6 +97,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/looker/lookergetlookmltests/lookergetlookmltests.go
+++ b/internal/tools/looker/lookergetlookmltests/lookergetlookmltests.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -46,6 +47,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
 	LookerApiSettings() *rtl.ApiSettings
@@ -93,12 +95,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -109,12 +115,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	sdk, err := source.GetLookerSDK(ctx, string(accessToken))
 	if err != nil {
 		return nil, util.NewClientServerError(fmt.Sprintf("error getting sdk: %v", err), http.StatusInternalServerError, err)
@@ -142,18 +147,18 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookergetlooks/lookergetlooks.go
+++ b/internal/tools/looker/lookergetlooks/lookergetlooks.go
@@ -103,6 +103,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/looker/lookergetlooks/lookergetlooks.go
+++ b/internal/tools/looker/lookergetlooks/lookergetlooks.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -45,6 +46,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
 	LookerApiSettings() *rtl.ApiSettings
@@ -99,12 +101,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -115,12 +121,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, util.NewClientServerError("unable to get logger from ctx", http.StatusInternalServerError, err)
@@ -185,18 +190,18 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return data, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookergetmeasures/lookergetmeasures.go
+++ b/internal/tools/looker/lookergetmeasures/lookergetmeasures.go
@@ -96,6 +96,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/looker/lookergetmeasures/lookergetmeasures.go
+++ b/internal/tools/looker/lookergetmeasures/lookergetmeasures.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/tools/looker/lookercommon"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -46,6 +47,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
 	LookerApiSettings() *rtl.ApiSettings
@@ -92,12 +94,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -108,12 +114,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, util.NewClientServerError("unable to get logger from ctx", http.StatusInternalServerError, err)
@@ -154,18 +159,18 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return data, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookergetmodels/lookergetmodels.go
+++ b/internal/tools/looker/lookergetmodels/lookergetmodels.go
@@ -96,6 +96,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) EmbedParams(ctx context.Context, paramValues parameters.ParamValues, embeddingModelsMap map[string]embeddingmodels.EmbeddingModel) (parameters.ParamValues, error) {
 	return parameters.ParamValues{}, nil
 }

--- a/internal/tools/looker/lookergetmodels/lookergetmodels.go
+++ b/internal/tools/looker/lookergetmodels/lookergetmodels.go
@@ -21,6 +21,7 @@ import (
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -46,6 +47,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
 	LookerApiSettings() *rtl.ApiSettings
@@ -92,12 +94,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -112,12 +118,11 @@ func (t Tool) EmbedParams(ctx context.Context, paramValues parameters.ParamValue
 	return parameters.ParamValues{}, nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, util.NewClientServerError("unable to get logger from ctx", http.StatusInternalServerError, err)
@@ -160,18 +165,18 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return data, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookergetparameters/lookergetparameters.go
+++ b/internal/tools/looker/lookergetparameters/lookergetparameters.go
@@ -96,6 +96,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/looker/lookergetparameters/lookergetparameters.go
+++ b/internal/tools/looker/lookergetparameters/lookergetparameters.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/tools/looker/lookercommon"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -46,6 +47,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
 	LookerApiSettings() *rtl.ApiSettings
@@ -92,12 +94,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -108,12 +114,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, util.NewClientServerError("unable to get logger from ctx", http.StatusInternalServerError, err)
@@ -154,18 +159,18 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return data, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookergetprojectdirectories/lookergetprojectdirectories.go
+++ b/internal/tools/looker/lookergetprojectdirectories/lookergetprojectdirectories.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/tools/looker/lookercommon"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -46,6 +47,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
 	LookerApiSettings() *rtl.ApiSettings
@@ -92,12 +94,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -108,12 +114,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	sdk, err := source.GetLookerSDK(ctx, string(accessToken))
 	if err != nil {
 		return nil, util.NewClientServerError("error getting sdk", http.StatusInternalServerError, err)
@@ -136,18 +141,18 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookergetprojectdirectories/lookergetprojectdirectories.go
+++ b/internal/tools/looker/lookergetprojectdirectories/lookergetprojectdirectories.go
@@ -96,6 +96,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/looker/lookergetprojectfile/lookergetprojectfile.go
+++ b/internal/tools/looker/lookergetprojectfile/lookergetprojectfile.go
@@ -97,6 +97,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/looker/lookergetprojectfile/lookergetprojectfile.go
+++ b/internal/tools/looker/lookergetprojectfile/lookergetprojectfile.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/tools/looker/lookercommon"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -46,6 +47,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
 	LookerApiSettings() *rtl.ApiSettings
@@ -93,12 +95,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -109,12 +115,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, util.NewClientServerError("unable to get logger from ctx", http.StatusInternalServerError, err)
@@ -151,18 +156,18 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return data, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookergetprojectfiles/lookergetprojectfiles.go
+++ b/internal/tools/looker/lookergetprojectfiles/lookergetprojectfiles.go
@@ -95,6 +95,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/looker/lookergetprojectfiles/lookergetprojectfiles.go
+++ b/internal/tools/looker/lookergetprojectfiles/lookergetprojectfiles.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -45,6 +46,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
 	LookerApiSettings() *rtl.ApiSettings
@@ -91,12 +93,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -107,12 +113,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, util.NewClientServerError("unable to get logger from ctx", http.StatusInternalServerError, err)
@@ -167,18 +172,18 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return data, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookergetprojects/lookergetprojects.go
+++ b/internal/tools/looker/lookergetprojects/lookergetprojects.go
@@ -21,6 +21,7 @@ import (
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -46,6 +47,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
 	LookerApiSettings() *rtl.ApiSettings
@@ -91,12 +93,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -111,12 +117,11 @@ func (t Tool) EmbedParams(ctx context.Context, paramValues parameters.ParamValue
 	return parameters.ParamValues{}, nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, util.NewClientServerError("unable to get logger from ctx", http.StatusInternalServerError, err)
@@ -149,18 +154,18 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return data, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookergetprojects/lookergetprojects.go
+++ b/internal/tools/looker/lookergetprojects/lookergetprojects.go
@@ -95,6 +95,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) EmbedParams(ctx context.Context, paramValues parameters.ParamValues, embeddingModelsMap map[string]embeddingmodels.EmbeddingModel) (parameters.ParamValues, error) {
 	return parameters.ParamValues{}, nil
 }

--- a/internal/tools/looker/lookerhealthanalyze/lookerhealthanalyze.go
+++ b/internal/tools/looker/lookerhealthanalyze/lookerhealthanalyze.go
@@ -111,6 +111,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/looker/lookerhealthanalyze/lookerhealthanalyze.go
+++ b/internal/tools/looker/lookerhealthanalyze/lookerhealthanalyze.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/tools/looker/lookercommon"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -50,6 +51,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
 	LookerApiSettings() *rtl.ApiSettings
@@ -107,12 +109,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -123,12 +129,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, util.NewClientServerError("unable to get logger from ctx", http.StatusInternalServerError, err)
@@ -201,12 +206,12 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	}
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
 // =================================================================================================================
@@ -556,10 +561,10 @@ func (t *analyzeTool) explores(ctx context.Context, model, explore string) ([]ma
 // END LOOKER HEALTH ANALYZE CORE LOGIC
 // =================================================================================================================
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookerhealthpulse/lookerhealthpulse.go
+++ b/internal/tools/looker/lookerhealthpulse/lookerhealthpulse.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/tools/looker/lookercommon"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -50,6 +51,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
 	LookerApiSettings() *rtl.ApiSettings
@@ -98,12 +100,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -114,12 +120,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, util.NewClientServerError("unable to get logger from ctx", http.StatusInternalServerError, err)
@@ -158,12 +163,12 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return result, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
 // =================================================================================================================
@@ -449,10 +454,10 @@ func (t *pulseTool) checkLegacyFeatures(ctx context.Context, source compatibleSo
 // END LOOKER HEALTH PULSE CORE LOGIC
 // =================================================================================================================
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookerhealthpulse/lookerhealthpulse.go
+++ b/internal/tools/looker/lookerhealthpulse/lookerhealthpulse.go
@@ -102,6 +102,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/looker/lookerhealthvacuum/lookerhealthvacuum.go
+++ b/internal/tools/looker/lookerhealthvacuum/lookerhealthvacuum.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/tools/looker/lookercommon"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -50,6 +51,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
 	LookerApiSettings() *rtl.ApiSettings
@@ -107,12 +109,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -123,12 +129,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	sdk, err := source.GetLookerSDK(ctx, string(accessToken))
 	if err != nil {
 		return nil, util.NewClientServerError("error getting sdk", http.StatusInternalServerError, err)
@@ -180,12 +185,12 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return res, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
 // =================================================================================================================
@@ -461,10 +466,10 @@ func (t *vacuumTool) getUsedExploreFields(ctx context.Context, model, explore st
 // END LOOKER HEALTH VACUUM CORE LOGIC
 // =================================================================================================================
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookerhealthvacuum/lookerhealthvacuum.go
+++ b/internal/tools/looker/lookerhealthvacuum/lookerhealthvacuum.go
@@ -111,6 +111,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/looker/lookerlistagents/lookerlistagents.go
+++ b/internal/tools/looker/lookerlistagents/lookerlistagents.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -45,6 +46,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
 	LookerApiSettings() *rtl.ApiSettings
@@ -96,12 +98,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -112,12 +118,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, util.NewClientServerError("unable to get logger from ctx", http.StatusInternalServerError, err)
@@ -142,18 +147,18 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookerlistagents/lookerlistagents.go
+++ b/internal/tools/looker/lookerlistagents/lookerlistagents.go
@@ -100,6 +100,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/looker/lookerlistagents/lookerlistagents_test.go
+++ b/internal/tools/looker/lookerlistagents/lookerlistagents_test.go
@@ -131,23 +131,6 @@ func (m MockSource) GetLookerSDK(ctx context.Context, s string) (*v4.LookerSDK, 
 	return &v4.LookerSDK{}, nil
 }
 
-type MockSourceProvider struct {
-	tools.SourceProvider
-	source MockSource
-}
-
-func (m MockSourceProvider) GetSource(name string) (sources.Source, bool) {
-	return m.source, true
-}
-
-func TestInvokeValidation(t *testing.T) {
-	primitiveMgr := MockSourceProvider{source: MockSource{}}
-
-	// No validation errors to mock for this simple tool that throws errors from Invoke directly
-	_ = primitiveMgr
-
-}
-
 func TestManifest(t *testing.T) {
 	cfg := lkr.Config{
 		ConfigBase: tools.ConfigBase{

--- a/internal/tools/looker/lookerlistgitbranches/lookerlistgitbranches.go
+++ b/internal/tools/looker/lookerlistgitbranches/lookerlistgitbranches.go
@@ -95,6 +95,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/looker/lookerlistgitbranches/lookerlistgitbranches.go
+++ b/internal/tools/looker/lookerlistgitbranches/lookerlistgitbranches.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -45,6 +46,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
 	LookerApiSettings() *rtl.ApiSettings
@@ -91,12 +93,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -107,12 +113,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	sdk, err := source.GetLookerSDK(ctx, string(accessToken))
 	if err != nil {
 		return nil, util.NewClientServerError(fmt.Sprintf("error getting sdk: %v", err), http.StatusInternalServerError, err)
@@ -131,18 +136,18 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookermakedashboard/lookermakedashboard.go
+++ b/internal/tools/looker/lookermakedashboard/lookermakedashboard.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -47,6 +48,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
 	LookerApiSettings() *rtl.ApiSettings
@@ -100,12 +102,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -116,12 +122,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, util.NewClientServerError("unable to get logger from ctx", http.StatusInternalServerError, err)
@@ -200,18 +205,18 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return data, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookermakedashboard/lookermakedashboard.go
+++ b/internal/tools/looker/lookermakedashboard/lookermakedashboard.go
@@ -104,6 +104,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/looker/lookermakelook/lookermakelook.go
+++ b/internal/tools/looker/lookermakelook/lookermakelook.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/tools/looker/lookercommon"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -48,6 +49,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
 	LookerApiSettings() *rtl.ApiSettings
@@ -104,12 +106,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -120,12 +126,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, util.NewClientServerError("unable to get logger from ctx", http.StatusInternalServerError, err)
@@ -221,18 +226,18 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return data, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookermakelook/lookermakelook.go
+++ b/internal/tools/looker/lookermakelook/lookermakelook.go
@@ -108,6 +108,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/looker/lookerquery/lookerquery.go
+++ b/internal/tools/looker/lookerquery/lookerquery.go
@@ -96,6 +96,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/looker/lookerquery/lookerquery.go
+++ b/internal/tools/looker/lookerquery/lookerquery.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/tools/looker/lookercommon"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -47,6 +48,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
 	LookerApiSettings() *rtl.ApiSettings
@@ -92,12 +94,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -108,12 +114,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, util.NewClientServerError("unable to get logger from ctx", http.StatusInternalServerError, err)
@@ -150,18 +155,18 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return data, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookerquerysql/lookerquerysql.go
+++ b/internal/tools/looker/lookerquerysql/lookerquerysql.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/tools/looker/lookercommon"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -46,6 +47,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
 	LookerApiSettings() *rtl.ApiSettings
@@ -91,12 +93,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -107,12 +113,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, util.NewClientServerError("unable to get logger from ctx", http.StatusInternalServerError, err)
@@ -140,18 +145,18 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookerquerysql/lookerquerysql.go
+++ b/internal/tools/looker/lookerquerysql/lookerquerysql.go
@@ -95,6 +95,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/looker/lookerqueryurl/lookerqueryurl.go
+++ b/internal/tools/looker/lookerqueryurl/lookerqueryurl.go
@@ -99,6 +99,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/looker/lookerqueryurl/lookerqueryurl.go
+++ b/internal/tools/looker/lookerqueryurl/lookerqueryurl.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/tools/looker/lookercommon"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -46,6 +47,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
 	LookerApiSettings() *rtl.ApiSettings
@@ -95,12 +97,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -111,12 +117,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, util.NewClientServerError("unable to get logger from ctx", http.StatusInternalServerError, err)
@@ -169,18 +174,18 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return data, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookerrundashboard/lookerrundashboard.go
+++ b/internal/tools/looker/lookerrundashboard/lookerrundashboard.go
@@ -101,6 +101,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/looker/lookerrundashboard/lookerrundashboard.go
+++ b/internal/tools/looker/lookerrundashboard/lookerrundashboard.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/tools/looker/lookercommon"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -48,6 +49,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
 	LookerApiSettings() *rtl.ApiSettings
@@ -97,12 +99,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -113,12 +119,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, util.NewClientServerError("unable to get logger from ctx", http.StatusInternalServerError, err)
@@ -163,12 +168,12 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return data, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
 func tileQueryWorker(ctx context.Context, sdk *v4.LookerSDK, options *rtl.ApiSettings, index int, element v4.DashboardElement) <-chan map[string]any {
@@ -331,10 +336,10 @@ func merge(channels ...<-chan map[string]any) <-chan map[string]any {
 	return out
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookerrunlook/lookerrunlook.go
+++ b/internal/tools/looker/lookerrunlook/lookerrunlook.go
@@ -102,6 +102,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/looker/lookerrunlook/lookerrunlook.go
+++ b/internal/tools/looker/lookerrunlook/lookerrunlook.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/tools/looker/lookercommon"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -47,6 +48,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
 	LookerApiSettings() *rtl.ApiSettings
@@ -98,12 +100,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -114,12 +120,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, util.NewClientServerError("unable to get logger from ctx", http.StatusInternalServerError, err)
@@ -172,18 +177,18 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return data, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookerrunlookmltests/lookerrunlookmltests.go
+++ b/internal/tools/looker/lookerrunlookmltests/lookerrunlookmltests.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -45,6 +46,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
 	LookerApiSettings() *rtl.ApiSettings
@@ -94,12 +96,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -110,12 +116,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	sdk, err := source.GetLookerSDK(ctx, string(accessToken))
 	if err != nil {
 		return nil, util.NewClientServerError(fmt.Sprintf("error getting sdk: %v", err), http.StatusInternalServerError, err)
@@ -163,18 +168,18 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookerrunlookmltests/lookerrunlookmltests.go
+++ b/internal/tools/looker/lookerrunlookmltests/lookerrunlookmltests.go
@@ -98,6 +98,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/looker/lookerswitchgitbranch/lookerswitchgitbranch.go
+++ b/internal/tools/looker/lookerswitchgitbranch/lookerswitchgitbranch.go
@@ -106,6 +106,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/looker/lookerswitchgitbranch/lookerswitchgitbranch.go
+++ b/internal/tools/looker/lookerswitchgitbranch/lookerswitchgitbranch.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -45,6 +46,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
 	LookerApiSettings() *rtl.ApiSettings
@@ -102,12 +104,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -118,12 +124,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	sdk, err := source.GetLookerSDK(ctx, string(accessToken))
 	if err != nil {
 		return nil, util.NewClientServerError(fmt.Sprintf("error getting sdk: %v", err), http.StatusInternalServerError, err)
@@ -153,18 +158,18 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookerupdateagent/lookerupdateagent.go
+++ b/internal/tools/looker/lookerupdateagent/lookerupdateagent.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -45,6 +46,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
 	LookerApiSettings() *rtl.ApiSettings
@@ -111,12 +113,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -127,12 +133,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, util.NewClientServerError("unable to get logger from ctx", http.StatusInternalServerError, err)
@@ -218,18 +223,18 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookerupdateagent/lookerupdateagent.go
+++ b/internal/tools/looker/lookerupdateagent/lookerupdateagent.go
@@ -115,6 +115,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/looker/lookerupdateagent/lookerupdateagent_test.go
+++ b/internal/tools/looker/lookerupdateagent/lookerupdateagent_test.go
@@ -132,15 +132,6 @@ func (m MockSource) GetLookerSDK(ctx context.Context, s string) (*v4.LookerSDK, 
 	return &v4.LookerSDK{}, nil
 }
 
-type MockSourceProvider struct {
-	tools.SourceProvider
-	source MockSource
-}
-
-func (m MockSourceProvider) GetSource(name string) (sources.Source, bool) {
-	return m.source, true
-}
-
 func TestInvokeValidation(t *testing.T) {
 	ctx, err := testutils.ContextWithNewLogger()
 	if err != nil {
@@ -160,8 +151,7 @@ func TestInvokeValidation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to initialize tool: %v", err)
 	}
-
-	primitiveMgr := MockSourceProvider{source: MockSource{}}
+	src := MockSource{}
 
 	tcs := []struct {
 		desc    string
@@ -187,7 +177,7 @@ func TestInvokeValidation(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
-			_, err := tool.Invoke(ctx, primitiveMgr, tc.params, "")
+			_, err := tool.Invoke(ctx, src, tc.params, "")
 			if err == nil {
 				t.Fatalf("expect error, got nil")
 			}

--- a/internal/tools/looker/lookerupdateprojectfile/lookerupdateprojectfile.go
+++ b/internal/tools/looker/lookerupdateprojectfile/lookerupdateprojectfile.go
@@ -97,6 +97,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/looker/lookerupdateprojectfile/lookerupdateprojectfile.go
+++ b/internal/tools/looker/lookerupdateprojectfile/lookerupdateprojectfile.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/tools/looker/lookercommon"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -46,6 +47,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
 	LookerApiSettings() *rtl.ApiSettings
@@ -93,12 +95,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -109,12 +115,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	sdk, err := source.GetLookerSDK(ctx, string(accessToken))
 	if err != nil {
 		return nil, util.NewClientServerError("error getting sdk", http.StatusInternalServerError, err)
@@ -154,18 +159,18 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return data, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/looker/lookervalidateproject/lookervalidateproject.go
+++ b/internal/tools/looker/lookervalidateproject/lookervalidateproject.go
@@ -95,6 +95,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/looker/lookervalidateproject/lookervalidateproject.go
+++ b/internal/tools/looker/lookervalidateproject/lookervalidateproject.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -45,6 +46,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	UseClientAuthorization() bool
 	GetAuthTokenHeaderName() string
 	LookerApiSettings() *rtl.ApiSettings
@@ -91,12 +93,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -107,12 +113,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		return nil, util.NewClientServerError("error getting logger", http.StatusInternalServerError, err)
@@ -142,18 +147,18 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return "", err
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return "", fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.GetAuthTokenHeaderName(), nil
+	return s.GetAuthTokenHeaderName(), nil
 }

--- a/internal/tools/mindsdb/mindsdbexecutesql/mindsdbexecutesql.go
+++ b/internal/tools/mindsdb/mindsdbexecutesql/mindsdbexecutesql.go
@@ -88,6 +88,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/mindsdb/mindsdbexecutesql/mindsdbexecutesql.go
+++ b/internal/tools/mindsdb/mindsdbexecutesql/mindsdbexecutesql.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -43,6 +44,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	MindsDBPool() *sql.DB
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -84,12 +86,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -100,12 +106,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	sqlStr, ok := paramsMap["sql"].(string)
 	if !ok {

--- a/internal/tools/mindsdb/mindsdbsql/mindsdbsql.go
+++ b/internal/tools/mindsdb/mindsdbsql/mindsdbsql.go
@@ -93,6 +93,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/mindsdb/mindsdbsql/mindsdbsql.go
+++ b/internal/tools/mindsdb/mindsdbsql/mindsdbsql.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -43,6 +44,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	MindsDBPool() *sql.DB
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -89,12 +91,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -105,12 +111,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	newStatement, err := parameters.ResolveTemplateParams(t.Cfg.TemplateParameters, t.Cfg.Statement, paramsMap)
 	if err != nil {

--- a/internal/tools/mongodb/mongodbaggregate/mongodbaggregate.go
+++ b/internal/tools/mongodb/mongodbaggregate/mongodbaggregate.go
@@ -101,6 +101,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/mongodb/mongodbaggregate/mongodbaggregate.go
+++ b/internal/tools/mongodb/mongodbaggregate/mongodbaggregate.go
@@ -20,6 +20,7 @@ import (
 	"slices"
 
 	"github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
 	"go.mongodb.org/mongo-driver/v2/mongo"
@@ -44,6 +45,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	MongoClient() *mongo.Client
 	Aggregate(context.Context, string, bool, bool, string, string) ([]any, error)
 }
@@ -97,12 +99,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -113,12 +119,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	pipelineString, err := parameters.PopulateTemplateWithJSON("MongoDBAggregatePipeline", t.Cfg.PipelinePayload, paramsMap)
 	if err != nil {

--- a/internal/tools/mongodb/mongodbdeletemany/mongodbdeletemany.go
+++ b/internal/tools/mongodb/mongodbdeletemany/mongodbdeletemany.go
@@ -103,6 +103,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/mongodb/mongodbdeletemany/mongodbdeletemany.go
+++ b/internal/tools/mongodb/mongodbdeletemany/mongodbdeletemany.go
@@ -20,6 +20,7 @@ import (
 	"slices"
 
 	"github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
 	"go.mongodb.org/mongo-driver/v2/mongo"
@@ -44,6 +45,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	MongoClient() *mongo.Client
 	DeleteMany(context.Context, string, string, string) (any, error)
 }
@@ -99,12 +101,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -115,12 +121,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	filterString, err := parameters.PopulateTemplateWithJSON("MongoDBDeleteManyFilter", t.Cfg.FilterPayload, paramsMap)
 	if err != nil {

--- a/internal/tools/mongodb/mongodbdeleteone/mongodbdeleteone.go
+++ b/internal/tools/mongodb/mongodbdeleteone/mongodbdeleteone.go
@@ -20,6 +20,7 @@ import (
 	"slices"
 
 	"github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
 	"go.mongodb.org/mongo-driver/v2/mongo"
@@ -44,6 +45,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	MongoClient() *mongo.Client
 	DeleteOne(context.Context, string, string, string) (any, error)
 }
@@ -99,12 +101,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -115,12 +121,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 
 	filterString, err := parameters.PopulateTemplateWithJSON("MongoDBDeleteOneFilter", t.Cfg.FilterPayload, paramsMap)

--- a/internal/tools/mongodb/mongodbdeleteone/mongodbdeleteone.go
+++ b/internal/tools/mongodb/mongodbdeleteone/mongodbdeleteone.go
@@ -103,6 +103,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/mongodb/mongodbfind/mongodbfind.go
+++ b/internal/tools/mongodb/mongodbfind/mongodbfind.go
@@ -114,6 +114,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func getOptions(ctx context.Context, sortParameters parameters.Parameters, projectPayload string, limit int64, paramsMap map[string]any) (*options.FindOptionsBuilder, error) {
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {

--- a/internal/tools/mongodb/mongodbfind/mongodbfind.go
+++ b/internal/tools/mongodb/mongodbfind/mongodbfind.go
@@ -20,6 +20,7 @@ import (
 	"slices"
 
 	"github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
 	"go.mongodb.org/mongo-driver/v2/bson"
@@ -46,6 +47,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	MongoClient() *mongo.Client
 	Find(context.Context, string, string, string, *options.FindOptionsBuilder) ([]any, error)
 }
@@ -110,12 +112,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -165,12 +171,11 @@ func getOptions(ctx context.Context, sortParameters parameters.Parameters, proje
 	return opts, nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	filterString, err := parameters.PopulateTemplateWithJSON("MongoDBFindFilterString", t.Cfg.FilterPayload, paramsMap)
 	if err != nil {

--- a/internal/tools/mongodb/mongodbfindone/mongodbfindone.go
+++ b/internal/tools/mongodb/mongodbfindone/mongodbfindone.go
@@ -107,6 +107,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/mongodb/mongodbfindone/mongodbfindone.go
+++ b/internal/tools/mongodb/mongodbfindone/mongodbfindone.go
@@ -20,6 +20,7 @@ import (
 	"slices"
 
 	"github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
 	"go.mongodb.org/mongo-driver/v2/bson"
@@ -46,6 +47,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	MongoClient() *mongo.Client
 	FindOne(context.Context, string, string, string, *options.FindOneOptionsBuilder) ([]any, error)
 }
@@ -103,12 +105,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -119,12 +125,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	filterString, err := parameters.PopulateTemplateWithJSON("MongoDBFindOneFilterString", t.Cfg.FilterPayload, paramsMap)
 	if err != nil {

--- a/internal/tools/mongodb/mongodbinsertmany/mongodbinsertmany.go
+++ b/internal/tools/mongodb/mongodbinsertmany/mongodbinsertmany.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 
 	"github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -44,6 +45,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	MongoClient() *mongo.Client
 	InsertMany(context.Context, string, bool, string, string) ([]any, error)
 }
@@ -96,12 +98,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -112,12 +118,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	if len(params) == 0 {
 		return nil, util.NewAgentError("no input found", nil)
 	}

--- a/internal/tools/mongodb/mongodbinsertmany/mongodbinsertmany.go
+++ b/internal/tools/mongodb/mongodbinsertmany/mongodbinsertmany.go
@@ -100,6 +100,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/mongodb/mongodbinsertone/mongodbinsertone.go
+++ b/internal/tools/mongodb/mongodbinsertone/mongodbinsertone.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 
 	"github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -44,6 +45,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	MongoClient() *mongo.Client
 	InsertOne(context.Context, string, bool, string, string) (any, error)
 }
@@ -96,12 +98,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -112,10 +118,10 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
 	if len(params) == 0 {
 		return nil, util.NewAgentError("no input found", nil)

--- a/internal/tools/mongodb/mongodbinsertone/mongodbinsertone.go
+++ b/internal/tools/mongodb/mongodbinsertone/mongodbinsertone.go
@@ -100,6 +100,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/mongodb/mongodbupdatemany/mongodbupdatemany.go
+++ b/internal/tools/mongodb/mongodbupdatemany/mongodbupdatemany.go
@@ -20,6 +20,7 @@ import (
 	"slices"
 
 	"github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -43,6 +44,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	MongoClient() *mongo.Client
 	UpdateMany(context.Context, string, bool, string, string, string, bool) ([]any, error)
 }
@@ -102,12 +104,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -118,12 +124,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	filterString, err := parameters.PopulateTemplateWithJSON("MongoDBUpdateManyFilter", t.Cfg.FilterPayload, paramsMap)
 	if err != nil {

--- a/internal/tools/mongodb/mongodbupdatemany/mongodbupdatemany.go
+++ b/internal/tools/mongodb/mongodbupdatemany/mongodbupdatemany.go
@@ -106,6 +106,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/mongodb/mongodbupdateone/mongodbupdateone.go
+++ b/internal/tools/mongodb/mongodbupdateone/mongodbupdateone.go
@@ -20,6 +20,7 @@ import (
 	"slices"
 
 	"github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -43,6 +44,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	MongoClient() *mongo.Client
 	UpdateOne(context.Context, string, bool, string, string, string, bool) (any, error)
 }
@@ -103,12 +105,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -119,12 +125,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	filterString, err := parameters.PopulateTemplateWithJSON("MongoDBUpdateOneFilter", t.Cfg.FilterPayload, paramsMap)
 	if err != nil {

--- a/internal/tools/mongodb/mongodbupdateone/mongodbupdateone.go
+++ b/internal/tools/mongodb/mongodbupdateone/mongodbupdateone.go
@@ -107,6 +107,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/mssql/mssqlexecutesql/mssqlexecutesql.go
+++ b/internal/tools/mssql/mssqlexecutesql/mssqlexecutesql.go
@@ -114,3 +114,15 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/mssql/mssqlexecutesql/mssqlexecutesql.go
+++ b/internal/tools/mssql/mssqlexecutesql/mssqlexecutesql.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -43,6 +44,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	MSSQLDB() *sql.DB
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -86,12 +88,11 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	sqlStr, ok := paramsMap["sql"].(string)
 	if !ok {
@@ -111,12 +112,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/mssql/mssqllisttables/mssqllisttables.go
+++ b/internal/tools/mssql/mssqllisttables/mssqllisttables.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -292,6 +293,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	MSSQLDB() *sql.DB
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -337,12 +339,11 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 
 	outputFormat, _ := paramsMap["output_format"].(string)
@@ -366,12 +367,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/mssql/mssqllisttables/mssqllisttables.go
+++ b/internal/tools/mssql/mssqllisttables/mssqllisttables.go
@@ -369,3 +369,15 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/mssql/mssqlsql/mssqlsql.go
+++ b/internal/tools/mssql/mssqlsql/mssqlsql.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -44,6 +45,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	MSSQLDB() *sql.DB
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -92,12 +94,11 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	newStatement, err := parameters.ResolveTemplateParams(t.Cfg.TemplateParameters, t.Cfg.Statement, paramsMap)
 	if err != nil {
@@ -128,12 +129,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/mssql/mssqlsql/mssqlsql.go
+++ b/internal/tools/mssql/mssqlsql/mssqlsql.go
@@ -131,3 +131,15 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/mysql/mysqlexecutesql/mysqlexecutesql.go
+++ b/internal/tools/mysql/mysqlexecutesql/mysqlexecutesql.go
@@ -114,3 +114,15 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/mysql/mysqlexecutesql/mysqlexecutesql.go
+++ b/internal/tools/mysql/mysqlexecutesql/mysqlexecutesql.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -43,6 +44,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	MySQLPool() *sql.DB
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -86,12 +88,11 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	sqlStr, ok := paramsMap["sql"].(string)
 	if !ok {
@@ -111,12 +112,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/mysql/mysqlgetqueryplan/mysqlgetqueryplan.go
+++ b/internal/tools/mysql/mysqlgetqueryplan/mysqlgetqueryplan.go
@@ -141,3 +141,15 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/mysql/mysqlgetqueryplan/mysqlgetqueryplan.go
+++ b/internal/tools/mysql/mysqlgetqueryplan/mysqlgetqueryplan.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/orderedmap"
@@ -45,6 +46,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	MySQLPool() *sql.DB
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -88,12 +90,11 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	sqlStr, ok := paramsMap["sql_statement"].(string)
 	if !ok {
@@ -138,12 +139,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return out, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/mysql/mysqllistactivequeries/mysqllistactivequeries.go
+++ b/internal/tools/mysql/mysqllistactivequeries/mysqllistactivequeries.go
@@ -108,6 +108,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	SourceType() string
 	MySQLPool() *sql.DB
 	RunSQL(context.Context, string, []any) (any, error)
@@ -154,12 +155,11 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	var statement string
 	switch source.SourceType() {
 	case mysql.SourceType:
@@ -194,12 +194,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -210,21 +214,18 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) validate(srcs map[string]sources.Source) error {
-	_, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	return err
+func (t Tool) GetParameters(source sources.Source) (parameters.Parameters, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return t.BaseTool.GetParameters(s)
 }
 
-func (t Tool) GetParameters(srcs map[string]sources.Source) (parameters.Parameters, error) {
-	if err := t.validate(srcs); err != nil {
-		return nil, err
+func (t Tool) Manifest(source sources.Source) (tools.Manifest, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return tools.Manifest{}, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return t.BaseTool.GetParameters(srcs)
-}
-
-func (t Tool) Manifest(srcs map[string]sources.Source) (tools.Manifest, error) {
-	if err := t.validate(srcs); err != nil {
-		return tools.Manifest{}, err
-	}
-	return t.BaseTool.Manifest(srcs)
+	return t.BaseTool.Manifest(s)
 }

--- a/internal/tools/mysql/mysqllistactivequeries/mysqllistactivequeries.go
+++ b/internal/tools/mysql/mysqllistactivequeries/mysqllistactivequeries.go
@@ -198,6 +198,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) validate(srcs map[string]sources.Source) error {
 	_, err := tools.GetCompatibleSourceFromMap[compatibleSource](srcs, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	return err

--- a/internal/tools/mysql/mysqllistalllocks/mysqllistalllocks.go
+++ b/internal/tools/mysql/mysqllistalllocks/mysqllistalllocks.go
@@ -214,3 +214,15 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/mysql/mysqllistalllocks/mysqllistalllocks.go
+++ b/internal/tools/mysql/mysqllistalllocks/mysqllistalllocks.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -94,6 +95,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	MySQLPool() *sql.DB
 	RunSQL(context.Context, string, []any) (any, error)
 	MySQLDatabase() string
@@ -144,12 +146,11 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	// Check performance schema
 	enabled, err := source.PerformanceSchemaEnabled(ctx)
 	if err != nil {
@@ -211,12 +212,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/mysql/mysqllisttablefragmentation/mysqllisttablefragmentation.go
+++ b/internal/tools/mysql/mysqllisttablefragmentation/mysqllisttablefragmentation.go
@@ -154,3 +154,15 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/mysql/mysqllisttablefragmentation/mysqllisttablefragmentation.go
+++ b/internal/tools/mysql/mysqllisttablefragmentation/mysqllisttablefragmentation.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -65,6 +66,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	MySQLPool() *sql.DB
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -112,12 +114,11 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 
 	table_schema, ok := paramsMap["table_schema"].(string)
@@ -151,12 +152,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/mysql/mysqllisttables/mysqllisttables.go
+++ b/internal/tools/mysql/mysqllisttables/mysqllisttables.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -196,6 +197,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	MySQLPool() *sql.DB
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -241,12 +243,11 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 
 	tableNames, ok := paramsMap["table_names"].(string)
@@ -269,12 +270,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/mysql/mysqllisttables/mysqllisttables.go
+++ b/internal/tools/mysql/mysqllisttables/mysqllisttables.go
@@ -272,3 +272,15 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/mysql/mysqllisttablesmissinguniqueindexes/mysqllisttablesmissinguniqueindexes.go
+++ b/internal/tools/mysql/mysqllisttablesmissinguniqueindexes/mysqllisttablesmissinguniqueindexes.go
@@ -144,3 +144,15 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/mysql/mysqllisttablesmissinguniqueindexes/mysqllisttablesmissinguniqueindexes.go
+++ b/internal/tools/mysql/mysqllisttablesmissinguniqueindexes/mysqllisttablesmissinguniqueindexes.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -66,6 +67,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	MySQLPool() *sql.DB
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -111,12 +113,11 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 
 	table_schema, ok := paramsMap["table_schema"].(string)
@@ -141,12 +142,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/mysql/mysqllisttablestats/mysqllisttablestats.go
+++ b/internal/tools/mysql/mysqllisttablestats/mysqllisttablestats.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -81,6 +82,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	MySQLPool() *sql.DB
 	RunSQL(context.Context, string, []any) (any, error)
 	MySQLDatabase() string
@@ -130,12 +132,11 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 
 	table_schema, ok := paramsMap["table_schema"].(string)
@@ -179,12 +180,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/mysql/mysqllisttablestats/mysqllisttablestats.go
+++ b/internal/tools/mysql/mysqllisttablestats/mysqllisttablestats.go
@@ -182,3 +182,15 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/mysql/mysqlshowquerystats/mysqlshowquerystats.go
+++ b/internal/tools/mysql/mysqlshowquerystats/mysqlshowquerystats.go
@@ -164,3 +164,15 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/mysql/mysqlshowquerystats/mysqlshowquerystats.go
+++ b/internal/tools/mysql/mysqlshowquerystats/mysqlshowquerystats.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -63,6 +64,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	MySQLPool() *sql.DB
 	RunSQL(context.Context, string, []any) (any, error)
 	MySQLDatabase() string
@@ -111,12 +113,11 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	// Check performance schema
 	enabled, err := source.PerformanceSchemaEnabled(ctx)
 	if err != nil {
@@ -161,12 +162,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/mysql/mysqlsql/mysqlsql.go
+++ b/internal/tools/mysql/mysqlsql/mysqlsql.go
@@ -119,3 +119,15 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/mysql/mysqlsql/mysqlsql.go
+++ b/internal/tools/mysql/mysqlsql/mysqlsql.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -43,6 +44,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	MySQLPool() *sql.DB
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -91,12 +93,11 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	newStatement, err := parameters.ResolveTemplateParams(t.Cfg.TemplateParameters, t.Cfg.Statement, paramsMap)
 	if err != nil {
@@ -116,12 +117,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/neo4j/neo4jcypher/neo4jcypher.go
+++ b/internal/tools/neo4j/neo4jcypher/neo4jcypher.go
@@ -89,6 +89,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/neo4j/neo4jcypher/neo4jcypher.go
+++ b/internal/tools/neo4j/neo4jcypher/neo4jcypher.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/goccy/go-yaml"
 
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -43,6 +44,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	Neo4jDatabase() string // kept to ensure neo4j source
 	RunQuery(context.Context, string, map[string]any, bool, bool) (any, error)
 }
@@ -85,12 +87,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -101,12 +107,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	resp, err := source.RunQuery(ctx, t.Cfg.Statement, paramsMap, false, false)
 	if err != nil {

--- a/internal/tools/neo4j/neo4jexecutecypher/neo4jexecutecypher.go
+++ b/internal/tools/neo4j/neo4jexecutecypher/neo4jexecutecypher.go
@@ -95,6 +95,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/neo4j/neo4jexecutecypher/neo4jexecutecypher.go
+++ b/internal/tools/neo4j/neo4jexecutecypher/neo4jexecutecypher.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	"github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -42,6 +43,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	Neo4jDatabase() string // kept to ensure neo4j source
 	RunQuery(context.Context, string, map[string]any, bool, bool) (any, error)
 }
@@ -91,12 +93,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -107,12 +113,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	cypherStr, ok := paramsMap["cypher"].(string)
 	if !ok {

--- a/internal/tools/neo4j/neo4jschema/neo4jschema.go
+++ b/internal/tools/neo4j/neo4jschema/neo4jschema.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/tools/neo4j/neo4jschema/cache"
 	"github.com/googleapis/mcp-toolbox/internal/tools/neo4j/neo4jschema/helpers"
@@ -54,6 +55,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 // compatibleSource defines the interface a data source must implement to be used by this tool.
 // It ensures that the source can provide a Neo4j driver and database name.
 type compatibleSource interface {
+	sources.Source
 	Neo4jDriver() neo4j.Driver
 	Neo4jDatabase() string
 }
@@ -111,12 +113,16 @@ type Tool struct {
 	cache *cache.Cache
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -129,12 +135,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 
 // Invoke executes the tool's main logic: fetching the Neo4j schema.
 // It first checks the cache for a valid schema before extracting it from the database.
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	// Check if a valid schema is already in the cache.
 	if cachedSchema, ok := t.cache.Get("schema"); ok {
 		if schema, ok := cachedSchema.(*types.SchemaInfo); ok {

--- a/internal/tools/neo4j/neo4jschema/neo4jschema.go
+++ b/internal/tools/neo4j/neo4jschema/neo4jschema.go
@@ -115,6 +115,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 // Invoke executes the tool's main logic: fetching the Neo4j schema.
 // It first checks the cache for a valid schema before extracting it from the database.
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {

--- a/internal/tools/oceanbase/oceanbaseexecutesql/oceanbaseexecutesql.go
+++ b/internal/tools/oceanbase/oceanbaseexecutesql/oceanbaseexecutesql.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -35,6 +36,7 @@ func init() {
 }
 
 type compatibleSource interface {
+	sources.Source
 	OceanBasePool() *sql.DB
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -87,12 +89,11 @@ type Tool struct {
 }
 
 // Invoke executes the SQL statement provided in the parameters.
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	sliceParams := params.AsSlice()
 	sqlStr, ok := sliceParams[0].(string)
 	if !ok {
@@ -105,12 +106,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/oceanbase/oceanbaseexecutesql/oceanbaseexecutesql.go
+++ b/internal/tools/oceanbase/oceanbaseexecutesql/oceanbaseexecutesql.go
@@ -108,3 +108,15 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/oceanbase/oceanbasesql/oceanbasesql.go
+++ b/internal/tools/oceanbase/oceanbasesql/oceanbasesql.go
@@ -119,3 +119,15 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/oceanbase/oceanbasesql/oceanbasesql.go
+++ b/internal/tools/oceanbase/oceanbasesql/oceanbasesql.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -35,6 +36,7 @@ func init() {
 }
 
 type compatibleSource interface {
+	sources.Source
 	OceanBasePool() *sql.DB
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -92,12 +94,11 @@ type Tool struct {
 }
 
 // Invoke executes the SQL statement with the provided parameters.
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	newStatement, err := parameters.ResolveTemplateParams(t.Cfg.TemplateParameters, t.Cfg.Statement, paramsMap)
 	if err != nil {
@@ -116,12 +117,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/oracle/oracleexecutesql/oracleexecutesql.go
+++ b/internal/tools/oracle/oracleexecutesql/oracleexecutesql.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -31,6 +32,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	OracleDB() *sql.DB
 	RunSQL(context.Context, string, []any, bool) (any, error)
 }
@@ -75,12 +77,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -91,12 +97,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	sqlParam, ok := paramsMap["sql"].(string)
 	if !ok {

--- a/internal/tools/oracle/oracleexecutesql/oracleexecutesql.go
+++ b/internal/tools/oracle/oracleexecutesql/oracleexecutesql.go
@@ -79,6 +79,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/oracle/oraclesql/oraclesql.go
+++ b/internal/tools/oracle/oraclesql/oraclesql.go
@@ -84,6 +84,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/oracle/oraclesql/oraclesql.go
+++ b/internal/tools/oracle/oraclesql/oraclesql.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -31,6 +32,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	OracleDB() *sql.DB
 	RunSQL(context.Context, string, []any, bool) (any, error)
 }
@@ -80,12 +82,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -96,12 +102,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	newStatement, err := parameters.ResolveTemplateParams(t.Cfg.TemplateParameters, t.Cfg.Statement, paramsMap)
 	if err != nil {

--- a/internal/tools/postgres/postgresdatabaseoverview/postgresdatabaseoverview.go
+++ b/internal/tools/postgres/postgresdatabaseoverview/postgresdatabaseoverview.go
@@ -119,3 +119,15 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/postgres/postgresdatabaseoverview/postgresdatabaseoverview.go
+++ b/internal/tools/postgres/postgresdatabaseoverview/postgresdatabaseoverview.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -57,6 +58,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	PostgresPool() *pgxpool.Pool
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -96,12 +98,11 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 
 	newParams, err := parameters.GetParams(t.StaticParameters, paramsMap)
@@ -116,12 +117,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/postgres/postgresexecutesql/postgresexecutesql.go
+++ b/internal/tools/postgres/postgresexecutesql/postgresexecutesql.go
@@ -111,3 +111,15 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/postgres/postgresexecutesql/postgresexecutesql.go
+++ b/internal/tools/postgres/postgresexecutesql/postgresexecutesql.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -43,6 +44,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	PostgresPool() *pgxpool.Pool
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -84,12 +86,11 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	sql, ok := paramsMap["sql"].(string)
 	if !ok {
@@ -108,12 +109,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/postgres/postgresgetcolumncardinality/postgresgetcolumncardinality.go
+++ b/internal/tools/postgres/postgresgetcolumncardinality/postgresgetcolumncardinality.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -62,6 +63,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	PostgresPool() *pgxpool.Pool
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -107,12 +109,11 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 
 	newParams, err := parameters.GetParams(t.StaticParameters, paramsMap)
@@ -127,12 +128,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/postgres/postgresgetcolumncardinality/postgresgetcolumncardinality.go
+++ b/internal/tools/postgres/postgresgetcolumncardinality/postgresgetcolumncardinality.go
@@ -130,3 +130,15 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/postgres/postgreslistactivequeries/postgreslistactivequeries.go
+++ b/internal/tools/postgres/postgreslistactivequeries/postgreslistactivequeries.go
@@ -134,3 +134,15 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/postgres/postgreslistactivequeries/postgreslistactivequeries.go
+++ b/internal/tools/postgres/postgreslistactivequeries/postgreslistactivequeries.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -66,6 +67,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	PostgresPool() *pgxpool.Pool
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -110,12 +112,11 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 
 	newParams, err := parameters.GetParams(t.StaticParameters, paramsMap)
@@ -131,12 +132,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/postgres/postgreslistavailableextensions/postgreslistavailableextensions.go
+++ b/internal/tools/postgres/postgreslistavailableextensions/postgreslistavailableextensions.go
@@ -107,3 +107,15 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/postgres/postgreslistavailableextensions/postgreslistavailableextensions.go
+++ b/internal/tools/postgres/postgreslistavailableextensions/postgreslistavailableextensions.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -53,6 +54,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	PostgresPool() *pgxpool.Pool
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -92,10 +94,10 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
 	resp, err := source.RunSQL(ctx, listAvailableExtensionsQuery, nil)
 	if err != nil {
@@ -104,12 +106,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/postgres/postgreslistdatabasestats/postgreslistdatabasestats.go
+++ b/internal/tools/postgres/postgreslistdatabasestats/postgreslistdatabasestats.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -109,6 +110,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	PostgresPool() *pgxpool.Pool
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -174,12 +176,11 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 
 	newParams, err := parameters.GetParams(t.StaticParameters, paramsMap)
@@ -195,12 +196,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/postgres/postgreslistdatabasestats/postgreslistdatabasestats.go
+++ b/internal/tools/postgres/postgreslistdatabasestats/postgreslistdatabasestats.go
@@ -198,3 +198,15 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/postgres/postgreslistindexes/postgreslistindexes.go
+++ b/internal/tools/postgres/postgreslistindexes/postgreslistindexes.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -89,6 +90,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	PostgresPool() *pgxpool.Pool
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -135,12 +137,11 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 
 	newParams, err := parameters.GetParams(t.StaticParameters, paramsMap)
@@ -156,12 +157,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/postgres/postgreslistindexes/postgreslistindexes.go
+++ b/internal/tools/postgres/postgreslistindexes/postgreslistindexes.go
@@ -159,3 +159,15 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/postgres/postgreslistinstalledextensions/postgreslistinstalledextensions.go
+++ b/internal/tools/postgres/postgreslistinstalledextensions/postgreslistinstalledextensions.go
@@ -118,3 +118,15 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/postgres/postgreslistinstalledextensions/postgreslistinstalledextensions.go
+++ b/internal/tools/postgres/postgreslistinstalledextensions/postgreslistinstalledextensions.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -64,6 +65,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	PostgresPool() *pgxpool.Pool
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -103,10 +105,10 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
 	resp, err := source.RunSQL(ctx, listAvailableExtensionsQuery, nil)
 	if err != nil {
@@ -115,12 +117,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/postgres/postgreslistlocks/postgreslistlocks.go
+++ b/internal/tools/postgres/postgreslistlocks/postgreslistlocks.go
@@ -128,3 +128,15 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/postgres/postgreslistlocks/postgreslistlocks.go
+++ b/internal/tools/postgres/postgreslistlocks/postgreslistlocks.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -64,6 +65,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	PostgresPool() *pgxpool.Pool
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -104,12 +106,11 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 
 	newParams, err := parameters.GetParams(t.StaticParameters, paramsMap)
@@ -125,12 +126,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/postgres/postgreslistpgsettings/postgreslistpgsettings.go
+++ b/internal/tools/postgres/postgreslistpgsettings/postgreslistpgsettings.go
@@ -125,3 +125,15 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/postgres/postgreslistpgsettings/postgreslistpgsettings.go
+++ b/internal/tools/postgres/postgreslistpgsettings/postgreslistpgsettings.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -62,6 +63,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	PostgresPool() *pgxpool.Pool
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -103,10 +105,10 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
 	paramsMap := params.AsMap()
 
@@ -122,12 +124,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/postgres/postgreslistpublicationtables/postgreslistpublicationtables.go
+++ b/internal/tools/postgres/postgreslistpublicationtables/postgreslistpublicationtables.go
@@ -139,3 +139,15 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/postgres/postgreslistpublicationtables/postgreslistpublicationtables.go
+++ b/internal/tools/postgres/postgreslistpublicationtables/postgreslistpublicationtables.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -73,6 +74,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	PostgresPool() *pgxpool.Pool
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -116,12 +118,11 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 
 	newParams, err := parameters.GetParams(t.StaticParameters, paramsMap)
@@ -136,12 +137,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/postgres/postgreslistquerystats/postgreslistquerystats.go
+++ b/internal/tools/postgres/postgreslistquerystats/postgreslistquerystats.go
@@ -128,3 +128,15 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/postgres/postgreslistquerystats/postgreslistquerystats.go
+++ b/internal/tools/postgres/postgreslistquerystats/postgreslistquerystats.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -63,6 +64,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	PostgresPool() *pgxpool.Pool
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -106,10 +108,10 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
 	paramsMap := params.AsMap()
 
@@ -125,12 +127,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/postgres/postgreslistroles/postgreslistroles.go
+++ b/internal/tools/postgres/postgreslistroles/postgreslistroles.go
@@ -150,3 +150,15 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/postgres/postgreslistroles/postgreslistroles.go
+++ b/internal/tools/postgres/postgreslistroles/postgreslistroles.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -85,6 +86,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	PostgresPool() *pgxpool.Pool
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -127,12 +129,11 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 
 	newParams, err := parameters.GetParams(t.StaticParameters, paramsMap)
@@ -147,12 +148,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/postgres/postgreslistschemas/postgreslistschemas.go
+++ b/internal/tools/postgres/postgreslistschemas/postgreslistschemas.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -97,6 +98,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	PostgresPool() *pgxpool.Pool
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -141,12 +143,11 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 
 	newParams, err := parameters.GetParams(t.StaticParameters, paramsMap)
@@ -161,12 +162,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/postgres/postgreslistschemas/postgreslistschemas.go
+++ b/internal/tools/postgres/postgreslistschemas/postgreslistschemas.go
@@ -164,3 +164,15 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/postgres/postgreslistsequences/postgreslistsequences.go
+++ b/internal/tools/postgres/postgreslistsequences/postgreslistsequences.go
@@ -131,3 +131,15 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/postgres/postgreslistsequences/postgreslistsequences.go
+++ b/internal/tools/postgres/postgreslistsequences/postgreslistsequences.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -63,6 +64,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	PostgresPool() *pgxpool.Pool
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -107,12 +109,11 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 
 	newParams, err := parameters.GetParams(t.StaticParameters, paramsMap)
@@ -128,12 +129,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/postgres/postgresliststoredprocedure/postgresliststoredprocedure.go
+++ b/internal/tools/postgres/postgresliststoredprocedure/postgresliststoredprocedure.go
@@ -156,3 +156,15 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/postgres/postgresliststoredprocedure/postgresliststoredprocedure.go
+++ b/internal/tools/postgres/postgresliststoredprocedure/postgresliststoredprocedure.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/sources/alloydbpg"
 	"github.com/googleapis/mcp-toolbox/internal/sources/cloudsqlpg"
 	"github.com/googleapis/mcp-toolbox/internal/sources/postgres"
@@ -67,6 +68,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	PostgresPool() *pgxpool.Pool
 }
 
@@ -115,12 +117,11 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 
 	newParams, err := parameters.GetParams(t.StaticParameters, paramsMap)
@@ -153,12 +154,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return out, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/postgres/postgreslisttables/postgreslisttables.go
+++ b/internal/tools/postgres/postgreslisttables/postgreslisttables.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -121,6 +122,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	PostgresPool() *pgxpool.Pool
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -163,12 +165,11 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 
 	tableNames, ok := paramsMap["table_names"].(string)
@@ -190,12 +191,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/postgres/postgreslisttables/postgreslisttables.go
+++ b/internal/tools/postgres/postgreslisttables/postgreslisttables.go
@@ -193,3 +193,15 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/postgres/postgreslisttablespaces/postgreslisttablespaces.go
+++ b/internal/tools/postgres/postgreslisttablespaces/postgreslisttablespaces.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -69,6 +70,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	PostgresPool() *pgxpool.Pool
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -110,12 +112,11 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 
 	tablespaceName, ok := paramsMap["tablespace_name"].(string)
@@ -134,12 +135,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/postgres/postgreslisttablespaces/postgreslisttablespaces.go
+++ b/internal/tools/postgres/postgreslisttablespaces/postgreslisttablespaces.go
@@ -137,3 +137,15 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/postgres/postgreslisttablestats/postgreslisttablestats.go
+++ b/internal/tools/postgres/postgreslisttablestats/postgreslisttablestats.go
@@ -168,3 +168,15 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/postgres/postgreslisttablestats/postgreslisttablestats.go
+++ b/internal/tools/postgres/postgreslisttablestats/postgreslisttablestats.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -90,6 +91,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	PostgresPool() *pgxpool.Pool
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -144,12 +146,11 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 
 	newParams, err := parameters.GetParams(t.StaticParameters, paramsMap)
@@ -165,12 +166,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/postgres/postgreslisttriggers/postgreslisttriggers.go
+++ b/internal/tools/postgres/postgreslisttriggers/postgreslisttriggers.go
@@ -157,3 +157,15 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/postgres/postgreslisttriggers/postgreslisttriggers.go
+++ b/internal/tools/postgres/postgreslisttriggers/postgreslisttriggers.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -89,6 +90,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	PostgresPool() *pgxpool.Pool
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -134,12 +136,11 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 
 	newParams, err := parameters.GetParams(t.StaticParameters, paramsMap)
@@ -154,12 +155,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/postgres/postgreslistviews/postgreslistviews.go
+++ b/internal/tools/postgres/postgreslistviews/postgreslistviews.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -64,6 +65,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	PostgresPool() *pgxpool.Pool
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -107,12 +109,11 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 
 	newParams, err := parameters.GetParams(t.StaticParameters, paramsMap)
@@ -127,12 +128,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/postgres/postgreslistviews/postgreslistviews.go
+++ b/internal/tools/postgres/postgreslistviews/postgreslistviews.go
@@ -130,3 +130,15 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/postgres/postgreslongrunningtransactions/postgreslongrunningtransactions.go
+++ b/internal/tools/postgres/postgreslongrunningtransactions/postgreslongrunningtransactions.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -71,6 +72,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	PostgresPool() *pgxpool.Pool
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -114,12 +116,11 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 
 	newParams, err := parameters.GetParams(t.StaticParameters, paramsMap)
@@ -134,12 +135,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/postgres/postgreslongrunningtransactions/postgreslongrunningtransactions.go
+++ b/internal/tools/postgres/postgreslongrunningtransactions/postgreslongrunningtransactions.go
@@ -137,3 +137,15 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/postgres/postgresreplicationstats/postgresreplicationstats.go
+++ b/internal/tools/postgres/postgresreplicationstats/postgresreplicationstats.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -61,6 +62,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	PostgresPool() *pgxpool.Pool
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -101,12 +103,11 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 
 	newParams, err := parameters.GetParams(t.StaticParameters, paramsMap)
@@ -121,12 +122,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/postgres/postgresreplicationstats/postgresreplicationstats.go
+++ b/internal/tools/postgres/postgresreplicationstats/postgresreplicationstats.go
@@ -124,3 +124,15 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/postgres/postgressql/postgressql.go
+++ b/internal/tools/postgres/postgressql/postgressql.go
@@ -21,6 +21,7 @@ import (
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -44,6 +45,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	PostgresPool() *pgxpool.Pool
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -89,12 +91,11 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	newStatement, err := parameters.ResolveTemplateParams(t.Cfg.TemplateParameters, t.Cfg.Statement, paramsMap)
 	if err != nil {
@@ -117,12 +118,16 @@ func (t Tool) EmbedParams(ctx context.Context, paramValues parameters.ParamValue
 	return parameters.EmbedParams(ctx, t.StaticParameters, paramValues, embeddingModelsMap, embeddingmodels.FormatVectorForPgvector)
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/postgres/postgressql/postgressql.go
+++ b/internal/tools/postgres/postgressql/postgressql.go
@@ -120,3 +120,15 @@ func (t Tool) EmbedParams(ctx context.Context, paramValues parameters.ParamValue
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/redis/redis.go
+++ b/internal/tools/redis/redis.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	redissrc "github.com/googleapis/mcp-toolbox/internal/sources/redis"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -42,6 +43,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	RedisClient() redissrc.RedisClient
 	RunCommand(context.Context, [][]any) (any, error)
 }
@@ -84,12 +86,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -100,12 +106,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	cmds, err := replaceCommandsParams(t.Cfg.Commands, t.Cfg.Parameters, params)
 	if err != nil {
 		return nil, util.NewAgentError("error replacing commands' parameters", err)

--- a/internal/tools/redis/redis.go
+++ b/internal/tools/redis/redis.go
@@ -88,6 +88,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/scylladb/scyllacql/scyllacql.go
+++ b/internal/tools/scylladb/scyllacql/scyllacql.go
@@ -91,6 +91,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 // Invoke implements tools.Tool.
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)

--- a/internal/tools/scylladb/scyllacql/scyllacql.go
+++ b/internal/tools/scylladb/scyllacql/scyllacql.go
@@ -21,6 +21,7 @@ import (
 
 	yaml "github.com/goccy/go-yaml"
 	gocql "github.com/gocql/gocql"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -35,6 +36,7 @@ func init() {
 }
 
 type compatibleSource interface {
+	sources.Source
 	ScyllaDBSession() *gocql.Session
 	RunSQL(context.Context, string, parameters.ParamValues) (any, error)
 }
@@ -87,12 +89,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -104,12 +110,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 }
 
 // Invoke implements tools.Tool.
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	newStatement, err := parameters.ResolveTemplateParams(t.Cfg.TemplateParameters, t.Cfg.Statement, paramsMap)
 	if err != nil {

--- a/internal/tools/serverlessspark/createbatch/config.go
+++ b/internal/tools/serverlessspark/createbatch/config.go
@@ -21,6 +21,7 @@ import (
 
 	dataprocpb "cloud.google.com/go/dataproc/v2/apiv1/dataprocpb"
 	"github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
@@ -36,6 +37,7 @@ func unmarshalProto(data any, m proto.Message) error {
 }
 
 type compatibleSource interface {
+	sources.Source
 	CreateBatch(context.Context, *dataprocpb.Batch) (map[string]any, error)
 }
 

--- a/internal/tools/serverlessspark/createbatch/tool.go
+++ b/internal/tools/serverlessspark/createbatch/tool.go
@@ -21,6 +21,7 @@ import (
 
 	dataprocpb "cloud.google.com/go/dataproc/v2/apiv1/dataprocpb"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -58,12 +59,27 @@ type Tool struct {
 	Builder        BatchBuilder
 }
 
-func (t *Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
-	}
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
+func (t *Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
+	}
 	batch, err := t.Builder.BuildBatch(params)
 	if err != nil {
 		if tbErr, ok := err.(util.ToolboxError); ok {

--- a/internal/tools/serverlessspark/serverlesssparkcancelbatch/serverlesssparkcancelbatch.go
+++ b/internal/tools/serverlessspark/serverlesssparkcancelbatch/serverlesssparkcancelbatch.go
@@ -118,3 +118,15 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/serverlessspark/serverlesssparkcancelbatch/serverlesssparkcancelbatch.go
+++ b/internal/tools/serverlessspark/serverlesssparkcancelbatch/serverlesssparkcancelbatch.go
@@ -22,6 +22,7 @@ import (
 
 	dataproc "cloud.google.com/go/dataproc/v2/apiv1"
 	"github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -44,6 +45,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	GetBatchControllerClient() *dataproc.BatchControllerClient
 	CancelOperation(context.Context, string) (any, error)
 }
@@ -93,12 +95,11 @@ type Tool struct {
 }
 
 // Invoke executes the tool's operation.
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramMap := params.AsMap()
 	operation, ok := paramMap["operation"].(string)
 	if !ok {
@@ -115,12 +116,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/serverlessspark/serverlesssparkgetbatch/serverlesssparkgetbatch.go
+++ b/internal/tools/serverlessspark/serverlesssparkgetbatch/serverlesssparkgetbatch.go
@@ -117,3 +117,15 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/serverlessspark/serverlesssparkgetbatch/serverlesssparkgetbatch.go
+++ b/internal/tools/serverlessspark/serverlesssparkgetbatch/serverlesssparkgetbatch.go
@@ -22,6 +22,7 @@ import (
 
 	dataproc "cloud.google.com/go/dataproc/v2/apiv1"
 	"github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -44,6 +45,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	GetBatchControllerClient() *dataproc.BatchControllerClient
 	GetBatch(context.Context, string) (map[string]any, error)
 }
@@ -93,10 +95,10 @@ type Tool struct {
 }
 
 // Invoke executes the tool's operation.
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
 	paramMap := params.AsMap()
 	name, ok := paramMap["name"].(string)
@@ -114,12 +116,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/serverlessspark/serverlesssparkgetsession/serverlesssparkgetsession.go
+++ b/internal/tools/serverlessspark/serverlesssparkgetsession/serverlesssparkgetsession.go
@@ -22,6 +22,7 @@ import (
 
 	dataproc "cloud.google.com/go/dataproc/v2/apiv1"
 	"github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -44,6 +45,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	GetSessionControllerClient() *dataproc.SessionControllerClient
 	GetSession(context.Context, string) (map[string]any, error)
 }
@@ -93,10 +95,10 @@ type Tool struct {
 }
 
 // Invoke executes the tool's operation.
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
 	paramMap := params.AsMap()
 	name, ok := paramMap["name"].(string)
@@ -113,12 +115,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return res, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/serverlessspark/serverlesssparkgetsession/serverlesssparkgetsession.go
+++ b/internal/tools/serverlessspark/serverlesssparkgetsession/serverlesssparkgetsession.go
@@ -116,3 +116,15 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/serverlessspark/serverlesssparkgetsessiontemplate/serverlesssparkgetsessiontemplate.go
+++ b/internal/tools/serverlessspark/serverlesssparkgetsessiontemplate/serverlesssparkgetsessiontemplate.go
@@ -22,6 +22,7 @@ import (
 
 	dataproc "cloud.google.com/go/dataproc/v2/apiv1"
 	"github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -44,6 +45,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	GetSessionTemplateControllerClient() *dataproc.SessionTemplateControllerClient
 	GetSessionTemplate(context.Context, string) (map[string]any, error)
 }
@@ -93,10 +95,10 @@ type Tool struct {
 }
 
 // Invoke executes the tool's operation.
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
 	paramMap := params.AsMap()
 	name, ok := paramMap["name"].(string)
@@ -113,12 +115,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return res, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/serverlessspark/serverlesssparkgetsessiontemplate/serverlesssparkgetsessiontemplate.go
+++ b/internal/tools/serverlessspark/serverlesssparkgetsessiontemplate/serverlesssparkgetsessiontemplate.go
@@ -116,3 +116,15 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/serverlessspark/serverlesssparklistbatches/serverlesssparklistbatches.go
+++ b/internal/tools/serverlessspark/serverlesssparklistbatches/serverlesssparklistbatches.go
@@ -131,3 +131,15 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/serverlessspark/serverlesssparklistbatches/serverlesssparklistbatches.go
+++ b/internal/tools/serverlessspark/serverlesssparklistbatches/serverlesssparklistbatches.go
@@ -21,6 +21,7 @@ import (
 
 	dataproc "cloud.google.com/go/dataproc/v2/apiv1"
 	"github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -43,6 +44,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	GetBatchControllerClient() *dataproc.BatchControllerClient
 	ListBatches(context.Context, *int, string, string) (any, error)
 }
@@ -93,12 +95,11 @@ type Tool struct {
 }
 
 // Invoke executes the tool's operation.
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramMap := params.AsMap()
 	var pageSize *int
 	if ps, ok := paramMap["pageSize"]; ok && ps != nil {
@@ -128,12 +129,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/serverlessspark/serverlesssparklistsessions/serverlesssparklistsessions.go
+++ b/internal/tools/serverlessspark/serverlesssparklistsessions/serverlesssparklistsessions.go
@@ -120,3 +120,15 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/serverlessspark/serverlesssparklistsessions/serverlesssparklistsessions.go
+++ b/internal/tools/serverlessspark/serverlesssparklistsessions/serverlesssparklistsessions.go
@@ -21,6 +21,7 @@ import (
 
 	dataproc "cloud.google.com/go/dataproc/v2/apiv1"
 	"github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -43,6 +44,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	GetSessionControllerClient() *dataproc.SessionControllerClient
 	ListSessions(context.Context, *int, string, string) (any, error)
 }
@@ -94,10 +96,10 @@ type Tool struct {
 }
 
 // Invoke executes the tool's operation.
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
 	paramMap := params.AsMap()
 	var pageSize *int
@@ -117,12 +119,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return res, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/singlestore/singlestoreexecutesql/singlestoreexecutesql.go
+++ b/internal/tools/singlestore/singlestoreexecutesql/singlestoreexecutesql.go
@@ -22,6 +22,7 @@ import (
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -44,6 +45,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	SingleStorePool() *sql.DB
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -92,12 +94,11 @@ type Tool struct {
 }
 
 // Invoke executes the provided SQL query using the tool's database connection and returns the results.
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	sqlStr, ok := paramsMap["sql"].(string)
 	if !ok {
@@ -123,12 +124,16 @@ func (t Tool) EmbedParams(ctx context.Context, paramValues parameters.ParamValue
 	return parameters.EmbedParams(ctx, t.StaticParameters, paramValues, embeddingModelsMap, embeddingmodels.FormatVectorForPgvector)
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/singlestore/singlestoreexecutesql/singlestoreexecutesql.go
+++ b/internal/tools/singlestore/singlestoreexecutesql/singlestoreexecutesql.go
@@ -126,3 +126,15 @@ func (t Tool) EmbedParams(ctx context.Context, paramValues parameters.ParamValue
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/singlestore/singlestoresql/singlestoresql.go
+++ b/internal/tools/singlestore/singlestoresql/singlestoresql.go
@@ -145,3 +145,15 @@ func (t Tool) EmbedParams(ctx context.Context, paramValues parameters.ParamValue
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/singlestore/singlestoresql/singlestoresql.go
+++ b/internal/tools/singlestore/singlestoresql/singlestoresql.go
@@ -22,6 +22,7 @@ import (
 
 	yaml "github.com/goccy/go-yaml"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -44,6 +45,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	SingleStorePool() *sql.DB
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -112,12 +114,11 @@ type Tool struct {
 // Returns:
 //   - A slice of maps, where each map represents a row with column names as keys.
 //   - An error if template resolution, parameter extraction, query execution, or result processing fails.
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	newStatement, err := parameters.ResolveTemplateParams(t.Cfg.TemplateParameters, t.Cfg.Statement, paramsMap)
 	if err != nil {
@@ -142,12 +143,16 @@ func (t Tool) EmbedParams(ctx context.Context, paramValues parameters.ParamValue
 	return parameters.EmbedParams(ctx, t.StaticParameters, paramValues, embeddingModelsMap, embeddingmodels.FormatVectorForPgvector)
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/snowflake/snowflakeexecutesql/snowflakeexecutesql.go
+++ b/internal/tools/snowflake/snowflakeexecutesql/snowflakeexecutesql.go
@@ -90,6 +90,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/snowflake/snowflakeexecutesql/snowflakeexecutesql.go
+++ b/internal/tools/snowflake/snowflakeexecutesql/snowflakeexecutesql.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -43,6 +44,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	SnowflakeDB() *sqlx.DB
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -86,12 +88,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -102,12 +108,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	mapParams := params.AsMap()
 	sqlStr, ok := mapParams["sql"].(string)
 	if !ok {

--- a/internal/tools/snowflake/snowflakesql/snowflakesql.go
+++ b/internal/tools/snowflake/snowflakesql/snowflakesql.go
@@ -95,6 +95,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/snowflake/snowflakesql/snowflakesql.go
+++ b/internal/tools/snowflake/snowflakesql/snowflakesql.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -43,6 +44,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	SnowflakeDB() *sqlx.DB
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -91,12 +93,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -107,12 +113,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	newStatement, err := parameters.ResolveTemplateParams(t.Cfg.TemplateParameters, t.Cfg.Statement, paramsMap)
 	if err != nil {

--- a/internal/tools/spanner/spannerexecutesql/spannerexecutesql.go
+++ b/internal/tools/spanner/spannerexecutesql/spannerexecutesql.go
@@ -21,6 +21,7 @@ import (
 
 	"cloud.google.com/go/spanner"
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -43,6 +44,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	SpannerClient() *spanner.Client
 	DatabaseDialect() string
 	RunSQL(context.Context, bool, string, map[string]any) (any, error)
@@ -93,12 +95,11 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	sql, ok := paramsMap["sql"].(string)
 	if !ok {
@@ -118,12 +119,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/spanner/spannerexecutesql/spannerexecutesql.go
+++ b/internal/tools/spanner/spannerexecutesql/spannerexecutesql.go
@@ -121,3 +121,15 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/spanner/spannerlistgraphs/spannerlistgraphs.go
+++ b/internal/tools/spanner/spannerlistgraphs/spannerlistgraphs.go
@@ -131,6 +131,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 // GoogleSQL statement for listing graphs
 const googleSQLStatement = `
 WITH FilterGraphNames AS (

--- a/internal/tools/spanner/spannerlistgraphs/spannerlistgraphs.go
+++ b/internal/tools/spanner/spannerlistgraphs/spannerlistgraphs.go
@@ -22,6 +22,7 @@ import (
 
 	"cloud.google.com/go/spanner"
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -44,6 +45,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	SpannerClient() *spanner.Client
 	DatabaseDialect() string
 	RunSQL(context.Context, bool, string, map[string]any) (any, error)
@@ -97,12 +99,11 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	// Check dialect here at RUNTIME instead of startup
 	if strings.ToLower(source.DatabaseDialect()) != "googlesql" {
 		return nil, util.NewAgentError(fmt.Sprintf("operation not supported: The 'spanner-list-graphs' tool is only available for GoogleSQL dialect databases. Your current database dialect is '%s'", source.DatabaseDialect()), nil)
@@ -127,12 +128,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/spanner/spannerlisttables/spannerlisttables.go
+++ b/internal/tools/spanner/spannerlisttables/spannerlisttables.go
@@ -161,6 +161,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 // PostgreSQL statement for listing tables
 const postgresqlStatement = `
 WITH table_info_cte AS (

--- a/internal/tools/spanner/spannerlisttables/spannerlisttables.go
+++ b/internal/tools/spanner/spannerlisttables/spannerlisttables.go
@@ -22,6 +22,7 @@ import (
 
 	"cloud.google.com/go/spanner"
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -44,6 +45,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	SpannerClient() *spanner.Client
 	DatabaseDialect() string
 	RunSQL(context.Context, bool, string, map[string]any) (any, error)
@@ -107,12 +109,11 @@ func getStatement(dialect string) string {
 	}
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 
 	// Get the appropriate SQL statement based on dialect
@@ -157,12 +158,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/spanner/spannersearchcatalog/spannersearchcatalog.go
+++ b/internal/tools/spanner/spannersearchcatalog/spannersearchcatalog.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	"github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/sources/dataplex/searchcatalog"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
@@ -43,6 +44,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	ProjectID() string
 	UseClientAuthorization() bool
 	InvokeSearchCatalog(ctx context.Context, params map[string]any, tokenStr string) ([]searchcatalog.DataplexSearchResponse, error)
@@ -108,12 +110,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -124,21 +130,21 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return false, err
+func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {
+	s, ok := source.(compatibleSource)
+	if !ok {
+		return false, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
 	}
-	return source.UseClientAuthorization(), nil
+	return s.UseClientAuthorization(), nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	var tokenStr string
+	var err error
 	if source.UseClientAuthorization() {
 		tokenStr, err = accessToken.ParseBearerToken()
 		if err != nil {
@@ -154,6 +160,6 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return results, nil
 }
 
-func (t Tool) GetAuthTokenHeaderName(primitiveMgr tools.SourceProvider) (string, error) {
+func (t Tool) GetAuthTokenHeaderName(source sources.Source) (string, error) {
 	return "", nil
 }

--- a/internal/tools/spanner/spannersearchcatalog/spannersearchcatalog.go
+++ b/internal/tools/spanner/spannersearchcatalog/spannersearchcatalog.go
@@ -112,6 +112,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) RequiresClientAuthorization(primitiveMgr tools.SourceProvider) (bool, error) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/spanner/spannersearchcatalog/spannersearchcatalog_test.go
+++ b/internal/tools/spanner/spannersearchcatalog/spannersearchcatalog_test.go
@@ -93,17 +93,6 @@ func (m mockSpannerSource) InvokeSearchCatalog(ctx context.Context, params map[s
 func (m mockSpannerSource) SourceType() string             { return "spanner" }
 func (m mockSpannerSource) ToConfig() sources.SourceConfig { return nil }
 
-type mockSourceProvider struct {
-	source sources.Source
-}
-
-func (m mockSourceProvider) GetSource(name string) (sources.Source, bool) {
-	if m.source != nil {
-		return m.source, true
-	}
-	return nil, false
-}
-
 func TestConfig_Initialize(t *testing.T) {
 	cfg := spannersearchcatalog.Config{
 		ConfigBase: tools.ConfigBase{
@@ -137,7 +126,6 @@ func TestTool_Invoke(t *testing.T) {
 			},
 		},
 	}
-	sourceProvider := mockSourceProvider{source: mockSource}
 
 	cfg := spannersearchcatalog.Config{
 		ConfigBase: tools.ConfigBase{
@@ -158,7 +146,7 @@ func TestTool_Invoke(t *testing.T) {
 		},
 	}
 
-	resp, err := tool.Invoke(ctx, sourceProvider, params, tools.AccessToken(""))
+	resp, err := tool.Invoke(ctx, mockSource, params, tools.AccessToken(""))
 	if err != nil {
 		t.Fatalf("Invoke failed: %v", err)
 	}

--- a/internal/tools/spanner/spannersql/spannersql.go
+++ b/internal/tools/spanner/spannersql/spannersql.go
@@ -22,6 +22,7 @@ import (
 
 	"cloud.google.com/go/spanner"
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -44,6 +45,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	SpannerClient() *spanner.Client
 	DatabaseDialect() string
 	RunSQL(context.Context, bool, string, map[string]any) (any, error)
@@ -110,12 +112,11 @@ func getMapParams(params parameters.ParamValues, dialect string) (map[string]int
 	}
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	newStatement, err := parameters.ResolveTemplateParams(t.Cfg.TemplateParameters, t.Cfg.Statement, paramsMap)
 	if err != nil {
@@ -162,12 +163,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/spanner/spannersql/spannersql.go
+++ b/internal/tools/spanner/spannersql/spannersql.go
@@ -165,3 +165,15 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/sqlite/sqliteexecutesql/sqliteexecutesql.go
+++ b/internal/tools/sqlite/sqliteexecutesql/sqliteexecutesql.go
@@ -90,6 +90,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/sqlite/sqliteexecutesql/sqliteexecutesql.go
+++ b/internal/tools/sqlite/sqliteexecutesql/sqliteexecutesql.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -43,6 +44,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	SQLiteDB() *sql.DB
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -86,12 +88,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -102,12 +108,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	sqlStr, ok := params.AsMap()["sql"].(string)
 	if !ok {
 		return nil, util.NewAgentError("missing or invalid 'sql' parameter", nil)

--- a/internal/tools/sqlite/sqlitesql/sqlitesql.go
+++ b/internal/tools/sqlite/sqlitesql/sqlitesql.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -43,6 +44,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	SQLiteDB() *sql.DB
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -91,12 +93,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -107,12 +113,11 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	newStatement, err := parameters.ResolveTemplateParams(t.Cfg.TemplateParameters, t.Cfg.Statement, paramsMap)
 	if err != nil {

--- a/internal/tools/sqlite/sqlitesql/sqlitesql.go
+++ b/internal/tools/sqlite/sqlitesql/sqlitesql.go
@@ -95,6 +95,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/tidb/tidbexecutesql/tidbexecutesql.go
+++ b/internal/tools/tidb/tidbexecutesql/tidbexecutesql.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -43,6 +44,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	TiDBPool() *sql.DB
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -86,12 +88,11 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	sqlStr, ok := paramsMap["sql"].(string)
 	if !ok {
@@ -112,12 +113,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return resp, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/tidb/tidbexecutesql/tidbexecutesql.go
+++ b/internal/tools/tidb/tidbexecutesql/tidbexecutesql.go
@@ -115,3 +115,15 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/tidb/tidbsql/tidbsql.go
+++ b/internal/tools/tidb/tidbsql/tidbsql.go
@@ -119,3 +119,15 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/tidb/tidbsql/tidbsql.go
+++ b/internal/tools/tidb/tidbsql/tidbsql.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -43,6 +44,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	TiDBPool() *sql.DB
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -91,12 +93,11 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source not compatible with this tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
-
 	paramsMap := params.AsMap()
 	newStatement, err := parameters.ResolveTemplateParams(t.Cfg.TemplateParameters, t.Cfg.Statement, paramsMap)
 	if err != nil {
@@ -116,12 +117,16 @@ func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, par
 	return res, nil
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -127,22 +127,22 @@ type Tool interface {
 	GetDescription() string
 	GetAuthRequired() []string
 	GetAnnotations() *ToolAnnotations
-	Invoke(context.Context, SourceProvider, parameters.ParamValues, AccessToken) (any, util.ToolboxError)
+	Invoke(context.Context, SourceManager, parameters.ParamValues, AccessToken) (any, util.ToolboxError)
 	EmbedParams(context.Context, parameters.ParamValues, map[string]embeddingmodels.EmbeddingModel) (parameters.ParamValues, error)
 	Manifest(map[string]sources.Source) (Manifest, error)
 	StaticManifest() Manifest
 	Authorized([]string) bool
-	RequiresClientAuthorization(SourceProvider) (bool, error)
+	RequiresClientAuthorization(SourceManager) (bool, error)
 	ToConfig() ToolConfig
-	GetAuthTokenHeaderName(SourceProvider) (string, error)
+	GetAuthTokenHeaderName(SourceManager) (string, error)
 	GetParameters(map[string]sources.Source) (parameters.Parameters, error)
 	GetScopesRequired() []string
 }
 
-// SourceProvider defines the minimal view of the primitives.PrimitiveManager
+// SourceManager defines the minimal view of the primitives.PrimitiveManager
 // that the Tool package needs.
 // This is implemented to prevent import cycles.
-type SourceProvider interface {
+type SourceManager interface {
 	GetSource(sourceName string) (sources.Source, bool)
 }
 

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -124,19 +124,21 @@ func (token AccessToken) ParseBearerToken() (string, error) {
 
 type Tool interface {
 	GetName() string
+	GetSource() string
 	GetDescription() string
 	GetAuthRequired() []string
 	GetAnnotations() *ToolAnnotations
-	Invoke(context.Context, SourceManager, parameters.ParamValues, AccessToken) (any, util.ToolboxError)
+	Invoke(context.Context, sources.Source, parameters.ParamValues, AccessToken) (any, util.ToolboxError)
 	EmbedParams(context.Context, parameters.ParamValues, map[string]embeddingmodels.EmbeddingModel) (parameters.ParamValues, error)
-	Manifest(map[string]sources.Source) (Manifest, error)
+	Manifest(sources.Source) (Manifest, error)
 	StaticManifest() Manifest
 	Authorized([]string) bool
-	RequiresClientAuthorization(SourceManager) (bool, error)
+	RequiresClientAuthorization(sources.Source) (bool, error)
 	ToConfig() ToolConfig
-	GetAuthTokenHeaderName(SourceManager) (string, error)
-	GetParameters(map[string]sources.Source) (parameters.Parameters, error)
+	GetAuthTokenHeaderName(sources.Source) (string, error)
+	GetParameters(sources.Source) (parameters.Parameters, error)
 	GetScopesRequired() []string
+	ValidateSource(SourceManager) error
 }
 
 // SourceManager defines the minimal view of the primitives.PrimitiveManager
@@ -165,36 +167,6 @@ func IsAuthorized(authRequiredSources []string, verifiedAuthServices []string) b
 		}
 	}
 	return false
-}
-
-func GetCompatibleSource[T any](primitiveMgr SourceProvider, sourceName, toolName, toolType string) (T, error) {
-	var zero T
-	s, ok := primitiveMgr.GetSource(sourceName)
-	if !ok {
-		return zero, fmt.Errorf("unable to retrieve source %q for tool %q", sourceName, toolName)
-	}
-	source, ok := s.(T)
-	if !ok {
-		return zero, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", toolType, sourceName)
-	}
-	return source, nil
-}
-
-// GetCompatibleSourceFromMap looks up a source by name from a sources map and
-// asserts it to the requested type. It mirrors GetCompatibleSource for callers
-// that hold the sources map directly (Manifest/GetParameters) rather than a
-// SourceProvider.
-func GetCompatibleSourceFromMap[T any](srcs map[string]sources.Source, sourceName, toolName, toolType string) (T, error) {
-	var zero T
-	s, ok := srcs[sourceName]
-	if !ok {
-		return zero, fmt.Errorf("unable to retrieve source %q for tool %q", sourceName, toolName)
-	}
-	source, ok := s.(T)
-	if !ok {
-		return zero, fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", toolType, sourceName)
-	}
-	return source, nil
 }
 
 // ToolMeta is the read-only view BaseTool needs of any tool's Config. Tools
@@ -254,7 +226,7 @@ func (b BaseTool[T]) GetAnnotations() *ToolAnnotations { return b.annotations }
 // Manifest returns the precomputed metadata. It and GetParameters stay trivial
 // and never call each other: embedded methods have no virtual dispatch, so a
 // BaseTool method calling another would miss a concrete tool's override.
-func (b BaseTool[T]) Manifest(_ map[string]sources.Source) (Manifest, error) {
+func (b BaseTool[T]) Manifest(_ sources.Source) (Manifest, error) {
 	return b.metadata, nil
 }
 
@@ -266,7 +238,7 @@ func (b BaseTool[T]) StaticManifest() Manifest {
 	return b.metadata
 }
 
-func (b BaseTool[T]) GetParameters(_ map[string]sources.Source) (parameters.Parameters, error) {
+func (b BaseTool[T]) GetParameters(_ sources.Source) (parameters.Parameters, error) {
 	return b.StaticParameters, nil
 }
 
@@ -274,11 +246,11 @@ func (b BaseTool[T]) Authorized(verifiedAuthServices []string) bool {
 	return IsAuthorized(b.Cfg.GetAuthRequired(), verifiedAuthServices)
 }
 
-func (b BaseTool[T]) RequiresClientAuthorization(_ SourceProvider) (bool, error) {
+func (b BaseTool[T]) RequiresClientAuthorization(_ sources.Source) (bool, error) {
 	return false, nil
 }
 
-func (b BaseTool[T]) GetAuthTokenHeaderName(_ SourceProvider) (string, error) {
+func (b BaseTool[T]) GetAuthTokenHeaderName(_ sources.Source) (string, error) {
 	return "Authorization", nil
 }
 

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -21,35 +21,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
-	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
 )
-
-// stubConfig and stubTool exercise the path of embedding BaseTool with only
-// the extra methods (Invoke, ToConfig) needed to satisfy the Tool interface.
-// Real tools embed ConfigBase in their Config; the stub does too so it
-// satisfies ToolMeta if/when wired into BaseTool.
-type stubConfig struct {
-	tools.ConfigBase
-}
-
-func (stubConfig) ToolConfigType() string { return "stub" }
-func (stubConfig) Initialize(context.Context) (tools.Tool, error) {
-	return nil, nil
-}
-
-type stubTool struct {
-	tools.BaseTool[stubConfig]
-}
-
-func (stubTool) Invoke(_ context.Context, _ tools.SourceProvider, _ parameters.ParamValues, _ tools.AccessToken) (any, util.ToolboxError) {
-	return nil, nil
-}
-
-func (stubTool) ToConfig() tools.ToolConfig { return stubConfig{} }
-
-// Compile-time check: embedding BaseTool plus Invoke + ToConfig satisfies Tool.
-var _ tools.Tool = stubTool{}
 
 // Compile-time check: ConfigBase satisfies ToolMeta on its own.
 var _ tools.ToolMeta = tools.ConfigBase{}

--- a/internal/tools/toolsets.go
+++ b/internal/tools/toolsets.go
@@ -60,10 +60,19 @@ type ToolsetManifest struct {
 
 // BuildManifest resolves the manifest for every tool in the toolset against the
 // provided sources, returning an error if any tool's manifest cannot be built.
-func (t Toolset) BuildManifest(srcs map[string]sources.Source) (ToolsetManifest, error) {
+func (t Toolset) BuildManifest(srcMgr SourceManager) (ToolsetManifest, error) {
 	toolsManifest := make(map[string]Manifest, len(t.Tools))
 	for _, tool := range t.Tools {
-		m, err := (*tool).Manifest(srcs)
+		srcName := (*tool).GetSource()
+		var src sources.Source
+		var ok bool
+		if srcName != "" {
+			src, ok = srcMgr.GetSource((*tool).GetSource())
+			if !ok {
+				return ToolsetManifest{}, fmt.Errorf("unable to retrieve %s source for tool %q", (*tool).GetSource(), (*tool).GetName())
+			}
+		}
+		m, err := (*tool).Manifest(src)
 		if err != nil {
 			return ToolsetManifest{}, fmt.Errorf("error generating manifest for tool %q: %w", (*tool).GetName(), err)
 		}

--- a/internal/tools/trino/trinoexecutesql/trinoexecutesql.go
+++ b/internal/tools/trino/trinoexecutesql/trinoexecutesql.go
@@ -90,6 +90,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/trino/trinoexecutesql/trinoexecutesql.go
+++ b/internal/tools/trino/trinoexecutesql/trinoexecutesql.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -43,6 +44,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	TrinoDB() *sql.DB
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -86,12 +88,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -102,10 +108,10 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source not compatible with this tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
 
 	sliceParams := params.AsSlice()

--- a/internal/tools/trino/trinosql/trinosql.go
+++ b/internal/tools/trino/trinosql/trinosql.go
@@ -95,6 +95,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/trino/trinosql/trinosql.go
+++ b/internal/tools/trino/trinosql/trinosql.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -43,6 +44,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	TrinoDB() *sql.DB
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -91,12 +93,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -107,10 +113,10 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source not compatible with this tool", http.StatusInternalServerError, err)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
 
 	paramsMap := params.AsMap()

--- a/internal/tools/utility/wait/wait.go
+++ b/internal/tools/utility/wait/wait.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -79,7 +80,7 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	paramsMap := params.AsMap()
 
 	durationStr, ok := paramsMap["duration"].(string)
@@ -101,18 +102,14 @@ func (t Tool) Authorized(verifiedAuthServices []string) bool {
 	return true
 }
 
+func (t Tool) GetSource() string {
+	return ""
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
-	if !ok {
-		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
-	}
-	_, ok = source.(compatibleSource)
-	if !ok {
-		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
-	}
 	return nil
 }

--- a/internal/tools/utility/wait/wait.go
+++ b/internal/tools/utility/wait/wait.go
@@ -104,3 +104,15 @@ func (t Tool) Authorized(verifiedAuthServices []string) bool {
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
+
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}

--- a/internal/tools/valkey/valkey.go
+++ b/internal/tools/valkey/valkey.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -42,6 +43,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	ValkeyClient() valkey.Client
 	RunCommand(context.Context, [][]string) (any, error)
 }
@@ -84,12 +86,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -100,10 +106,10 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source not compatible with this tool", http.StatusInternalServerError, nil)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
 
 	// Replace parameters

--- a/internal/tools/valkey/valkey.go
+++ b/internal/tools/valkey/valkey.go
@@ -88,6 +88,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/yugabytedbsql/yugabytedbsql.go
+++ b/internal/tools/yugabytedbsql/yugabytedbsql.go
@@ -95,6 +95,18 @@ func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
+func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
+	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	if !ok {
+		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
+	}
+	_, ok = source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
 func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
 	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
 	if err != nil {

--- a/internal/tools/yugabytedbsql/yugabytedbsql.go
+++ b/internal/tools/yugabytedbsql/yugabytedbsql.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	yaml "github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/util"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
@@ -43,6 +44,7 @@ func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.T
 }
 
 type compatibleSource interface {
+	sources.Source
 	YugabyteDBPool() *pgxpool.Pool
 	RunSQL(context.Context, string, []any) (any, error)
 }
@@ -91,12 +93,16 @@ type Tool struct {
 	tools.BaseTool[Config]
 }
 
+func (t Tool) GetSource() string {
+	return t.Cfg.Source
+}
+
 func (t Tool) ToConfig() tools.ToolConfig {
 	return t.Cfg
 }
 
 func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
-	source, ok := srcMgr.GetSource(t.Cfg.Name)
+	source, ok := srcMgr.GetSource(t.Cfg.Source)
 	if !ok {
 		return fmt.Errorf("unable to retrieve source %q for tool %q", t.Cfg.Source, t.Cfg.Name)
 	}
@@ -107,10 +113,10 @@ func (t Tool) ValidateSource(srcMgr tools.SourceManager) error {
 	return nil
 }
 
-func (t Tool) Invoke(ctx context.Context, primitiveMgr tools.SourceProvider, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
-	source, err := tools.GetCompatibleSource[compatibleSource](primitiveMgr, t.Cfg.Source, t.Cfg.Name, t.Cfg.Type)
-	if err != nil {
-		return nil, util.NewClientServerError("source not compatible with this tool", http.StatusInternalServerError, nil)
+func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.ParamValues, accessToken tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
 	}
 
 	paramsMap := params.AsMap()

--- a/tests/clickhouse/clickhouse_integration_test.go
+++ b/tests/clickhouse/clickhouse_integration_test.go
@@ -1131,8 +1131,8 @@ func TestClickHouseListTablesTool(t *testing.T) {
 	t.Run("ListTablesWithInvalidSource", func(t *testing.T) {
 		api := "http://127.0.0.1:5000/api/tool/test-invalid-source/invoke"
 		resp, _ := tests.RunRequest(t, http.MethodPost, api, bytes.NewBuffer([]byte(`{}`)), nil)
-		if resp.StatusCode != http.StatusOK {
-			t.Errorf("Expected 200 OK for non-existent source, but got %d", resp.StatusCode)
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("Expected 404 NOT FOUND for non-existent source, but got %d", resp.StatusCode)
 		}
 	})
 


### PR DESCRIPTION
This PR does the following:
1. Rename `SourceProvider` to `SourceManager`
2. Remove `GetCompatibleSource` and `GetCompatibleSourceFromMap` function.
3. Add `ValidateSource()` and `GetSource()` function to Tool interface.
4. Remove `GetSourcesMap()` from primitives manager.