### PR TITLE
feat(server): add --defer-source-connect and --defer-env-var-parsing

### DIFF
--- a/cmd/internal/config.go
+++ b/cmd/internal/config.go
@@ -51,12 +51,18 @@ type ConfigParser struct {
 	requiredEnvVars []string
 
 	// AllowMissingEnvVars, when true, substitutes the variable name for an unset
-	// required ${VAR} placeholder instead of erroring. Used by offline flows like
-	// skills-generate, where source env vars are needed only to satisfy config
-	// parsing/validation, never to connect. A non-empty placeholder is used (not
-	// "") so required string fields still pass validation. The served path leaves
-	// this false so missing config still fails fast.
+	// required ${VAR} placeholder instead of erroring. Used by flows that never
+	// connect during parsing — skills-generate, and serving with a deferred
+	// connect — where source env vars are needed only to satisfy config
+	// parsing/validation. A non-empty placeholder is used (not "") so required
+	// string fields still pass validation. Eager serving leaves this false so
+	// missing config still fails fast.
 	AllowMissingEnvVars bool
+
+	// MissingEnvVars names the variables that were substituted with a
+	// placeholder, so a caller can report them rather than let a placeholder
+	// stand in for real config silently.
+	MissingEnvVars []string
 }
 
 // parseEnv replaces environment variables ${ENV_NAME} with their values.
