### PR TITLE
docs: redirect empty integration roots to Source pages

### DIFF
--- a/docs/en/integrations/alloydb-admin/_index.md
+++ b/docs/en/integrations/alloydb-admin/_index.md
@@ -2,3 +2,8 @@
 title: "AlloyDB Admin"
 weight: 1
 ---
+
+The AlloyDB Admin integration documentation starts on the **[Source](source/)** page (configuration, tools, and requirements).
+
+<meta http-equiv="refresh" content="0; url=source/">
+<p><a href="source/">Continue to the Source documentation</a>.</p>

--- a/docs/en/integrations/alloydb/_index.md
+++ b/docs/en/integrations/alloydb/_index.md
@@ -2,3 +2,8 @@
 title: "AlloyDB PostgreSQL"
 weight: 1
 ---
+
+The AlloyDB PostgreSQL integration documentation starts on the **[Source](source/)** page (configuration, tools, and requirements).
+
+<meta http-equiv="refresh" content="0; url=source/">
+<p><a href="source/">Continue to the Source documentation</a>.</p>

--- a/docs/en/integrations/arcadedb/_index.md
+++ b/docs/en/integrations/arcadedb/_index.md
@@ -5,3 +5,8 @@ weight: 1
 description: >
   ArcadeDB is a multi-model database with Bolt protocol support.
 ---
+
+The ArcadeDB integration documentation starts on the **[Source](source/)** page (configuration, tools, and requirements).
+
+<meta http-equiv="refresh" content="0; url=source/">
+<p><a href="source/">Continue to the Source documentation</a>.</p>

--- a/docs/en/integrations/bigquery/_index.md
+++ b/docs/en/integrations/bigquery/_index.md
@@ -2,3 +2,8 @@
 title: "BigQuery"
 weight: 1
 ---
+
+The BigQuery integration documentation starts on the **[Source](source/)** page (configuration, tools, and requirements).
+
+<meta http-equiv="refresh" content="0; url=source/">
+<p><a href="source/">Continue to the Source documentation</a>.</p>

--- a/docs/en/integrations/bigtable/_index.md
+++ b/docs/en/integrations/bigtable/_index.md
@@ -2,3 +2,8 @@
 title: "Bigtable"
 weight: 1
 ---
+
+The Bigtable integration documentation starts on the **[Source](source/)** page (configuration, tools, and requirements).
+
+<meta http-equiv="refresh" content="0; url=source/">
+<p><a href="source/">Continue to the Source documentation</a>.</p>

--- a/docs/en/integrations/cassandra/_index.md
+++ b/docs/en/integrations/cassandra/_index.md
@@ -2,3 +2,8 @@
 title: "Cassandra"
 weight: 1
 ---
+
+The Cassandra integration documentation starts on the **[Source](source/)** page (configuration, tools, and requirements).
+
+<meta http-equiv="refresh" content="0; url=source/">
+<p><a href="source/">Continue to the Source documentation</a>.</p>

--- a/docs/en/integrations/clickhouse/_index.md
+++ b/docs/en/integrations/clickhouse/_index.md
@@ -2,3 +2,8 @@
 title: "ClickHouse"
 weight: 1
 ---
+
+The ClickHouse integration documentation starts on the **[Source](source/)** page (configuration, tools, and requirements).
+
+<meta http-equiv="refresh" content="0; url=source/">
+<p><a href="source/">Continue to the Source documentation</a>.</p>

--- a/docs/en/integrations/cloud-sql-admin/_index.md
+++ b/docs/en/integrations/cloud-sql-admin/_index.md
@@ -2,3 +2,8 @@
 title: "Cloud SQL Admin"
 weight: 1
 ---
+
+The Cloud SQL Admin integration documentation starts on the **[Source](source/)** page (configuration, tools, and requirements).
+
+<meta http-equiv="refresh" content="0; url=source/">
+<p><a href="source/">Continue to the Source documentation</a>.</p>

--- a/docs/en/integrations/cloud-sql-mssql/_index.md
+++ b/docs/en/integrations/cloud-sql-mssql/_index.md
@@ -2,3 +2,8 @@
 title: "Cloud SQL for SQL Server"
 weight: 1
 ---
+
+The Cloud SQL for SQL Server integration documentation starts on the **[Source](source/)** page (configuration, tools, and requirements).
+
+<meta http-equiv="refresh" content="0; url=source/">
+<p><a href="source/">Continue to the Source documentation</a>.</p>

