### PR TITLE
fix(tools/looker): scope filters quoting rule and align param names with schema

### DIFF
--- a/docs/en/integrations/looker/tools/looker-add-dashboard-element.md
+++ b/docs/en/integrations/looker/tools/looker-add-dashboard-element.md
@@ -38,12 +38,12 @@ description: |
 
   Required Parameters:
   - dashboard_id: The ID of the target dashboard, obtained from `make_dashboard`.
-  - model_name, explore_name, fields: These query parameters are inherited
+  - model, explore, fields: These query parameters are inherited
     from the `query` tool and are required to define the data for the tile.
 
   Optional Parameters:
   - title: An optional title for the dashboard tile.
-  - pivots, filters, sorts, limit, query_timezone: These query parameters are
+  - pivots, filters, sorts, limit, tz: These query parameters are
     inherited from the `query` tool and can be used to customize the tile's query.
   - vis_config: A JSON object defining the visualization settings for this tile.
     The structure and options are the same as for the `query_url` tool's `vis_config`.

--- a/docs/en/integrations/looker/tools/looker-get-dimensions.md
+++ b/docs/en/integrations/looker/tools/looker-get-dimensions.md
@@ -33,8 +33,8 @@ description: |
   filtering, or segmenting query results.
 
   Parameters:
-  - model_name (required): The name of the LookML model, obtained from `get_models`.
-  - explore_name (required): The name of the explore within the model, obtained from `get_explores`.
+  - model (required): The name of the LookML model, obtained from `get_models`.
+  - explore (required): The name of the explore within the model, obtained from `get_explores`.
 
   Output Details:
   - If a dimension includes a `suggestions` field, its contents are valid values

--- a/docs/en/integrations/looker/tools/looker-get-explores.md
+++ b/docs/en/integrations/looker/tools/looker-get-explores.md
@@ -45,7 +45,7 @@ description: |
   The output provides details like the explore's `name` and `label`.
 
   Parameters:
-  - model_name (required): The name of the LookML model, obtained from `get_models`.
+  - model (required): The name of the LookML model, obtained from `get_models`.
 ```
 
 ## Reference

--- a/docs/en/integrations/looker/tools/looker-get-filters.md
+++ b/docs/en/integrations/looker/tools/looker-get-filters.md
@@ -37,8 +37,8 @@ description: |
   This tool *only* returns fields explicitly defined as `filter:` in LookML.
 
   Parameters:
-  - model_name (required): The name of the LookML model, obtained from `get_models`.
-  - explore_name (required): The name of the explore within the model, obtained from `get_explores`.
+  - model (required): The name of the LookML model, obtained from `get_models`.
+  - explore (required): The name of the explore within the model, obtained from `get_explores`.
 ```
 
 The response is a json array with the following elements:

--- a/docs/en/integrations/looker/tools/looker-get-measures.md
+++ b/docs/en/integrations/looker/tools/looker-get-measures.md
@@ -31,8 +31,8 @@ description: |
   that are used for calculations and quantitative analysis in your queries.
 
   Parameters:
-  - model_name (required): The name of the LookML model, obtained from `get_models`.
-  - explore_name (required): The name of the explore within the model, obtained from `get_explores`.
+  - model (required): The name of the LookML model, obtained from `get_models`.
+  - explore (required): The name of the explore within the model, obtained from `get_explores`.
 
   Output Details:
   - If a measure includes a `suggestions` field, its contents are valid values

--- a/docs/en/integrations/looker/tools/looker-get-parameters.md
+++ b/docs/en/integrations/looker/tools/looker-get-parameters.md
@@ -33,8 +33,8 @@ description: |
   users to choose dimensions, measures, or other query components at runtime.
 
   Parameters:
