### PR TITLE
fix(docs): redirect integration sections to source

### DIFF
--- a/.hugo/layouts/docs/section.html
+++ b/.hugo/layouts/docs/section.html
@@ -1,4 +1,10 @@
 {{ define "main" }}
+{{ $sourcePages := where .Pages "File.BaseFileName" "source" }}
+{{ if and (hasPrefix .RelPermalink "/integrations/") (gt (len $sourcePages) 0) }}
+<meta http-equiv="refresh" content="0; url={{ (index $sourcePages 0).RelPermalink }}">
+<script>window.location.replace({{ (index $sourcePages 0).RelPermalink | jsonify }});</script>
+<p>Redirecting to <a href="{{ (index $sourcePages 0).RelPermalink }}">{{ (index $sourcePages 0).Title }}</a>...</p>
+{{ else }}
 <div class="td-content">
     <h1>{{ .Title }}</h1>
     {{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
@@ -23,4 +29,5 @@
     {{ end }}
     {{ partial "page-meta-lastmod.html" . }}
 </div>
+{{ end }}
 {{ end }}


### PR DESCRIPTION
Fixes #3752.

Integration sections that contain a `source.md` page now redirect their root URL to that source page. This applies globally through the shared Hugo section layout, so new integrations inherit the behavior automatically.

Validation:
- Verified the Hugo template references the child `source` page and emits both a meta refresh and JavaScript fallback.
- `git diff --check` passes.