--- a/docs/en/integrations/cloud-sql-mysql/_index.md
+++ b/docs/en/integrations/cloud-sql-mysql/_index.md
@@ -2,3 +2,8 @@
 title: "Cloud SQL for MySQL"
 weight: 1
 ---
+
+The Cloud SQL for MySQL integration documentation starts on the **[Source](source/)** page (configuration, tools, and requirements).
+
+<meta http-equiv="refresh" content="0; url=source/">
+<p><a href="source/">Continue to the Source documentation</a>.</p>

--- a/docs/en/integrations/cloud-sql-pg/_index.md
+++ b/docs/en/integrations/cloud-sql-pg/_index.md
@@ -2,3 +2,8 @@
 title: "Cloud SQL for PostgreSQL"
 weight: 1
 ---
+
+The Cloud SQL for PostgreSQL integration documentation starts on the **[Source](source/)** page (configuration, tools, and requirements).
+
+<meta http-equiv="refresh" content="0; url=source/">
+<p><a href="source/">Continue to the Source documentation</a>.</p>

--- a/docs/en/integrations/cloud-storage/_index.md
+++ b/docs/en/integrations/cloud-storage/_index.md
@@ -2,3 +2,8 @@
 title: "Cloud Storage"
 weight: 1
 ---
+
+The Cloud Storage integration documentation starts on the **[Source](source/)** page (configuration, tools, and requirements).
+
+<meta http-equiv="refresh" content="0; url=source/">
+<p><a href="source/">Continue to the Source documentation</a>.</p>

--- a/docs/en/integrations/cloudgda/_index.md
+++ b/docs/en/integrations/cloudgda/_index.md
@@ -2,3 +2,8 @@
 title: "Gemini Data Analytics"
 weight: 1
 ---
+
+The Gemini Data Analytics integration documentation starts on the **[Source](source/)** page (configuration, tools, and requirements).
+
+<meta http-equiv="refresh" content="0; url=source/">
+<p><a href="source/">Continue to the Source documentation</a>.</p>

--- a/docs/en/integrations/cloudhealthcare/_index.md
+++ b/docs/en/integrations/cloudhealthcare/_index.md
@@ -2,3 +2,8 @@
 title: "Cloud Healthcare"
 weight: 1
 ---
+
+The Cloud Healthcare integration documentation starts on the **[Source](source/)** page (configuration, tools, and requirements).
+
+<meta http-equiv="refresh" content="0; url=source/">
+<p><a href="source/">Continue to the Source documentation</a>.</p>

--- a/docs/en/integrations/cloudloggingadmin/_index.md
+++ b/docs/en/integrations/cloudloggingadmin/_index.md
@@ -2,3 +2,8 @@
 title: "Cloud Logging Admin"
 weight: 1
 ---
+
+The Cloud Logging Admin integration documentation starts on the **[Source](source/)** page (configuration, tools, and requirements).
+
+<meta http-equiv="refresh" content="0; url=source/">
+<p><a href="source/">Continue to the Source documentation</a>.</p>

--- a/docs/en/integrations/cloudmonitoring/_index.md
+++ b/docs/en/integrations/cloudmonitoring/_index.md
@@ -2,3 +2,8 @@
 title: "Cloud Monitoring"
 weight: 1
 ---
+
+The Cloud Monitoring integration documentation starts on the **[Source](source/)** page (configuration, tools, and requirements).
+
+<meta http-equiv="refresh" content="0; url=source/">
+<p><a href="source/">Continue to the Source documentation</a>.</p>

--- a/docs/en/integrations/cockroachdb/_index.md
+++ b/docs/en/integrations/cockroachdb/_index.md
@@ -2,3 +2,8 @@
 title: "CockroachDB"
 weight: 1
 ---
+
+The CockroachDB integration documentation starts on the **[Source](source/)** page (configuration, tools, and requirements).
+
+<meta http-equiv="refresh" content="0; url=source/">
+<p><a href="source/">Continue to the Source documentation</a>.</p>

--- a/docs/en/integrations/couchbase/_index.md
+++ b/docs/en/integrations/couchbase/_index.md
@@ -2,3 +2,8 @@
 title: "Couchbase"
 weight: 1
 ---
+
+The Couchbase integration documentation starts on the **[Source](source/)** page (configuration, tools, and requirements).
+
+<meta http-equiv="refresh" content="0; url=source/">
+<p><a href="source/">Continue to the Source documentation</a>.</p>

--- a/docs/en/integrations/datalineage/_index.md
+++ b/docs/en/integrations/datalineage/_index.md
@@ -2,3 +2,8 @@
 title: "Data Lineage"
 weight: 1
 ---
