### PR TITLE
fix(config): ignore environment variables in YAML comments

### DIFF
--- a/cmd/internal/config.go
+++ b/cmd/internal/config.go
@@ -27,6 +27,8 @@ import (
 	"strings"
 
 	"github.com/goccy/go-yaml"
+	"github.com/goccy/go-yaml/lexer"
+	"github.com/goccy/go-yaml/token"
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/mcp-toolbox/internal/auth/generic"
 	"github.com/googleapis/mcp-toolbox/internal/server"
@@ -60,6 +62,10 @@ type ConfigParser struct {
 // also support ${ENV_NAME:default_value}.
 func (p *ConfigParser) parseEnv(input string) (string, error) {
 	re := regexp.MustCompile(`\$\{(\w+)(:([^}]*))?\}`)
+	var commentColumns map[int][]int
+	if strings.Contains(input, "#") {
+		commentColumns = yamlCommentColumns(input)
+	}
 
 	if p.EnvVars == nil {
 		p.EnvVars = make(map[string]string)
@@ -73,6 +79,11 @@ func (p *ConfigParser) parseEnv(input string) (string, error) {
 	for _, match := range matches {
 		start, end := match[0], match[1]
 		output.WriteString(input[lastIndex:start])
+		if isYAMLComment(input, start, commentColumns) {
+			output.WriteString(input[start:end])
+			lastIndex = end
+			continue
+		}
 
 		variableName := input[match[2]:match[3]]
 		defaultValue := ""
@@ -127,6 +138,29 @@ func (p *ConfigParser) parseEnv(input string) (string, error) {
 	}
 
 	return output.String(), err
+}
+
+// yamlCommentColumns records the first column after each real YAML comment
+// marker. The lexer keeps quoted and block-scalar hash signs out of this set.
+func yamlCommentColumns(input string) map[int][]int {
+	comments := make(map[int][]int)
+	for _, tk := range lexer.Tokenize(input) {
+		if tk.Type != token.CommentType || tk.Position == nil {
+			continue
+		}
+		comments[tk.Position.Line] = append(comments[tk.Position.Line], tk.Position.Column)
+	}
+	return comments
+}
+
+func isYAMLComment(input string, index int, commentColumns map[int][]int) bool {
+	line, column := lineColumnAt(input, index)
+	for _, commentColumn := range commentColumns[line] {
+		if column >= commentColumn {
+			return true
+		}
+	}
+	return false
 }
 
 // ParseConfig parses the provided yaml into appropriate configs.

--- a/cmd/internal/config.go
+++ b/cmd/internal/config.go
@@ -74,12 +74,14 @@ func (p *ConfigParser) parseEnv(input string) (string, error) {
 	var missing []string
 	seenMissing := make(map[string]bool)
 	matches := re.FindAllStringSubmatchIndex(input, -1)
+	locations := lineColumnsAt(input, matches)
 	var output strings.Builder
 	lastIndex := 0
-	for _, match := range matches {
+	for i, match := range matches {
 		start, end := match[0], match[1]
+		location := locations[i]
 		output.WriteString(input[lastIndex:start])
-		if isYAMLComment(input, start, commentColumns) {
+		if isYAMLComment(location.line, location.column, commentColumns) {
 			output.WriteString(input[start:end])
 			lastIndex = end
 			continue
@@ -110,8 +112,7 @@ func (p *ConfigParser) parseEnv(input string) (string, error) {
 				output.WriteString(variableName)
 			} else if !seenMissing[variableName] {
 				seenMissing[variableName] = true
-				line, column := lineColumnAt(input, start)
-				missing = append(missing, fmt.Sprintf("%q (line %d, column %d)", variableName, line, column))
+				missing = append(missing, fmt.Sprintf("%q (line %d, column %d)", variableName, location.line, location.column))
 			}
 		}
 
@@ -153,8 +154,7 @@ func yamlCommentColumns(input string) map[int][]int {
 	return comments
 }
 
-func isYAMLComment(input string, index int, commentColumns map[int][]int) bool {
-	line, column := lineColumnAt(input, index)
+func isYAMLComment(line, column int, commentColumns map[int][]int) bool {
 	for _, commentColumn := range commentColumns[line] {
 		if column >= commentColumn {
 			return true
@@ -163,24 +163,35 @@ func isYAMLComment(input string, index int, commentColumns map[int][]int) bool {
 	return false
 }
 
-// ParseConfig parses the provided yaml into appropriate configs.
-func lineColumnAt(input string, index int) (int, int) {
-	line := 1
-	column := 1
-	for i, r := range input {
-		if i >= index {
-			break
-		}
-		if r == '\n' {
-			line++
-			column = 1
-		} else {
-			column++
-		}
-	}
-	return line, column
+type sourceLocation struct {
+	line   int
+	column int
 }
 
+// lineColumnsAt computes source positions for the ordered regex matches in a
+// single pass over input. Regex indexes are byte offsets, while YAML columns
+// count runes, so range is used to preserve Unicode column reporting.
+func lineColumnsAt(input string, matches [][]int) []sourceLocation {
+	locations := make([]sourceLocation, len(matches))
+	line := 1
+	column := 1
+	lastIndex := 0
+	for i, match := range matches {
+		for _, r := range input[lastIndex:match[0]] {
+			if r == '\n' {
+				line++
+				column = 1
+			} else {
+				column++
+			}
+		}
+		locations[i] = sourceLocation{line: line, column: column}
+		lastIndex = match[0]
+	}
+	return locations
+}
+
+// ParseConfig parses the provided yaml into appropriate configs.
 func (p *ConfigParser) ParseConfig(ctx context.Context, raw []byte) (Config, error) {
 	var config Config
 	// Replace environment variables if found

--- a/cmd/internal/config_test.go
+++ b/cmd/internal/config_test.go
@@ -130,6 +130,43 @@ func TestParseEnv(t *testing.T) {
 			want:         "project_req: my_project, project_opt: my_project",
 			wantOptional: []string{}, // Because it was marked required at least once
 		},
+		{
+			desc:         "environment variables in YAML comments are ignored",
+			in:           "# ${TEST_COMMENTED_ENV_3793}\n  # ${TEST_INDENTED_COMMENTED_ENV_3793}\nvalue: ${TEST_ACTIVE_ENV_3793:active} # ${TEST_INLINE_COMMENTED_ENV_3793}\n",
+			want:         "# ${TEST_COMMENTED_ENV_3793}\n  # ${TEST_INDENTED_COMMENTED_ENV_3793}\nvalue: active # ${TEST_INLINE_COMMENTED_ENV_3793}\n",
+			wantOptional: []string{"TEST_ACTIVE_ENV_3793"},
+		},
+		{
+			desc: "hash signs in quoted scalars are not comments",
+			env: map[string]string{
+				"TEST_QUOTED_ENV_3793": "expanded",
+			},
+			in:   `value: "# ${TEST_QUOTED_ENV_3793}"`,
+			want: `value: "# expanded"`,
+		},
+		{
+			desc: "hash signs in block scalars are not comments",
+			env: map[string]string{
+				"TEST_BLOCK_ENV_3793": "expanded",
+			},
+			in:   "description: |\n  # ${TEST_BLOCK_ENV_3793}\n",
+			want: "description: |\n  # expanded\n",
+		},
+		{
+			desc: "hash signs without preceding whitespace are not comments",
+			env: map[string]string{
+				"TEST_URL_FRAGMENT_ENV_3793": "expanded",
+			},
+			in:   "url: https://example.com/#${TEST_URL_FRAGMENT_ENV_3793}",
+			want: "url: https://example.com/#expanded",
+		},
+		{
+			desc:      "comments do not shift active variable locations",
+			in:        "# 注释 ${TEST_COMMENTED_ENV_3793}\r\n值: ${TEST_REQUIRED_ENV_3793}",
+			want:      "# 注释 ${TEST_COMMENTED_ENV_3793}\r\n值: ",
+			err:       true,
+			errString: `environment variable not found: "TEST_REQUIRED_ENV_3793" (line 2, column 4)`,
+		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
@@ -160,6 +197,35 @@ func TestParseEnv(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestParseConfigIgnoresEnvPlaceholdersInComments(t *testing.T) {
+	ctx, err := testutils.ContextWithNewLogger()
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	parser := ConfigParser{}
+	config, err := parser.ParseConfig(ctx, []byte(`
+kind: source
+name: my-http-instance
+type: http
+baseUrl: https://example.com
+# headers:
+#   Authorization: ${TEST_COMMENTED_CONFIG_ENV_3793}
+`))
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if _, ok := config.Sources["my-http-instance"]; !ok {
+		t.Fatal("expected source config to be parsed")
+	}
+	if _, ok := parser.EnvVars["TEST_COMMENTED_CONFIG_ENV_3793"]; ok {
+		t.Fatal("commented environment variable should not be tracked")
+	}
+	if len(parser.requiredEnvVars) != 0 || len(parser.OptionalEnvVars) != 0 {
+		t.Fatalf("commented environment variable should not be required or optional: required=%v optional=%v", parser.requiredEnvVars, parser.OptionalEnvVars)
 	}
 }
 


### PR DESCRIPTION
## Description

`ConfigParser.ParseConfig` expands environment placeholders before parsing YAML. As a result, placeholders inside YAML comments were treated as active configuration and could fail startup when the referenced variable was unset.

This change uses the existing YAML lexer to identify real comment tokens before interpolation. Placeholders inside those comments are preserved verbatim and are not tracked as required or optional variables. Hash signs inside quoted values, block scalars, and URL fragments continue to behave as data, so their placeholders are still expanded.

Regression coverage includes full-line, indented, and inline comments; quoted and block-scalar hash signs; URL fragments; Unicode and CRLF source locations; variable tracking; and a `ParseConfig` integration path.

## Verification

- `go test ./cmd/internal -run '^(TestParseEnv|TestParseConfigIgnoresEnvPlaceholdersInComments)$' -count=1`
- `go test ./cmd/internal -count=1`
- `go test -race ./cmd/... ./internal/... -count=1` (all affected and internal packages passed; the unrelated watcher test `TestSingleEdit` timed out once during the aggregate run and passed immediately in the bounded isolated rerun below)
- `go test -race ./cmd -run '^TestSingleEdit$' -count=1 -v`
- `go vet ./cmd/internal`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest run --timeout 10m ./cmd/internal/...` (`0 issues`)
- `go mod tidy` (no module-file changes)

## PR Checklist

- [x] Reviewed [CONTRIBUTING.md](https://github.com/googleapis/mcp-toolbox/blob/main/CONTRIBUTING.md)
- [x] Opened an issue before implementation
- [x] Relevant tests and linters pass
- [x] Added regression coverage for the source-code change
- [x] No documentation update is needed for standard YAML comment behavior
- [x] This is not a breaking change

🛠️ Fixes #3793
