### PR TITLE
test(tool/looker): stop pinning the exact get_field_value_suggestions list

### DIFF
--- a/tests/looker/looker_integration_test.go
+++ b/tests/looker/looker_integration_test.go
@@ -2390,7 +2390,7 @@ func TestLooker(t *testing.T) {
 	tests.RunToolInvokeParametersTest(t, "get_field_value_suggestions", []byte(`{"model": "system__activity", "explore": "history", "field": "history.source", "term": "ap"}`), wantResult)
 
 	// Verify that conditional filtering based on other fields works
-	testFieldValueSuggestions(t, []byte(`{"model": "system__activity", "explore": "history", "field": "history.source", "filters": {"history.status": "complete"}}`), wantSuggestions)
+	testFieldValueSuggestions(t, "with_filtering", []byte(`{"model": "system__activity", "explore": "history", "field": "history.source", "filters": {"history.status": "complete"}}`), wantSuggestions)
 
 	wantResult = "{\"description\":\"\",\"label\":\"API Usage\",\"label_short\":\"API Usage\",\"name\":\"turtle::api_usage\",\"suggestable\":false,\"type\":\"turtle_look\"}"
 	tests.RunToolInvokeParametersTest(t, "get_measures", []byte(`{"model": "system__activity", "explore": "content_usage"}`), wantResult)

--- a/tests/looker/looker_integration_test.go
+++ b/tests/looker/looker_integration_test.go
@@ -2383,7 +2383,7 @@ func TestLooker(t *testing.T) {
 
 	// Verify that the suggestions list contains the expected values
 	wantSuggestions := []string{"api4", "dashboard", "explore", "merge_query", "regenerator", "sqlrunner", "suggest"}
-	testFieldValueSuggestions(t, []byte(`{"model": "system__activity", "explore": "history", "field": "history.source"}`), wantSuggestions)
+	testFieldValueSuggestions(t, "basic", []byte("{\"model\": \"system__activity\", \"explore\": \"history\", \"field\": \"history.source\"}"), wantSuggestions)
 
 	// Verify that search term filtering works
 	wantResult = "{\"suggestions\":[\"api4\"]}"

--- a/tests/looker/looker_integration_test.go
+++ b/tests/looker/looker_integration_test.go
@@ -2381,17 +2381,16 @@ func TestLooker(t *testing.T) {
 	wantResult = `{"suggestions":`
 	tests.RunToolInvokeParametersTest(t, "get_field_value_suggestions", []byte(`{"model": "system__activity", "explore": "history", "field": "history.source"}`), wantResult)
 
-	// Verify that the suggestions list contains the expected value
-	wantResult = "{\"suggestions\":[\"api4\",\"dashboard\",\"explore\",\"merge_query\",\"regenerator\",\"sqlrunner\",\"suggest\"]}"
-	tests.RunToolInvokeParametersTest(t, "get_field_value_suggestions", []byte(`{"model": "system__activity", "explore": "history", "field": "history.source"}`), wantResult)
+	// Verify that the suggestions list contains the expected values
+	wantSuggestions := []string{"api4", "dashboard", "explore", "merge_query", "regenerator", "sqlrunner", "suggest"}
+	testFieldValueSuggestions(t, []byte(`{"model": "system__activity", "explore": "history", "field": "history.source"}`), wantSuggestions)
 
 	// Verify that search term filtering works
 	wantResult = "{\"suggestions\":[\"api4\"]}"
 	tests.RunToolInvokeParametersTest(t, "get_field_value_suggestions", []byte(`{"model": "system__activity", "explore": "history", "field": "history.source", "term": "ap"}`), wantResult)
 
 	// Verify that conditional filtering based on other fields works
-	wantResult = "{\"suggestions\":[\"api4\",\"dashboard\",\"explore\",\"merge_query\",\"regenerator\",\"sqlrunner\",\"suggest\"]}"
-	tests.RunToolInvokeParametersTest(t, "get_field_value_suggestions", []byte(`{"model": "system__activity", "explore": "history", "field": "history.source", "filters": {"history.status": "complete"}}`), wantResult)
+	testFieldValueSuggestions(t, []byte(`{"model": "system__activity", "explore": "history", "field": "history.source", "filters": {"history.status": "complete"}}`), wantSuggestions)
 
 	wantResult = "{\"description\":\"\",\"label\":\"API Usage\",\"label_short\":\"API Usage\",\"name\":\"turtle::api_usage\",\"suggestable\":false,\"type\":\"turtle_look\"}"
 	tests.RunToolInvokeParametersTest(t, "get_measures", []byte(`{"model": "system__activity", "explore": "content_usage"}`), wantResult)
@@ -2548,6 +2547,48 @@ func TestLooker(t *testing.T) {
 
 	wantResult = "\"Model\":\"the_look\""
 	tests.RunToolInvokeParametersTest(t, "health_vacuum", []byte(`{"action": "models"}`), wantResult)
+}
+
+// testFieldValueSuggestions asserts that get_field_value_suggestions returns at
+// least the wanted values. Suggestions are drawn from live System Activity data,
+// which only accumulates — running the LookML tests in this suite, for instance,
+// adds "__lookml_test__" as a history source — so the exact list cannot be pinned.
+func testFieldValueSuggestions(t *testing.T, params []byte, want []string) {
+	t.Run("invoke get_field_value_suggestions", func(t *testing.T) {
+		url := "http://127.0.0.1:5000/api/tool/get_field_value_suggestions/invoke"
+		resp, bodyBytes := tests.RunRequest(t, http.MethodPost, url, bytes.NewBuffer(params), nil)
+
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("unexpected status code: got %d, want %d. Body: %s", resp.StatusCode, http.StatusOK, string(bodyBytes))
+		}
+
+		var respBody map[string]any
+		if err := json.Unmarshal(bodyBytes, &respBody); err != nil {
+			t.Fatalf("error parsing response body: %v", err)
+		}
+
+		result, ok := respBody["result"].(string)
+		if !ok {
+			t.Fatalf("unable to find result in response body: %s", string(bodyBytes))
+		}
+
+		var got struct {
+			Suggestions []string `json:"suggestions"`
+		}
+		if err := json.Unmarshal([]byte(result), &got); err != nil {
+			t.Fatalf("error parsing result body: %v", err)
+		}
+
+		gotSuggestions := make(map[string]bool, len(got.Suggestions))
+		for _, s := range got.Suggestions {
+			gotSuggestions[s] = true
+		}
+		for _, w := range want {
+			if !gotSuggestions[w] {
+				t.Errorf("missing suggestion %q: got %v", w, got.Suggestions)
+			}
+		}
+	})
 }
 
 func findTestAgentId(t *testing.T, name string) (string, error) {

--- a/tests/looker/looker_integration_test.go
+++ b/tests/looker/looker_integration_test.go
@@ -2553,8 +2553,10 @@ func TestLooker(t *testing.T) {
 // least the wanted values. Suggestions are drawn from live System Activity data,
 // which only accumulates — running the LookML tests in this suite, for instance,
 // adds "__lookml_test__" as a history source — so the exact list cannot be pinned.
-func testFieldValueSuggestions(t *testing.T, params []byte, want []string) {
-	t.Run("invoke get_field_value_suggestions", func(t *testing.T) {
+func testFieldValueSuggestions(t *testing.T, name string, params []byte, want []string) {
+	t.Helper()
+	t.Run("invoke get_field_value_suggestions/"+name, func(t *testing.T) {
+		t.Helper()
 		url := "http://127.0.0.1:5000/api/tool/get_field_value_suggestions/invoke"
 		resp, bodyBytes := tests.RunRequest(t, http.MethodPost, url, bytes.NewBuffer(params), nil)
 


### PR DESCRIPTION
## Description

Two `get_field_value_suggestions` assertions in the Looker integration test matched the complete set of values for `history.source` on the shared Looker instance:

```go
wantResult = "{\"suggestions\":[\"api4\",\"dashboard\",\"explore\",\"merge_query\",\"regenerator\",\"sqlrunner\",\"suggest\"]}"
```

System Activity history is live, append-only data — and this suite appends to it. `run_lookml_tests` (same test, line 2481) writes history rows with source `__lookml_test__`, so the tool now returns an eighth value and the exact-list match can never pass again:

```
got  {"suggestions":["api4","dashboard","explore","merge_query","regenerator","sqlrunner","suggest","__lookml_test__"]}
want {"suggestions":["api4","dashboard","explore","merge_query","regenerator","sqlrunner","suggest"]}
```

This fails `TestLooker/invoke_get_field_value_suggestions#01` and `#03` on every PR that triggers the Looker step, regardless of what the PR changes.

The fix replaces the two exact-list assertions with a helper that checks the expected values are all present, tolerating extra values and ordering changes. The `term: "ap"` case keeps its exact assertion — it filters down to a single deterministic value.