+
+The Data Lineage integration documentation starts on the **[Source](source/)** page (configuration, tools, and requirements).
+
+<meta http-equiv="refresh" content="0; url=source/">
+<p><a href="source/">Continue to the Source documentation</a>.</p>

--- a/docs/en/integrations/dataproc/_index.md
+++ b/docs/en/integrations/dataproc/_index.md
@@ -2,3 +2,8 @@
 title: "Dataproc Clusters"
 weight: 1
 ---
+
+The Dataproc Clusters integration documentation starts on the **[Source](source/)** page (configuration, tools, and requirements).
+
+<meta http-equiv="refresh" content="0; url=source/">
+<p><a href="source/">Continue to the Source documentation</a>.</p>

--- a/docs/en/integrations/dgraph/_index.md
+++ b/docs/en/integrations/dgraph/_index.md
@@ -2,3 +2,8 @@
 title: "Dgraph"
 weight: 1
 ---
+
+The Dgraph integration documentation starts on the **[Source](source/)** page (configuration, tools, and requirements).
+
+<meta http-equiv="refresh" content="0; url=source/">
+<p><a href="source/">Continue to the Source documentation</a>.</p>

--- a/docs/en/integrations/elasticsearch/_index.md
+++ b/docs/en/integrations/elasticsearch/_index.md
@@ -2,3 +2,8 @@
 title: "Elasticsearch"
 weight: 1
 ---
+
+The Elasticsearch integration documentation starts on the **[Source](source/)** page (configuration, tools, and requirements).
+
+<meta http-equiv="refresh" content="0; url=source/">
+<p><a href="source/">Continue to the Source documentation</a>.</p>

--- a/docs/en/integrations/firebird/_index.md
+++ b/docs/en/integrations/firebird/_index.md
@@ -2,3 +2,8 @@
 title: "Firebird"
 weight: 1
 ---
+
+The Firebird integration documentation starts on the **[Source](source/)** page (configuration, tools, and requirements).
+
+<meta http-equiv="refresh" content="0; url=source/">
+<p><a href="source/">Continue to the Source documentation</a>.</p>

--- a/docs/en/integrations/firestore/_index.md
+++ b/docs/en/integrations/firestore/_index.md
@@ -2,3 +2,8 @@
 title: "Firestore"
 weight: 1
 ---
+
+The Firestore integration documentation starts on the **[Source](source/)** page (configuration, tools, and requirements).
+
+<meta http-equiv="refresh" content="0; url=source/">
+<p><a href="source/">Continue to the Source documentation</a>.</p>

--- a/docs/en/integrations/http/_index.md
+++ b/docs/en/integrations/http/_index.md
@@ -2,3 +2,8 @@
 title: "HTTP"
 weight: 1
 ---
+
+The HTTP integration documentation starts on the **[Source](source/)** page (configuration, tools, and requirements).
+
+<meta http-equiv="refresh" content="0; url=source/">
+<p><a href="source/">Continue to the Source documentation</a>.</p>

--- a/docs/en/integrations/knowledge-catalog/_index.md
+++ b/docs/en/integrations/knowledge-catalog/_index.md
@@ -4,3 +4,8 @@ weight: 1
 aliases:
   - /integrations/dataplex/
 ---
+
+The Knowledge Catalog integration documentation starts on the **[Source](source/)** page (configuration, tools, and requirements).
+
+<meta http-equiv="refresh" content="0; url=source/">
+<p><a href="source/">Continue to the Source documentation</a>.</p>

--- a/docs/en/integrations/looker/_index.md
+++ b/docs/en/integrations/looker/_index.md
@@ -2,3 +2,8 @@
 title: "Looker"
 weight: 1
 ---
+
+The Looker integration documentation starts on the **[Source](source/)** page (configuration, tools, and requirements).
+
+<meta http-equiv="refresh" content="0; url=source/">
+<p><a href="source/">Continue to the Source documentation</a>.</p>

--- a/docs/en/integrations/mariadb/_index.md
+++ b/docs/en/integrations/mariadb/_index.md
@@ -2,3 +2,8 @@
 title: "MariaDB"
 weight: 1
 ---
+
+The MariaDB integration documentation starts on the **[Source](source/)** page (configuration, tools, and requirements).
+
+<meta http-equiv="refresh" content="0; url=source/">
+<p><a href="source/">Continue to the Source documentation</a>.</p>

--- a/docs/en/integrations/mindsdb/_index.md
+++ b/docs/en/integrations/mindsdb/_index.md
@@ -2,3 +2,8 @@
 title: "MindsDB"
 weight: 1
 ---
