### PR TITLE
test(mongodb,bigtable): migrate to `testcontainers` for integration tests and fix flakey test

### DIFF
--- a/.ci/integration.cloudbuild.yaml
+++ b/.ci/integration.cloudbuild.yaml
@@ -968,9 +968,8 @@ steps:
     entrypoint: /bin/bash
     env:
       - "GOPATH=/gopath"
-      - "MONGODB_DATABASE=$_DATABASE_NAME"
       - "SERVICE_ACCOUNT_EMAIL=$SERVICE_ACCOUNT_EMAIL"
-    secretEnv: ["MONGODB_URI", "CLIENT_ID"]
+    secretEnv: ["CLIENT_ID"]
     volumes:
       - name: "go"
         path: "/gopath"
@@ -1672,8 +1671,6 @@ availableSecrets:
       env: MARIADB_PASS
     - versionName: projects/$PROJECT_ID/secrets/mariadb_host/versions/latest
       env: MARIADB_HOST
-    - versionName: projects/$PROJECT_ID/secrets/mongodb_uri/versions/latest
-      env: MONGODB_URI
 
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/go.mod
+++ b/go.mod
@@ -243,6 +243,7 @@ require (
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.6.0 // indirect
 	github.com/stretchr/testify v1.11.1 // indirect
+	github.com/testcontainers/testcontainers-go/modules/mongodb v0.43.0 // indirect
 	github.com/tidwall/gjson v1.17.1 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -62,6 +62,7 @@ require (
 	github.com/testcontainers/testcontainers-go v0.43.0
 	github.com/testcontainers/testcontainers-go/modules/cockroachdb v0.43.0
 	github.com/testcontainers/testcontainers-go/modules/couchbase v0.43.0
+	github.com/testcontainers/testcontainers-go/modules/mongodb v0.43.0
 	github.com/testcontainers/testcontainers-go/modules/scylladb v0.43.0
 	github.com/thlib/go-timezone-local v0.0.7
 	github.com/trinodb/trino-go-client v0.333.0
@@ -243,7 +244,6 @@ require (
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.6.0 // indirect
 	github.com/stretchr/testify v1.11.1 // indirect
-	github.com/testcontainers/testcontainers-go/modules/mongodb v0.43.0 // indirect
 	github.com/tidwall/gjson v1.17.1 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -574,6 +574,8 @@ github.com/testcontainers/testcontainers-go/modules/cockroachdb v0.43.0 h1:WD1xV
 github.com/testcontainers/testcontainers-go/modules/cockroachdb v0.43.0/go.mod h1:Y68nC09QC+RmnOyh2WLfAS3VR3/EPkcKoKcn6a8BRFQ=
 github.com/testcontainers/testcontainers-go/modules/couchbase v0.43.0 h1:jmn8aYThX+xAmNh1n5ErFT7ju2EvKbXD6nWXLM71AME=
 github.com/testcontainers/testcontainers-go/modules/couchbase v0.43.0/go.mod h1:6lKST1Z6/281hrMDKB37P/v30PNICU9CQVGnW8w5Hcg=
+github.com/testcontainers/testcontainers-go/modules/mongodb v0.43.0 h1:RJlAAz8dv61icyHvFmrr1xZHJEWZdvBfVBAU6wnmGPM=
+github.com/testcontainers/testcontainers-go/modules/mongodb v0.43.0/go.mod h1:1zaDEZyV1SK+mpz83tmB2KthF6DHaS4Y+lRvy3d2XiE=
 github.com/testcontainers/testcontainers-go/modules/scylladb v0.43.0 h1:0CxAoATVlXC45GSzaJFChR1wqIj8v0XetWhGUdBEPC8=
 github.com/testcontainers/testcontainers-go/modules/scylladb v0.43.0/go.mod h1:07IhPfqcWw2RArDcuNUKAl+CCHe+/a9trUr+ZvVWVig=
 github.com/thlib/go-timezone-local v0.0.7 h1:fX8zd3aJydqLlTs/TrROrIIdztzsdFV23OzOQx31jII=

--- a/internal/sources/bigtable/admin_wrappers.go
+++ b/internal/sources/bigtable/admin_wrappers.go
@@ -16,6 +16,7 @@ package bigtable
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -68,6 +69,10 @@ func (s *Source) DeleteInstance(ctx context.Context, instanceId string) (any, er
 func (s *Source) ListInstances(ctx context.Context) (any, error) {
 	instances, err := s.InstanceAdmin.Instances(ctx)
 	if err != nil {
+		var partialErr bigtable.ErrPartiallyUnavailable
+		if errors.As(err, &partialErr) {
+			return instances, nil
+		}
 		return nil, fmt.Errorf("failed to list instances: %w", err)
 	}
 	return instances, nil
@@ -84,6 +89,10 @@ func (s *Source) GetCluster(ctx context.Context, instanceId, clusterId string) (
 func (s *Source) ListClusters(ctx context.Context, instanceId string) (any, error) {
 	clusters, err := s.InstanceAdmin.Clusters(ctx, instanceId)
 	if err != nil {
+		var partialErr bigtable.ErrPartiallyUnavailable
+		if errors.As(err, &partialErr) {
+			return clusters, nil
+		}
 		return nil, fmt.Errorf("failed to list clusters: %w", err)
 	}
 	return clusters, nil

--- a/tests/mongodb/mongodb_integration_test.go
+++ b/tests/mongodb/mongodb_integration_test.go
@@ -21,35 +21,50 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"regexp"
 	"testing"
 	"time"
 
 	"github.com/googleapis/mcp-toolbox/internal/testutils"
 	"github.com/googleapis/mcp-toolbox/tests"
+	tcmongodb "github.com/testcontainers/testcontainers-go/modules/mongodb"
 	"go.mongodb.org/mongo-driver/v2/mongo"
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 var (
-	MongoDbSourceType   = "mongodb"
-	MongoDbToolType     = "mongodb-find"
-	MongoDbUri          = os.Getenv("MONGODB_URI")
-	MongoDbDatabase     = os.Getenv("MONGODB_DATABASE")
-	ServiceAccountEmail = os.Getenv("SERVICE_ACCOUNT_EMAIL")
+	MongoDbSourceType = "mongodb"
+	MongoDbToolType   = "mongodb-find"
+	MongoDbDatabase   = "testdb"
 )
 
-func getMongoDBVars(t *testing.T) map[string]any {
-	switch "" {
-	case MongoDbUri:
-		t.Fatal("'MongoDbUri' not set")
-	case MongoDbDatabase:
-		t.Fatal("'MongoDbDatabase' not set")
+func setupMongoDBContainer(ctx context.Context, t *testing.T) (string, func()) {
+	t.Helper()
+
+	mongodbContainer, err := tcmongodb.Run(ctx, "mongo:6")
+	if err != nil {
+		t.Fatalf("failed to start mongodb container: %s", err)
 	}
+
+	cleanup := func() {
+		if err := mongodbContainer.Terminate(ctx); err != nil {
+			t.Logf("failed to terminate mongodb container: %s", err)
+		}
+	}
+
+	endpoint, err := mongodbContainer.ConnectionString(ctx)
+	if err != nil {
+		cleanup()
+		t.Fatalf("failed to get mongodb connection string: %s", err)
+	}
+
+	return endpoint, cleanup
+}
+
+func getMongoDBVars(uri string) map[string]any {
 	return map[string]any{
 		"type": MongoDbSourceType,
-		"uri":  MongoDbUri,
+		"uri":  uri,
 	}
 }
 
@@ -67,13 +82,17 @@ func initMongoDbDatabase(ctx context.Context, uri, database string) (*mongo.Data
 }
 
 func TestMongoDBToolEndpoints(t *testing.T) {
-	sourceConfig := getMongoDBVars(t)
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
+
+	uri, cleanupContainer := setupMongoDBContainer(ctx, t)
+	defer cleanupContainer()
+
+	sourceConfig := getMongoDBVars(uri)
 
 	args := []string{"--enable-api"}
 
-	database, err := initMongoDbDatabase(ctx, MongoDbUri, MongoDbDatabase)
+	database, err := initMongoDbDatabase(ctx, uri, MongoDbDatabase)
 	if err != nil {
 		t.Fatalf("unable to create MongoDB connection: %s", err)
 	}
@@ -452,7 +471,7 @@ func setupMongoDB(t *testing.T, ctx context.Context, database *mongo.Database) f
 	}
 
 	documents := []map[string]any{
-		{"_id": 1, "id": 1, "name": "Alice", "email": ServiceAccountEmail},
+		{"_id": 1, "id": 1, "name": "Alice", "email": tests.ServiceAccountEmail},
 		{"_id": 14, "id": 2, "name": "FakeAlice", "email": "fakeAlice@gmail.com"},
 		{"_id": 2, "id": 2, "name": "Jane"},
 		{"_id": 3, "id": 3, "name": "Sid"},

--- a/tests/mongodb/mongodb_integration_test.go
+++ b/tests/mongodb/mongodb_integration_test.go
@@ -47,7 +47,7 @@ func setupMongoDBContainer(ctx context.Context, t *testing.T) (string, func()) {
 	}
 
 	cleanup := func() {
-		if err := mongodbContainer.Terminate(ctx); err != nil {
+		if err := mongodbContainer.Terminate(context.Background()); err != nil {
 			t.Logf("failed to terminate mongodb container: %s", err)
 		}
 	}

--- a/tests/mongodb/mongodb_integration_test.go
+++ b/tests/mongodb/mongodb_integration_test.go
@@ -110,8 +110,8 @@ func TestMongoDBToolEndpoints(t *testing.T) {
 	}
 	defer cleanup()
 
-	waitCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
+	waitCtx, waitCancel := context.WithTimeout(ctx, 10*time.Second)
+	defer waitCancel()
 	out, err := testutils.WaitForString(waitCtx, regexp.MustCompile(`Server ready to serve`), cmd.Out)
 	if err != nil {
 		t.Logf("toolbox command logs: \n%s", out)


### PR DESCRIPTION
Getting rid of external test instance dependency to reduce future maintenance burden, preventing CVE on VM.
Also fix a bigtable flakey test error-When partial results are returned due to unavailable locations, ListInstances and ListClusters will now return the retrieved instances/clusters instead of failing the request.