### PR TITLE
fix: normalize postgres UUIDs to strings

### DIFF
--- a/internal/sources/alloydbpg/alloydb_pg.go
+++ b/internal/sources/alloydbpg/alloydb_pg.go
@@ -121,7 +121,8 @@ func (s *Source) RunSQL(ctx context.Context, statement string, params []any) (an
 		}
 		row := orderedmap.Row{}
 		for i, f := range fields {
-			row.Add(f.Name, v[i])
+			val := sources.NormalizeValue(v[i], f.DataTypeOID)
+			row.Add(f.Name, val)
 		}
 		out = append(out, row)
 	}

--- a/internal/sources/cloudsqlpg/cloud_sql_pg.go
+++ b/internal/sources/cloudsqlpg/cloud_sql_pg.go
@@ -127,7 +127,8 @@ func (s *Source) RunSQL(ctx context.Context, statement string, params []any) (an
 		}
 		row := orderedmap.Row{}
 		for i, f := range fields {
-			row.Add(f.Name, values[i])
+			val := sources.NormalizeValue(values[i], f.DataTypeOID)
+			row.Add(f.Name, val)
 		}
 		out = append(out, row)
 	}

--- a/internal/sources/postgres/postgres.go
+++ b/internal/sources/postgres/postgres.go
@@ -125,7 +125,8 @@ func (s *Source) RunSQL(ctx context.Context, statement string, params []any) (an
 		}
 		row := orderedmap.Row{}
 		for i, f := range fields {
-			row.Add(f.Name, values[i])
+			val := sources.NormalizeValue(values[i], f.DataTypeOID)
+			row.Add(f.Name, val)
 		}
 		out = append(out, row)
 	}

--- a/internal/sources/util.go
+++ b/internal/sources/util.go
@@ -23,8 +23,41 @@ import (
 	"strings"
 
 	"cloud.google.com/go/cloudsqlconn"
+	"github.com/google/uuid"
 	"golang.org/x/oauth2/google"
 )
+
+// NormalizeValue converts specific database types to friendly representations (e.g. UUID to string).
+func NormalizeValue(val any, oid uint32) any {
+	// 2950 is the standard OID for UUID in PostgreSQL
+	if oid == 2950 {
+		if b, ok := val.([16]byte); ok {
+			return uuid.UUID(b).String()
+		}
+	}
+	// 2951 is the standard OID for _uuid (UUID array) in PostgreSQL
+	if oid == 2951 {
+		if arr, ok := val.([][16]byte); ok {
+			strs := make([]string, len(arr))
+			for i, b := range arr {
+				strs[i] = uuid.UUID(b).String()
+			}
+			return strs
+		}
+		if arr, ok := val.([]any); ok {
+			strs := make([]any, len(arr))
+			for i, item := range arr {
+				if b, ok := item.([16]byte); ok {
+					strs[i] = uuid.UUID(b).String()
+				} else {
+					strs[i] = item
+				}
+			}
+			return strs
+		}
+	}
+	return val
+}
 
 // GetCloudSQLDialOpts retrieve dial options with the right ip type and user agent for cloud sql
 // databases.

--- a/internal/sources/util_test.go
+++ b/internal/sources/util_test.go
@@ -1,0 +1,56 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sources
+
+import (
+	"testing"
+)
+
+func TestNormalizeValue(t *testing.T) {
+	// Test case 1: UUID OID (2950) with [16]byte
+	uuidBytes := [16]byte{1, 158, 103, 138, 45, 22, 120, 229, 146, 32, 191, 118, 245, 114, 247, 50}
+	expectedUUIDStr := "019e678a-2d16-78e5-9220-bf76f572f732"
+
+	result := NormalizeValue(uuidBytes, 2950)
+	if str, ok := result.(string); !ok || str != expectedUUIDStr {
+		t.Errorf("Expected UUID string %s, got %v", expectedUUIDStr, result)
+	}
+
+	// Test case 2: UUID OID (2950) with other type
+	result = NormalizeValue("not-bytes", 2950)
+	if str, ok := result.(string); !ok || str != "not-bytes" {
+		t.Errorf("Expected original string 'not-bytes', got %v", result)
+	}
+
+	// Test case 3: Other OID
+	result = NormalizeValue(uuidBytes, 1000)
+	if bytes, ok := result.([16]byte); !ok || bytes != uuidBytes {
+		t.Errorf("Expected original [16]byte array, got %v", result)
+	}
+
+	// Test case 4: UUID Array OID (2951) with [][16]byte
+	uuidArray := [][16]byte{uuidBytes}
+	result = NormalizeValue(uuidArray, 2951)
+	if arr, ok := result.([]string); !ok || len(arr) != 1 || arr[0] != expectedUUIDStr {
+		t.Errorf("Expected []string with %s, got %v", expectedUUIDStr, result)
+	}
+
+	// Test case 5: UUID Array OID (2951) with []any
+	uuidAnyArray := []any{uuidBytes, "not-a-uuid"}
+	result = NormalizeValue(uuidAnyArray, 2951)
+	if arr, ok := result.([]any); !ok || len(arr) != 2 || arr[0] != expectedUUIDStr || arr[1] != "not-a-uuid" {
+		t.Errorf("Expected []any with normalized UUID, got %v", result)
+	}
+}

--- a/internal/sources/yugabytedb/yugabytedb.go
+++ b/internal/sources/yugabytedb/yugabytedb.go
@@ -115,7 +115,8 @@ func (s *Source) RunSQL(ctx context.Context, statement string, params []any) (an
 		}
 		vMap := make(map[string]any)
 		for i, f := range fields {
-			vMap[f.Name] = v[i]
+			val := sources.NormalizeValue(v[i], f.DataTypeOID)
+			vMap[f.Name] = val
 		}
 		out = append(out, vMap)
 	}


### PR DESCRIPTION
## Description

Fixes a bug where PostgreSQL UUID columns were being serialized as numerical arrays (e.g., [1, 158, 103, ...]) in JSON output instead of standard hyphenated strings.

**Root Cause**
The generic results.Values() method in the pgx driver returns UUIDs as [16]byte fixed arrays. Go's standard encoding/json package serializes fixed arrays of bytes as numerical arrays rather than strings.

**Solution**
Introduced a centralized NormalizeValue helper function in internal/sources/util.go that intercepts values based on their PostgreSQL Object Identifier (OID). If it detects a UUID OID (2950) and a [16]byte type, it converts it into a standard UUID string via the github.com/google/uuid package.

**Impact**
Consistent string serialization for UUIDs across all Postgres-compatible drivers (postgres, alloydb-postgres, cloud-sql-postgres, yugabytedb). Added unit tests to internal/sources/util_test.go to guarantee reliability.

## PR Checklist

- [x] Make sure you reviewed [CONTRIBUTING.md](https://github.com/googleapis/mcp-toolbox/blob/main/CONTRIBUTING.md)
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/mcp-toolbox/issues/new/choose) before writing your code! That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
- [x] Make sure to add `!` if this involve a breaking change

🛠️ Fixes #3795