-  - model_name (required): The name of the LookML model, obtained from `get_models`.
-  - explore_name (required): The name of the explore within the model, obtained from `get_explores`.
+  - model (required): The name of the LookML model, obtained from `get_models`.
+  - explore (required): The name of the explore within the model, obtained from `get_explores`.
 ```
 
 The response is a json array with the following elements:

--- a/docs/en/integrations/looker/tools/looker-make-look.md
+++ b/docs/en/integrations/looker/tools/looker-make-look.md
@@ -45,12 +45,12 @@ description: |
   Required Parameters:
   - title: A unique title for the new Look.
   - description: A brief description of the Look's purpose.
-  - model_name: The name of the LookML model (from `get_models`).
-  - explore_name: The name of the explore (from `get_explores`).
+  - model: The name of the LookML model (from `get_models`).
+  - explore: The name of the explore (from `get_explores`).
   - fields: A list of field names (dimensions, measures, filters, or parameters) to include in the query.
 
   Optional Parameters:
-  - pivots, filters, sorts, limit, query_timezone: These parameters are identical
+  - pivots, filters, sorts, limit, tz: These parameters are identical
     to those described for the `query` tool.
   - vis_config: A JSON object defining the visualization settings for the Look.
     The structure and options are the same as for the `query_url` tool's `vis_config`.

--- a/docs/en/integrations/looker/tools/looker-query-sql.md
+++ b/docs/en/integrations/looker/tools/looker-query-sql.md
@@ -47,8 +47,8 @@ description: |
 
   Parameters:
   All parameters for this tool are identical to those of the `query` tool.
-  This includes `model_name`, `explore_name`, `fields` (required),
-  and optional parameters like `pivots`, `filters`, `filter_expression`, `dynamic_fields`, `sorts`, `limit`, and `query_timezone`.
+  This includes `model`, `explore`, `fields` (required),
+  and optional parameters like `pivots`, `filters`, `filter_expression`, `dynamic_fields`, `sorts`, `limit`, and `tz`.
 
   Output:
   The result of this tool is the raw SQL text.

--- a/docs/en/integrations/looker/tools/looker-query-url.md
+++ b/docs/en/integrations/looker/tools/looker-query-url.md
@@ -42,8 +42,8 @@ description: |
   along with the `query_id` and `slug`.
 
   Parameters:
-  All query parameters (e.g., `model_name`, `explore_name`, `fields`, `pivots`,
-  `filters`, `filter_expression`, `dynamic_fields`, `sorts`, `limit`, `query_timezone`) are the same as the `query` tool.
+  All query parameters (e.g., `model`, `explore`, `fields`, `pivots`,
+  `filters`, `filter_expression`, `dynamic_fields`, `sorts`, `limit`, `tz`) are the same as the `query` tool.
 
   Additionally, it accepts an optional `vis_config` parameter:
   - vis_config (optional): A JSON object that controls the default visualization

--- a/docs/en/integrations/looker/tools/looker-query.md
+++ b/docs/en/integrations/looker/tools/looker-query.md
@@ -44,16 +44,21 @@ description: |
   This tool runs a query against a LookML model and returns the results in JSON format.
 
   Required Parameters:
-  - model_name: The name of the LookML model (from `get_models`).
-  - explore_name: The name of the explore (from `get_explores`).
+  - model: The name of the LookML model (from `get_models`).
+  - explore: The name of the explore (from `get_explores`).
   - fields: A list of field names (dimensions, measures, filters, or parameters) to include in the query.
 
   Optional Parameters:
   - pivots: A list of fields to pivot the results by. These fields must also be included in the `fields` list.
-  - filters: A map of filter expressions, e.g., `{"view.field": "value", "view.date": "7 days"}`.
-    - Do not quote field names.
+  - filters: A map of filter expressions, e.g., `{"view_name.field_name": "value", "view_name.date": "7 days"}`.
+    - Each key must be a fully-scoped `view_name.field_name`, copied verbatim from
+      `get_dimensions`, `get_measures`, `get_filters`, or `get_parameters`. The view
+      prefix and the dot are required.
+    - Each value is a Looker filter expression. Pass values bare: do not wrap them in
+      extra quote characters. For LookML `parameter` fields, use the raw allowed_value
+      (e.g. `first_touch`, not `"first_touch"`).
     - Use `not null` instead of `-NULL`.
-    - If a value contains a comma, enclose it in single quotes (e.g., "'New York, NY'").
+    - If a value contains a comma, enclose it in single quotes (e.g., `'New York, NY'`).
   - filter_expression: A Looker expression filter string (custom filter). This allows complex logic and comparing fields.
     - Reference fields using `${view.field_name}` syntax.
     - Supports logical operators (`AND`, `OR`, `NOT`) and comparison operators.
@@ -71,7 +76,7 @@ description: |
       - Custom Measure: `[{"measure": "sum_of_revenue", "label": "Sum of Revenue", "based_on": "training.revenue", "type": "sum", "_type_hint": "number"}]`
   - sorts: A list of fields to sort by, optionally including direction (e.g., `["view.field desc"]`).
   - limit: Row limit (default 500). Use "-1" for unlimited.
-  - query_timezone: specific timezone for the query (e.g. `America/Los_Angeles`).
+  - tz: specific timezone for the query (e.g. `America/Los_Angeles`).
 
   Note: Use `get_dimensions`, `get_measures`, `get_filters`, and `get_parameters` to find valid fields.
 

--- a/internal/prebuiltconfigs/tools/looker-conversational-analytics.yaml
+++ b/internal/prebuiltconfigs/tools/looker-conversational-analytics.yaml
@@ -61,7 +61,7 @@ description: |
   The output provides details like the explore's `name` and `label`.
 
   Parameters:
-  - model_name (required): The name of the LookML model, obtained from `get_models`.
+  - model (required): The name of the LookML model, obtained from `get_models`.
 ---
 kind: toolset
 name: looker_conversational_analytics_tools

--- a/internal/prebuiltconfigs/tools/looker.yaml
+++ b/internal/prebuiltconfigs/tools/looker.yaml
@@ -48,7 +48,7 @@ description: |
   The output provides details like the explore's `name` and `label`.
 
   Parameters:
-  - model_name (required): The name of the LookML model, obtained from `get_models`.
+  - model (required): The name of the LookML model, obtained from `get_models`.
 ---
 kind: tool
 name: get_dimensions
@@ -61,8 +61,8 @@ description: |
   filtering, or segmenting query results.
 
   Parameters:
-  - model_name (required): The name of the LookML model, obtained from `get_models`.
-  - explore_name (required): The name of the explore within the model, obtained from `get_explores`.
+  - model (required): The name of the LookML model, obtained from `get_models`.
+  - explore (required): The name of the explore within the model, obtained from `get_explores`.
 
   Output Details:
   - If a dimension includes a `suggestions` field, its contents are valid values
@@ -81,8 +81,8 @@ description: |
   that are used for calculations and quantitative analysis in your queries.
 
   Parameters:
-  - model_name (required): The name of the LookML model, obtained from `get_models`.
-  - explore_name (required): The name of the explore within the model, obtained from `get_explores`.
+  - model (required): The name of the LookML model, obtained from `get_models`.
+  - explore (required): The name of the explore within the model, obtained from `get_explores`.
 
   Output Details:
   - If a measure includes a `suggestions` field, its contents are valid values
@@ -105,8 +105,8 @@ description: |
   This tool *only* returns fields explicitly defined as `filter:` in LookML.
 
   Parameters:
-  - model_name (required): The name of the LookML model, obtained from `get_models`.
-  - explore_name (required): The name of the explore within the model, obtained from `get_explores`.
+  - model (required): The name of the LookML model, obtained from `get_models`.
+  - explore (required): The name of the explore within the model, obtained from `get_explores`.
 ---
 kind: tool
 name: get_parameters
@@ -120,8 +120,8 @@ description: |
   users to choose dimensions, measures, or other query components at runtime.
 
   Parameters:
-  - model_name (required): The name of the LookML model, obtained from `get_models`.
-  - explore_name (required): The name of the explore within the model, obtained from `get_explores`.
+  - model (required): The name of the LookML model, obtained from `get_models`.
+  - explore (required): The name of the explore within the model, obtained from `get_explores`.
 ---
 kind: tool
 name: get_field_value_suggestions
@@ -150,16 +150,21 @@ description: |
   This tool runs a query against a LookML model and returns the results in JSON format.
 
   Required Parameters:
-  - model_name: The name of the LookML model (from `get_models`).
-  - explore_name: The name of the explore (from `get_explores`).
+  - model: The name of the LookML model (from `get_models`).
+  - explore: The name of the explore (from `get_explores`).
   - fields: A list of field names (dimensions, measures, filters, or parameters) to include in the query.
 
   Optional Parameters:
   - pivots: A list of fields to pivot the results by. These fields must also be included in the `fields` list.
-  - filters: A map of filter expressions, e.g., `{"view.field": "value", "view.date": "7 days"}`.
-    - Do not quote field names.
+  - filters: A map of filter expressions, e.g., `{"view_name.field_name": "value", "view_name.date": "7 days"}`.
+    - Each key must be a fully-scoped `view_name.field_name`, copied verbatim from
+      `get_dimensions`, `get_measures`, `get_filters`, or `get_parameters`. The view
+      prefix and the dot are required.
+    - Each value is a Looker filter expression. Pass values bare: do not wrap them in
+      extra quote characters. For LookML `parameter` fields, use the raw allowed_value
+      (e.g. `first_touch`, not `"first_touch"`).
     - Use `not null` instead of `-NULL`.
-    - If a value contains a comma, enclose it in single quotes (e.g., "'New York, NY'").
+    - If a value contains a comma, enclose it in single quotes (e.g., `'New York, NY'`).
     - To retrieve valid filter values for a suggestible field, use the 'get_field_value_suggestions' tool.
   - filter_expression: A Looker expression filter string (custom filter). This allows complex logic and comparing fields.
     - Reference fields using `${view.field_name}` syntax.
@@ -178,7 +183,7 @@ description: |
       - Custom Measure: `[{"measure": "sum_of_revenue", "label": "Sum of Revenue", "based_on": "training.revenue", "type": "sum", "_type_hint": "number"}]`
   - sorts: A list of fields to sort by, optionally including direction (e.g., `["view.field desc"]`).
   - limit: Row limit (default 500). Use "-1" for unlimited.
-  - query_timezone: specific timezone for the query (e.g. `America/Los_Angeles`).
+  - tz: specific timezone for the query (e.g. `America/Los_Angeles`).
 
   Note: Use `get_dimensions`, `get_measures`, `get_filters`, and `get_parameters` to find valid fields.
 ---
@@ -193,8 +198,8 @@ description: |
   
   Parameters:
   All parameters for this tool are identical to those of the `query` tool.
-  This includes `model_name`, `explore_name`, `fields` (required),
-  and optional parameters like `pivots`, `filters`, `filter_expression`, `dynamic_fields`, `sorts`, `limit`, and `query_timezone`.
+  This includes `model`, `explore`, `fields` (required),
+  and optional parameters like `pivots`, `filters`, `filter_expression`, `dynamic_fields`, `sorts`, `limit`, and `tz`.
   
   Output:
   The result of this tool is the raw SQL text.
@@ -209,8 +214,8 @@ description: |
   along with the `query_id` and `slug`.
 
   Parameters:
-  All query parameters (e.g., `model_name`, `explore_name`, `fields`, `pivots`,
-  `filters`, `filter_expression`, `dynamic_fields`, `sorts`, `limit`, `query_timezone`) are the same as the `query` tool.
+  All query parameters (e.g., `model`, `explore`, `fields`, `pivots`,
+  `filters`, `filter_expression`, `dynamic_fields`, `sorts`, `limit`, `tz`) are the same as the `query` tool.
 
   Additionally, it accepts an optional `vis_config` parameter:
   - vis_config (optional): A JSON object that controls the default visualization
@@ -706,12 +711,12 @@ description: |
   Required Parameters:
   - title: A unique title for the new Look.
   - description: A brief description of the Look's purpose.
-  - model_name: The name of the LookML model (from `get_models`).
-  - explore_name: The name of the explore (from `get_explores`).
+  - model: The name of the LookML model (from `get_models`).
+  - explore: The name of the explore (from `get_explores`).
   - fields: A list of field names (dimensions, measures, filters, or parameters) to include in the query.
 
   Optional Parameters:
-  - pivots, filters, sorts, limit, query_timezone: These parameters are identical
+  - pivots, filters, sorts, limit, tz: These parameters are identical
     to those described for the `query` tool.
   - vis_config: A JSON object defining the visualization settings for the Look.
     The structure and options are the same as for the `query_url` tool's `vis_config`.
@@ -793,12 +798,12 @@ description: |
 
   Required Parameters:
   - dashboard_id: The ID of the target dashboard, obtained from `make_dashboard`.
-  - model_name, explore_name, fields: These query parameters are inherited
+  - model, explore, fields: These query parameters are inherited
     from the `query` tool and are required to define the data for the tile.
 
   Optional Parameters:
   - title: An optional title for the dashboard tile.
-  - pivots, filters, sorts, limit, query_timezone: These query parameters are
+  - pivots, filters, sorts, limit, tz: These query parameters are
     inherited from the `query` tool and can be used to customize the tile's query.
   - vis_config: A JSON object defining the visualization settings for this tile.
     The structure and options are the same as for the `query_url` tool's `vis_config`.


### PR DESCRIPTION
## Description

The `filters` guidance in the prebuilt Looker `query` tool description reads:

```
- filters: A map of filter expressions, e.g., `{"view.field": "value", "view.date": "7 days"}`.
  - Do not quote field names.
