### PR TITLE
docs(integrations): redirect roots to source pages

### DIFF
--- a/.hugo/layouts/partials/hooks/head-end.html
+++ b/.hugo/layouts/partials/hooks/head-end.html
@@ -2,3 +2,9 @@
 {{ if not .Site.Params.disableBanner }}
   <script src="{{ "js/custom-layout.js" | relURL }}"></script>
 {{ end }}
+{{ if and .IsSection (findRE `^/integrations/[^/]+/$` .RelPermalink) }}
+  {{ with .GetPage "source" }}
+    <link rel="canonical" href="{{ .Permalink }}">
+    <meta http-equiv="refresh" content="0;url={{ .RelPermalink }}">
+  {{ end }}
+{{ end }}

--- a/.hugo/layouts/partials/hooks/head-end.html
+++ b/.hugo/layouts/partials/hooks/head-end.html
@@ -2,7 +2,7 @@
 {{ if not .Site.Params.disableBanner }}
   <script src="{{ "js/custom-layout.js" | relURL }}"></script>
 {{ end }}
-{{ if and .IsSection (findRE `^/integrations/[^/]+/$` .RelPermalink) }}
+{{ if and .IsSection .Parent (eq .Parent (site.GetPage "/integrations")) }}
   {{ with .GetPage "source" }}
     <link rel="canonical" href="{{ .Permalink }}">
     <meta http-equiv="refresh" content="0;url={{ .RelPermalink }}">


### PR DESCRIPTION
## Description

Direct integration URLs such as `/integrations/alloydb/` currently render empty section pages. This change adds a Hugo head hook that redirects only direct integration sections with a `source` child to their generated `/source/` page. Nested sections and category pages without a source page remain unchanged.

## Validation

- `npm ci`
- Hugo 0.163.3 development build (777 pages)
- `hugo --minify --config hugo.cloudflare.toml`
- Verified all 47 integration roots with `source.md` receive exactly one redirect, with no redirects on nested or category sections

## PR Checklist

- [x] Reviewed `CONTRIBUTING.md`
- [x] Existing issue describes the change
- [x] Relevant builds pass
- [x] No source-code coverage impact
- [x] Documentation routing updated
- [x] No breaking change

Fixes #3752