+
+The MindsDB integration documentation starts on the **[Source](source/)** page (configuration, tools, and requirements).
+
+<meta http-equiv="refresh" content="0; url=source/">
+<p><a href="source/">Continue to the Source documentation</a>.</p>

--- a/docs/en/integrations/mongodb/_index.md
+++ b/docs/en/integrations/mongodb/_index.md
@@ -2,3 +2,8 @@
 title: "MongoDB"
 weight: 1
 ---
+
+The MongoDB integration documentation starts on the **[Source](source/)** page (configuration, tools, and requirements).
+
+<meta http-equiv="refresh" content="0; url=source/">
+<p><a href="source/">Continue to the Source documentation</a>.</p>

--- a/docs/en/integrations/mssql/_index.md
+++ b/docs/en/integrations/mssql/_index.md
@@ -2,3 +2,8 @@
 title: "SQL Server"
 weight: 1
 ---
+
+The SQL Server integration documentation starts on the **[Source](source/)** page (configuration, tools, and requirements).
+
+<meta http-equiv="refresh" content="0; url=source/">
+<p><a href="source/">Continue to the Source documentation</a>.</p>

--- a/docs/en/integrations/mysql/_index.md
+++ b/docs/en/integrations/mysql/_index.md
@@ -2,3 +2,8 @@
 title: "MySQL"
 weight: 1
 ---
+
+The MySQL integration documentation starts on the **[Source](source/)** page (configuration, tools, and requirements).
+
+<meta http-equiv="refresh" content="0; url=source/">
+<p><a href="source/">Continue to the Source documentation</a>.</p>

--- a/docs/en/integrations/neo4j/_index.md
+++ b/docs/en/integrations/neo4j/_index.md
@@ -2,3 +2,8 @@
 title: "Neo4j"
 weight: 1
 ---
+
+The Neo4j integration documentation starts on the **[Source](source/)** page (configuration, tools, and requirements).
+
+<meta http-equiv="refresh" content="0; url=source/">
+<p><a href="source/">Continue to the Source documentation</a>.</p>

--- a/docs/en/integrations/oceanbase/_index.md
+++ b/docs/en/integrations/oceanbase/_index.md
@@ -2,3 +2,8 @@
 title: "OceanBase"
 weight: 1
 ---
+
+The OceanBase integration documentation starts on the **[Source](source/)** page (configuration, tools, and requirements).
+
+<meta http-equiv="refresh" content="0; url=source/">
+<p><a href="source/">Continue to the Source documentation</a>.</p>

--- a/docs/en/integrations/oracle/_index.md
+++ b/docs/en/integrations/oracle/_index.md
@@ -2,3 +2,8 @@
 title: "Oracle"
 weight: 1
 ---
+
+The Oracle integration documentation starts on the **[Source](source/)** page (configuration, tools, and requirements).
+
+<meta http-equiv="refresh" content="0; url=source/">
+<p><a href="source/">Continue to the Source documentation</a>.</p>

--- a/docs/en/integrations/postgres/_index.md
+++ b/docs/en/integrations/postgres/_index.md
@@ -2,3 +2,8 @@
 title: "PostgreSQL"
 weight: 1
 ---
+
+The PostgreSQL integration documentation starts on the **[Source](source/)** page (configuration, tools, and requirements).
+
+<meta http-equiv="refresh" content="0; url=source/">
+<p><a href="source/">Continue to the Source documentation</a>.</p>

--- a/docs/en/integrations/redis/_index.md
+++ b/docs/en/integrations/redis/_index.md
@@ -2,3 +2,8 @@
 title: "Redis"
 weight: 1
 ---
+
+The Redis integration documentation starts on the **[Source](source/)** page (configuration, tools, and requirements).
+
+<meta http-equiv="refresh" content="0; url=source/">
+<p><a href="source/">Continue to the Source documentation</a>.</p>

--- a/docs/en/integrations/scylladb/_index.md
+++ b/docs/en/integrations/scylladb/_index.md
@@ -2,3 +2,8 @@
 title: "ScyllaDB"
 weight: 1
 ---
+
+The ScyllaDB integration documentation starts on the **[Source](source/)** page (configuration, tools, and requirements).
+
+<meta http-equiv="refresh" content="0; url=source/">
+<p><a href="source/">Continue to the Source documentation</a>.</p>

--- a/docs/en/integrations/serverless-spark/_index.md
+++ b/docs/en/integrations/serverless-spark/_index.md
@@ -2,3 +2,8 @@
 title: "Serverless for Apache Spark"
 weight: 1
 ---