@@ -117,6 +123,9 @@ func (p *ConfigParser) parseEnv(input string) (string, error) {
 		} else {
 			if p.AllowMissingEnvVars {
 				p.EnvVars[variableName] = variableName
+				if !slices.Contains(p.MissingEnvVars, variableName) {
+					p.MissingEnvVars = append(p.MissingEnvVars, variableName)
+				}
 				output.WriteString(variableName)
 			} else if !seenMissing[variableName] {
 				seenMissing[variableName] = true

--- a/cmd/internal/config_test.go
+++ b/cmd/internal/config_test.go
@@ -47,6 +47,7 @@ func TestParseEnv(t *testing.T) {
 		err          bool
 		errString    string
 		wantOptional []string
+		wantMissing  []string
 		lenient      bool
 	}{
 		{
@@ -71,17 +72,33 @@ func TestParseEnv(t *testing.T) {
 			errString: `environment variable not found: "HOST" (line 1, column 4)`,
 		},
 		{
-			desc:    "without default without env, lenient",
-			in:      "${FOO}",
-			want:    "FOO",
-			lenient: true,
+			desc:        "without default without env, lenient",
+			in:          "${FOO}",
+			want:        "FOO",
+			lenient:     true,
+			wantMissing: []string{"FOO"},
 		},
 		{
-			desc:    "missing required mixed with env, lenient",
-			in:      "project: ${PROJECT}, region: ${REGION}",
-			env:     map[string]string{"REGION": "us-central1"},
-			want:    "project: PROJECT, region: us-central1",
-			lenient: true,
+			desc:        "missing required mixed with env, lenient",
+			in:          "project: ${PROJECT}, region: ${REGION}",
+			env:         map[string]string{"REGION": "us-central1"},
+			want:        "project: PROJECT, region: us-central1",
+			lenient:     true,
+			wantMissing: []string{"PROJECT"},
+		},
+		{
+			desc:        "repeated missing var recorded once, lenient",
+			in:          "a: ${HOST}, b: ${HOST}",
+			want:        "a: HOST, b: HOST",
+			lenient:     true,
+			wantMissing: []string{"HOST"},
+		},
+		{
+			desc:        "tool config env vars are recorded too",
+			in:          "sources:\n  s: ${DB_PASSWORD}\ntools:\n  t: ${TOOL_TOKEN}\n",
+			want:        "sources:\n  s: DB_PASSWORD\ntools:\n  t: TOOL_TOKEN\n",
+			lenient:     true,
+			wantMissing: []string{"DB_PASSWORD", "TOOL_TOKEN"},
 		},
 		{
 			desc: "without default with env",
@@ -246,6 +263,9 @@ func TestParseEnv(t *testing.T) {
 				if v != tc.wantOptional[i] {
 					t.Errorf("OptionalEnvVars element %d mismatch: got %q, want %q", i, v, tc.wantOptional[i])
 				}
+			}
+			if diff := cmp.Diff(tc.wantMissing, parser.MissingEnvVars); diff != "" {
+				t.Errorf("MissingEnvVars mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/cmd/internal/flags.go
+++ b/cmd/internal/flags.go
@@ -77,4 +77,6 @@ func ServeFlags(flags *pflag.FlagSet, opts *ToolboxOptions) {
 	flags.Int64Var(&opts.Cfg.HttpMaxRequestBytes, "http-max-request-bytes", server.DefaultHTTPMaxRequestBytes, "Maximum MCP HTTP request body size in bytes.")
 	flags.BoolVar(&opts.Cfg.EnableDraftSpecs, "enable-draft-specs", false, "Opt-in and test upcoming draft MCP specifications.")
 	flags.StringSliceVar(&opts.Cfg.DisableExt, "disable-ext", []string{}, "Specifies MCP extension URIs disabled on this server.")
+	flags.BoolVar(&opts.Cfg.DeferSourceConnect, "defer-source-connect", false, "Connect to each source on first use instead of at startup. Tools can be listed without any source being reachable.")
+	flags.BoolVar(&opts.Cfg.DeferEnvVarParsing, "defer-env-var-parsing", false, "Let an unset environment variable resolve to its own name instead of failing startup. Requires --defer-source-connect.")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -359,7 +359,7 @@ func watchChanges(ctx context.Context, watchDirs map[string]bool, watchedFiles m
 			reloadedOpts.Configs = slices.Clone(opts.Configs)
 			reloadedOpts.Cfg.Version = versionString
 
-			if _, err := reloadedOpts.LoadConfig(ctx, &internal.ConfigParser{}); err != nil {
+			if _, err := reloadedOpts.LoadConfig(ctx, &internal.ConfigParser{AllowMissingEnvVars: opts.Cfg.DeferEnvVarParsing}); err != nil {
 				logger.WarnContext(ctx, fmt.Sprintf("Error reloading config: %s", err))
 				continue
 			}
@@ -431,9 +431,25 @@ func run(cmd *cobra.Command, opts *internal.ToolboxOptions) error {
 		_ = shutdown(ctx)
 	}()
 
-	isCustomConfigured, err := opts.LoadConfig(ctx, &internal.ConfigParser{})
+	// A placeholder only makes sense for a source that has not connected yet.
+	// Substituting one and then connecting eagerly fails on the placeholder
+	// itself, so reject the combination rather than report that failure.
+	if opts.Cfg.DeferEnvVarParsing && !opts.Cfg.DeferSourceConnect {
+		errMsg := fmt.Errorf("--defer-env-var-parsing requires --defer-source-connect")
+		opts.Logger.ErrorContext(ctx, errMsg.Error())
+		return errMsg
+	}
+
+	parser := internal.ConfigParser{AllowMissingEnvVars: opts.Cfg.DeferEnvVarParsing}
+	isCustomConfigured, err := opts.LoadConfig(ctx, &parser)
 	if err != nil {
 		return err
+	}
+	if len(parser.MissingEnvVars) > 0 {
+		slices.Sort(parser.MissingEnvVars)
+		opts.Logger.WarnContext(ctx, fmt.Sprintf(
+			"Unset environment variables replaced with placeholders because --defer-env-var-parsing is set; any source using them will fail to connect: %s",
+			strings.Join(parser.MissingEnvVars, ", ")))
 	}
 
 	// Validate ToolboxUrl if MCP Auth is enabled

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -266,6 +266,21 @@ func TestServerConfigFlags(t *testing.T) {
 				DisableExt: []string{"io.modelcontextprotocol/tasks"},
 			}),
 		},
+		{
+			desc: "defer source connect",
+			args: []string{"--defer-source-connect"},
+			want: withDefaults(server.ServerConfig{
+				DeferSourceConnect: true,
+			}),
+		},
+		{
+			desc: "defer env var parsing",
+			args: []string{"--defer-source-connect", "--defer-env-var-parsing"},
+			want: withDefaults(server.ServerConfig{
+				DeferSourceConnect: true,
+				DeferEnvVarParsing: true,
+			}),
+		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
@@ -1087,6 +1102,26 @@ authServices:
 		t.Fatal("expected error when running with MCP Auth and --enable-api, got nil")
 	}
 	if !strings.Contains(err.Error(), "MCP Auth cannot be enabled together with the legacy HTTP API") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestDeferEnvVarParsingRequiresDeferSourceConnect(t *testing.T) {
+	configFile := filepath.Join(t.TempDir(), "tools.yaml")
+	if err := os.WriteFile(configFile, []byte("sources:\ntools:\n"), 0644); err != nil {
+		t.Fatalf("failed to write temp config file: %v", err)
+	}
+
+	buf := new(bytes.Buffer)
+	opts := internal.NewToolboxOptions(internal.WithIOStreams(buf, buf))
+	cmd := NewCommand(opts)
+	cmd.SetArgs([]string{"--config", configFile, "--defer-env-var-parsing"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when --defer-env-var-parsing is set alone, got nil")
+	}
+	if !strings.Contains(err.Error(), "--defer-env-var-parsing requires --defer-source-connect") {
 		t.Errorf("unexpected error: %v", err)
 	}
 }

--- a/docs/en/reference/cli.md
+++ b/docs/en/reference/cli.md
@@ -11,6 +11,8 @@ description: >
 | Flag (Short) | Flag (Long)                | Description                                                                                                                                                               | Default     |
 |--------------|----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
 | `-a`         | `--address`                | Address of the interface the server will listen on.                                                                                                                       | `127.0.0.1` |
+|              | `--defer-env-var-parsing`  | Let an unset environment variable resolve to its own name instead of failing startup. Requires `--defer-source-connect`.                                                  | `false`     |
+|              | `--defer-source-connect`   | Connect to each source on first use instead of at startup.                                                                                                                | `false`     |
 |              | `--disable-ext`            | Specifies MCP extension URIs disabled on this server.                                                                                                                     |             |
 |              | `--disable-reload`         | Disables dynamic reloading config.                                                                                                                                        |             |
 | `-h`         | `--help`                   | help for toolbox                                                                                                                                                          |             |
@@ -243,6 +245,48 @@ reloading, use the `--disable-reload` flag.
 To launch Toolbox's interactive UI, use the `--ui` flag. This allows you to test
 tools and toolsets with features such as authorized parameters. To learn more,
 visit [Toolbox UI](../documentation/configuration/toolbox-ui/index.md).
+
+### Deferring Source Connections
+
+By default Toolbox connects to every configured source at startup and fails to
+start if any connection fails. Pass `--defer-source-connect` to defer each
+connection until the first tool call that needs it.
+
+```bash
+./toolbox --tools-file tools.yaml --defer-source-connect
+```
+
+This is useful when you want to inspect a tool catalog without provisioning
+databases, when cold start time matters, or when you would rather a broken
+source surface as a tool error the agent can read than as a server that never
+comes up. With the flag set:
+
+* Toolbox starts even when no source is reachable, and `tools/list` and
+  `/api/toolset` return the full catalog with complete schemas.
+* The first call to a tool connects its source. If that fails, the call returns
+  a tool error containing the connection failure and the server stays up. Only
+  successful connections are kept, so a source that comes up later starts
+  working without a restart.
+* A tool naming a source that does not exist, or one whose type it cannot use,
+  is still rejected at startup.
+
+Configuration is still validated at startup. A malformed value — an unparseable
+`queryTimeout`, an invalid `writeMode` — fails immediately, because detecting it
+takes no network.
+
+Environment variables are also still required, since a source cannot connect
+without them. To inspect a catalog without setting them, add
+`--defer-env-var-parsing`, which resolves an unset `${VAR}` to its own name and
+logs one warning naming every variable it replaced:
+
+```bash
+./toolbox --tools-file tools.yaml --defer-source-connect --defer-env-var-parsing
+```
+
+Any source configured from a placeholder will fail to connect when a tool calls
+it. This flag requires `--defer-source-connect`; on its own it would substitute
+placeholders and then immediately connect with them, so Toolbox rejects that
+combination at startup.
 
 ### Disabling MCP Extensions
 

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -105,6 +105,11 @@ type ServerConfig struct {
 	SkipSourceValidation bool
 	// DisableExt specifies MCP extension URIs disabled on this server.
 	DisableExt []string
+	// DeferSourceConnect connects each source on first use instead of at startup.
+	DeferSourceConnect bool
+	// DeferEnvVarParsing resolves an unset ${VAR} to its own name instead of
+	// failing startup. Requires DeferSourceConnect.
+	DeferEnvVarParsing bool
 }
 
 type logFormat string

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -113,8 +113,7 @@ func InitializeConfigs(ctx context.Context, cfg ServerConfig) (
 				trace.WithAttributes(attribute.String("source_name", name)),
 			)
 			defer span.End()
-			// Always connects here; the flag that defers it lands separately.
-			s, err := sc.Initialize(childCtx, instrumentation.Tracer, false)
+			s, err := sc.Initialize(childCtx, instrumentation.Tracer, cfg.DeferSourceConnect)
 			if err != nil {
 				return nil, fmt.Errorf("unable to initialize source %q: %w", name, err)
 			}
@@ -129,7 +128,11 @@ func InitializeConfigs(ctx context.Context, cfg ServerConfig) (
 	for name := range sourcesMap {
 		sourceNames = append(sourceNames, name)
 	}
-	l.InfoContext(ctx, fmt.Sprintf("Initialized %d sources: %s", len(sourcesMap), strings.Join(sourceNames, ", ")))
+	if cfg.DeferSourceConnect {
+		l.InfoContext(ctx, fmt.Sprintf("Deferred initialization of %d sources, each connects on first use: %s", len(sourcesMap), strings.Join(sourceNames, ", ")))
+	} else {
+		l.InfoContext(ctx, fmt.Sprintf("Initialized %d sources: %s", len(sourcesMap), strings.Join(sourceNames, ", ")))
+	}
 
 	// initialize and validate the auth services from configs
 	authServicesMap := make(map[string]auth.AuthService)


### PR DESCRIPTION
Adds the two flags that turn on the deferred path the sources gained in #3907.

**Stacked on #3907** — based on `feat/lazy-source-init-all-sources`, so this diff shows only the flag work. It retargets to `main` automatically when #3907 merges.

* `--defer-source-connect` — each source connects on the first tool call that needs it. Toolbox starts with nothing reachable, `tools/list` returns the full catalog, and a connect failure comes back as a tool error the agent can read while the server stays up. Only successful connections are kept, so a source that comes up later works without a restart.
* `--defer-env-var-parsing` — an unset `${VAR}` resolves to its own name instead of failing the parse, with one warning naming every variable replaced. Requires `--defer-source-connect`; alone it would substitute placeholders and then immediately connect with them, so that combination is rejected at startup rather than left to fail confusingly.
* Both default to false. The eager path is unchanged.

Substitution already runs over the whole config document (`ParseConfig`, `cmd/internal/config.go`), so **tool** environment variables are covered along with source ones — the Sep 1 sync had this down as open work and it is not.

## This replaces the SourceResolver design

The previous revision of this PR put laziness in a `SourceResolver` and added 93 lines to `internal/server/primitives/primitives.go`. #3907 moved laziness into the sources instead, so the resolver is deleted and `primitives.go` is untouched — which was the gate from the Aug 19 design review.

Three things the old revision needed turn out to be unnecessary under the new design, each checked rather than assumed:

* **Static manifest fallback.** It existed because the resolver could return *no* source. A source is now always present. All 41 tools overriding `Manifest`/`GetParameters` read config-only accessors (`BigQueryProject()`, `BigQueryAllowedDatasets()`, `GetDefaultProject()`, `AllowedFHIRStores()`) — plain struct-field reads, none reaching `ConnectOnce`. Full schemas render with nothing connected.
* **`isError` handling.** Already correct. `method.go` maps a `util.CategoryAgent` error to `CallToolResult{IsError: true}`, and a connect failure becomes an `AgentError` through `util.ProcessGeneralError`.
* **A separate failure metric.** The existing recorder in each `method.go` already fires on an `Invoke` error with `error.type` attached. The old revision needed its own because resolution failed *before* `Invoke`; now the connect failure happens inside it.

Reload needed no ordering fix either — `handleDynamicReload` swaps everything in one `SetPrimitives` call, and there is no second registry to keep in step.

## Testing

`go build`, `go test -race ./cmd/... ./internal/...`, `golangci-lint run` all pass. Verified end to end against a config naming an unreachable database:

| case | result |
|---|---|
| neither flag | startup fails on the connect, as today |
| `--defer-env-var-parsing` alone | `Error: --defer-env-var-parsing requires --defer-source-connect` |
| `--defer-source-connect` | starts, logs the deferred sources, `tools/list` returns the catalog, `tools/call` returns `isError: true` with the connect error, server stays up |
| both, `${VAR}` unset | starts, one warning naming the substituted variable |
| database brought up mid-run | next call succeeds with no restart |

Towards #3791 🦕

## PR Checklist

- [x] Make sure you reviewed [CONTRIBUTING.md](https://github.com/googleapis/mcp-toolbox/blob/main/CONTRIBUTING.md)
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/mcp-toolbox/issues/new/choose) before writing your code! That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
- [x] Make sure to add `!` if this involve a breaking change