### PR TITLE
fix(tools/looker): scope the filters quoting rule to values in query description

### DIFF
--- a/docs/en/integrations/looker/tools/looker-query.md
+++ b/docs/en/integrations/looker/tools/looker-query.md
@@ -50,10 +50,15 @@ description: |
 
   Optional Parameters:
   - pivots: A list of fields to pivot the results by. These fields must also be included in the `fields` list.
-  - filters: A map of filter expressions, e.g., `{"view.field": "value", "view.date": "7 days"}`.
-    - Do not quote field names.
+  - filters: A map of filter expressions, e.g., `{"view_name.field_name": "value", "view_name.date": "7 days"}`.
+    - Each key must be a fully-scoped `view_name.field_name`, copied verbatim from
+      `get_dimensions`, `get_measures`, `get_filters`, or `get_parameters`. The view
+      prefix and the dot are required.
+    - Each value is a Looker filter expression. Pass values bare: do not wrap them in
+      extra quote characters. For LookML `parameter` fields, use the raw allowed_value
+      (e.g. `first_touch`, not `"first_touch"`).
     - Use `not null` instead of `-NULL`.
-    - If a value contains a comma, enclose it in single quotes (e.g., "'New York, NY'").
+    - If a value contains a comma, enclose it in single quotes (e.g., `'New York, NY'`).
   - filter_expression: A Looker expression filter string (custom filter). This allows complex logic and comparing fields.
     - Reference fields using `${view.field_name}` syntax.
     - Supports logical operators (`AND`, `OR`, `NOT`) and comparison operators.

--- a/internal/prebuiltconfigs/tools/looker.yaml
+++ b/internal/prebuiltconfigs/tools/looker.yaml
@@ -156,10 +156,15 @@ description: |
 
   Optional Parameters:
   - pivots: A list of fields to pivot the results by. These fields must also be included in the `fields` list.
-  - filters: A map of filter expressions, e.g., `{"view.field": "value", "view.date": "7 days"}`.
-    - Do not quote field names.
+  - filters: A map of filter expressions, e.g., `{"view_name.field_name": "value", "view_name.date": "7 days"}`.
+    - Each key must be a fully-scoped `view_name.field_name`, copied verbatim from
+      `get_dimensions`, `get_measures`, `get_filters`, or `get_parameters`. The view
+      prefix and the dot are required.
+    - Each value is a Looker filter expression. Pass values bare: do not wrap them in
+      extra quote characters. For LookML `parameter` fields, use the raw allowed_value
+      (e.g. `first_touch`, not `"first_touch"`).
     - Use `not null` instead of `-NULL`.
-    - If a value contains a comma, enclose it in single quotes (e.g., "'New York, NY'").
+    - If a value contains a comma, enclose it in single quotes (e.g., `'New York, NY'`).
     - To retrieve valid filter values for a suggestible field, use the 'get_field_value_suggestions' tool.
   - filter_expression: A Looker expression filter string (custom filter). This allows complex logic and comparing fields.
     - Reference fields using `${view.field_name}` syntax.


### PR DESCRIPTION
## Description

The `filters` guidance in the prebuilt Looker `query` tool description reads:

```
- filters: A map of filter expressions, e.g., `{"view.field": "value", "view.date": "7 days"}`.
  - Do not quote field names.
```

The rule sits directly beneath an example whose field name **is** quoted, because JSON map keys have to be. The two read as contradicting each other.

The instruction isn't wrong as Looker guidance, it's under-scoped: it means "don't wrap filter *values* in extra quote characters," but nothing in the text says that. And the mandatory `view_name.field_name` key format is never stated at all, it's only implied by the shape of a placeholder. The block contains no *must*, *required*, or *always*, so a model that omits the view prefix hasn't violated any stated rule.

This matters more than it looks: `filters` is a free-form map, and Gemini's function-calling schema subset has no construct for it, so the parameter reaches the model as a bare `OBJECT` with no declared properties. This prose is the only guidance on key format, so an ambiguity here has nothing to fall back on.

**Fix:** rewrite the block to state the fully-scoped key requirement explicitly and to scope the quoting rule to values, matching the authoritative parameter description already in `lookercommon.GetQueryParameters`:

```
- filters: A map of filter expressions, e.g., `{"view_name.field_name": "value", "view_name.date": "7 days"}`.
  - Each key must be a fully-scoped `view_name.field_name`, copied verbatim from
    `get_dimensions`, `get_measures`, `get_filters`, or `get_parameters`. The view
    prefix and the dot are required.
  - Each value is a Looker filter expression. Pass values bare: do not wrap them in
    extra quote characters. For LookML `parameter` fields, use the raw allowed_value
    (e.g. `first_touch`, not `"first_touch"`).
  - Use `not null` instead of `-NULL`.
  - If a value contains a comma, enclose it in single quotes (e.g., `'New York, NY'`).
  - To retrieve valid filter values for a suggestible field, use the 'get_field_value_suggestions' tool.
```

Two files: the prebuilt config and the docs page that quotes it verbatim. Description-only change, no Go source, schema, or runtime behaviour is touched.

> **Note:** the second, unrelated half of #3786 (description parameter names not matching the declared schema) is split out into its own PR: #3789. The two touch nearby lines in `looker.yaml`, so whichever merges second may need a trivial rebase.

## PR Checklist

- [x] Make sure to open an issue as a bug/issue before writing your code!
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
- [ ] Make sure to add `!` if this involves a breaking change

`go test ./internal/prebuiltconfigs/...` passes.

Fixes #3786 🦕