+
+The Serverless for Apache Spark integration documentation starts on the **[Source](source/)** page (configuration, tools, and requirements).
+
+<meta http-equiv="refresh" content="0; url=source/">
+<p><a href="source/">Continue to the Source documentation</a>.</p>

--- a/docs/en/integrations/singlestore/_index.md
+++ b/docs/en/integrations/singlestore/_index.md
@@ -2,3 +2,8 @@
 title: "SingleStore"
 weight: 1
 ---
+
+The SingleStore integration documentation starts on the **[Source](source/)** page (configuration, tools, and requirements).
+
+<meta http-equiv="refresh" content="0; url=source/">
+<p><a href="source/">Continue to the Source documentation</a>.</p>

--- a/docs/en/integrations/snowflake/_index.md
+++ b/docs/en/integrations/snowflake/_index.md
@@ -2,3 +2,8 @@
 title: "Snowflake"
 weight: 1
 ---
+
+The Snowflake integration documentation starts on the **[Source](source/)** page (configuration, tools, and requirements).
+
+<meta http-equiv="refresh" content="0; url=source/">
+<p><a href="source/">Continue to the Source documentation</a>.</p>

--- a/docs/en/integrations/spanner/_index.md
+++ b/docs/en/integrations/spanner/_index.md
@@ -2,3 +2,8 @@
 title: "Spanner"
 weight: 1
 ---
+
+The Spanner integration documentation starts on the **[Source](source/)** page (configuration, tools, and requirements).
+
+<meta http-equiv="refresh" content="0; url=source/">
+<p><a href="source/">Continue to the Source documentation</a>.</p>

--- a/docs/en/integrations/sqlite/_index.md
+++ b/docs/en/integrations/sqlite/_index.md
@@ -2,3 +2,8 @@
 title: "SQLite"
 weight: 1
 ---
+
+The SQLite integration documentation starts on the **[Source](source/)** page (configuration, tools, and requirements).
+
+<meta http-equiv="refresh" content="0; url=source/">
+<p><a href="source/">Continue to the Source documentation</a>.</p>

--- a/docs/en/integrations/tidb/_index.md
+++ b/docs/en/integrations/tidb/_index.md
@@ -2,3 +2,8 @@
 title: "TiDB"
 weight: 1
 ---
+
+The TiDB integration documentation starts on the **[Source](source/)** page (configuration, tools, and requirements).
+
+<meta http-equiv="refresh" content="0; url=source/">
+<p><a href="source/">Continue to the Source documentation</a>.</p>

--- a/docs/en/integrations/trino/_index.md
+++ b/docs/en/integrations/trino/_index.md
@@ -2,3 +2,8 @@
 title: "Trino"
 weight: 1
 ---
+
+The Trino integration documentation starts on the **[Source](source/)** page (configuration, tools, and requirements).
+
+<meta http-equiv="refresh" content="0; url=source/">
+<p><a href="source/">Continue to the Source documentation</a>.</p>

--- a/docs/en/integrations/valkey/_index.md
+++ b/docs/en/integrations/valkey/_index.md
@@ -2,3 +2,8 @@
 title: "Valkey"
 weight: 1
 ---
+
+The Valkey integration documentation starts on the **[Source](source/)** page (configuration, tools, and requirements).
+
+<meta http-equiv="refresh" content="0; url=source/">
+<p><a href="source/">Continue to the Source documentation</a>.</p>

--- a/docs/en/integrations/yuagbytedb/_index.md
+++ b/docs/en/integrations/yuagbytedb/_index.md
@@ -2,3 +2,8 @@
 title: "YugabyteDB"
 weight: 1
 ---
+
+The YugabyteDB integration documentation starts on the **[Source](source/)** page (configuration, tools, and requirements).
+
+<meta http-equiv="refresh" content="0; url=source/">
+<p><a href="source/">Continue to the Source documentation</a>.</p>


### PR DESCRIPTION
## Summary

Navigating to `/integrations/<name>/` (e.g. AlloyDB) hit an empty section index that only set the page title. This change updates those empty `_index.md` files to:

1. Link to the **Source** documentation page for that integration
2. Meta-refresh to `source/` so the root path is not a dead-end

Applies to all integrations that had an empty section index and a `source.md` sibling (47 pages).

Fixes #3752

## Test plan

- [x] Spot-checked `docs/en/integrations/alloydb/_index.md` content
- [x] Counted 47 integration indexes updated
- [x] Confirmed Hugo `markup.goldmark.renderer.unsafe = true` so meta refresh is emitted