```

The rule sits directly beneath an example whose field name **is** quoted, because JSON map keys have to be. The two read as contradicting each other.

The instruction isn't wrong as Looker guidance, it's under-scoped: it means "don't wrap filter *values* in extra quote characters," but nothing in the text says that. And the mandatory `view_name.field_name` key format is never stated at all, it's only implied by the shape of a placeholder. The block contains no *must*, *required*, or *always*, so a model that omits the view prefix hasn't violated any stated rule.

This matters more than it looks: `filters` is a free-form map, and Gemini's function-calling schema subset has no construct for it, so the parameter reaches the model as a bare `OBJECT` with no declared properties. This prose is the only guidance on key format, so an ambiguity here has nothing to fall back on.

**Fix:** rewrite the block to state the fully-scoped key requirement explicitly and to scope the quoting rule to values, matching the authoritative parameter description already in `lookercommon.GetQueryParameters`:

```
- filters: A map of filter expressions, e.g., `{"view_name.field_name": "value", "view_name.date": "7 days"}`.
  - Each key must be a fully-scoped `view_name.field_name`, copied verbatim from
    `get_dimensions`, `get_measures`, `get_filters`, or `get_parameters`. The view
    prefix and the dot are required.
  - Each value is a Looker filter expression. Pass values bare: do not wrap them in
    extra quote characters. For LookML `parameter` fields, use the raw allowed_value
    (e.g. `first_touch`, not `"first_touch"`).
  - Use `not null` instead of `-NULL`.
  - If a value contains a comma, enclose it in single quotes (e.g., `'New York, NY'`).
  - To retrieve valid filter values for a suggestible field, use the 'get_field_value_suggestions' tool.
