### PR TITLE
fix(bigquery): validate allowedDatasets before dry-run in execute-sql

### DIFF
--- a/internal/tools/bigquery/bigqueryexecutesql/bigqueryexecutesql.go
+++ b/internal/tools/bigquery/bigqueryexecutesql/bigqueryexecutesql.go
@@ -149,6 +149,25 @@ func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.Pa
 		}
 	}
 
+	// When dataset restrictions are configured, statically validate the datasets
+	// the query references *before* the dry-run. The dry-run below still runs to
+	// catch views/wildcards the parser cannot see, but running it first means a
+	// query against a non-existent dataset outside the allowlist fails with an
+	// opaque BigQuery 404 instead of the clear "not in the allowed list" policy
+	// error. Catching it here keeps the policy signal correct regardless of
+	// whether the referenced table actually exists.
+	if len(source.BigQueryAllowedDatasets()) > 0 {
+		parsedTables, parseErr := bqutil.TableParser(sql, bqClient.Project())
+		if parseErr != nil {
+			return nil, util.NewAgentError("could not parse tables from query to validate against allowed datasets", parseErr)
+		}
+		for _, tableID := range parsedTables {
+			if agentErr := checkDatasetAllowed(source, tableID); agentErr != nil {
+				return nil, agentErr
+			}
+		}
+	}
+
 	dryRunJob, err := bqutil.DryRunQuery(ctx, restService, bqClient.Project(), bqClient.Location, sql, nil, connProps, source.GetMaximumBytesBilled())
 	if err != nil {
 		return nil, util.ProcessGcpError(err)
@@ -207,12 +226,8 @@ func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.Pa
 		}
 
 		for tableID := range tableIDSet {
-			parts := strings.Split(tableID, ".")
-			if len(parts) == 3 {
-				projectID, datasetID := parts[0], parts[1]
-				if !source.IsDatasetAllowed(projectID, datasetID) {
-					return nil, util.NewAgentError(fmt.Sprintf("query accesses dataset '%s.%s', which is not in the allowed list", projectID, datasetID), nil)
-				}
+			if agentErr := checkDatasetAllowed(source, tableID); agentErr != nil {
+				return nil, agentErr
 			}
 		}
 	}
@@ -240,6 +255,22 @@ func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.Pa
 		return nil, util.ProcessGcpError(err)
 	}
 	return resp, nil
+}
+
+// checkDatasetAllowed returns an AgentError when a fully-qualified
+// "project.dataset.table" identifier refers to a dataset that is not in the
+// source's allowed list. Identifiers that are not three-part (e.g. bare
+// function calls) are left for other validation paths and return nil.
+func checkDatasetAllowed(source compatibleSource, tableID string) util.ToolboxError {
+	parts := strings.Split(tableID, ".")
+	if len(parts) != 3 {
+		return nil
+	}
+	projectID, datasetID := parts[0], parts[1]
+	if !source.IsDatasetAllowed(projectID, datasetID) {
+		return util.NewAgentError(fmt.Sprintf("query accesses dataset '%s.%s', which is not in the allowed list", projectID, datasetID), nil)
+	}
+	return nil
 }
 
 func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {

--- a/internal/tools/bigquery/bigqueryexecutesql/bigqueryexecutesql_test.go
+++ b/internal/tools/bigquery/bigqueryexecutesql/bigqueryexecutesql_test.go
@@ -98,6 +98,13 @@ func TestInvokeDatasetRestrictions(t *testing.T) {
 			if body.Configuration.DryRun {
 				var referencedTables []map[string]any
 				query := body.Configuration.Query.Query
+				// Simulate BigQuery returning a 404 when the dry-run touches a
+				// non-existent dataset/table. This mirrors the real failure the
+				// allowlist pre-check must front-run.
+				if strings.Contains(query, "nonexistent_dataset") {
+					http.Error(w, "googleapi: Error 404: Not found: Table test-project:nonexistent_dataset.no_such_table, notFound", http.StatusNotFound)
+					return
+				}
 				if strings.Contains(query, "allowed_dataset.my_table") {
 					referencedTables = append(referencedTables, map[string]any{
 						"projectId": "test-project",
@@ -207,6 +214,15 @@ func TestInvokeDatasetRestrictions(t *testing.T) {
 			sql:     "SELECT * FROM forbidden_dataset.my_table",
 			wantErr: true,
 			wantSub: "query accesses dataset 'test-project.forbidden_dataset', which is not in the allowed list",
+		},
+		{
+			// Regression for #3717: a non-existent dataset outside the allowlist
+			// must fail with the allowlist policy error, not the BigQuery 404 the
+			// dry-run would otherwise raise first.
+			desc:    "querying non-existent forbidden dataset returns allowlist error, not 404",
+			sql:     "SELECT * FROM nonexistent_dataset.no_such_table",
+			wantErr: true,
+			wantSub: "query accesses dataset 'test-project.nonexistent_dataset', which is not in the allowed list",
 		},
 		{
 			desc:    "querying allowed dataset INFORMATION_SCHEMA tables",


### PR DESCRIPTION
## Summary

With `allowedDatasets` configured, `bigquery-execute-sql` only enforced the allowlist **after** a successful dry-run. A query referencing a **non-existent** dataset outside the allowlist therefore failed the dry-run with an opaque BigQuery **404 Not Found** (via `ProcessGcpError`) instead of the documented policy error:

```
query accesses dataset 'PROJECT.DATASET', which is not in the allowed list
```

Security stayed fail-safe (no data returned), but the signal was wrong — agents and evals couldn't distinguish "table missing" from "dataset not allowlisted".

Fixes #3717

## Change

- In `Invoke`, when `allowedDatasets` is non-empty, statically parse the referenced datasets with `TableParser` and reject any outside the allowlist **before** the dry-run.
- The dry-run and the existing post-dry-run check still run afterward to catch views/wildcards the static parser can't see (statement-type restrictions, `ReferencedTables` enrichment), so no coverage is lost.
- Extracted the shared "is this dataset allowed?" logic into a `checkDatasetAllowed` helper, used by both the pre- and post-dry-run paths.

## Testing

- Added a `TestInvokeDatasetRestrictions` case where the mocked dry-run returns a 404 for a non-existent dataset; it asserts the tool now returns the allowlist policy error rather than the 404.
- Verified the new case **fails on the pre-fix code** (`got HTTP response code 404 ... Not found: Table ...nonexistent_dataset`) and **passes with the fix** — a genuine regression guard.
- All existing `TestInvokeDatasetRestrictions` cases (allowed/forbidden tables, INFORMATION_SCHEMA, EXTERNAL_QUERY, etc.) still pass; `go build`, `go vet`, and `go test` on the package are green.