```

### Also: parameter names in the descriptions didn't match the schema

Verifiable from `tools/list` alone:

| description said | schema declares |
| --- | --- |
| `model_name` | `model` |
| `explore_name` | `explore` |
| `query_timezone` | `tz` |

The schema wins at call time so calls still succeeded, but the model was being pointed at names that don't exist. Corrected across the affected descriptions in `looker.yaml` and `looker-conversational-analytics.yaml`, and mirrored in the docs that quote them verbatim.

Two categories of occurrence are deliberately left unchanged because they are not input parameter names:
- `looker-dev.yaml` lines 361/363/385, which are **output** field names of `get_lookml_tests` / `run_lookml_tests`.
- `generate_embed_url`'s `"model_name/explore_name"`, which is a **value** format for the `id` parameter.

`update_dashboard_element` already used the correct `model` / `explore` / `tz` names, so this brings the rest of the file in line with it.

This is a description-only change. No Go source, schema, or runtime behavior is touched.

## PR Checklist

- [x] Make sure to open an issue as a bug/issue before writing your code!
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
- [ ] Make sure to add `!` if this involves a breaking change

`go test ./internal/prebuiltconfigs/... ./internal/tools/looker/... ./internal/server/...` passes.

Fixes #3786 🦕

🤖 Generated with [Claude Code](https://claude.com/claude-code)
