### PR TITLE
feat(core): dynamic tool annotations for multi-mode tools on read-only sources

### DIFF
--- a/internal/server/mcp/v20241105/manifests.go
+++ b/internal/server/mcp/v20241105/manifests.go
@@ -118,7 +118,7 @@ func GenerateListToolsResult(pMgr *primitives.PrimitiveManager, g group.Group, u
 		if err != nil {
 			return ListToolsResult{}, fmt.Errorf("error getting parameters for tool %q: %w", toolName, err)
 		}
-		toolManifest := generateToolManifest(toolName, tool.GetDescription(), tool.GetAuthRequired(), params, tool.GetAnnotations(), urlParams)
+		toolManifest := generateToolManifest(toolName, tool.GetDescription(), tool.GetAuthRequired(), params, tool.GetAnnotations(src), urlParams)
 		mcpManifest = append(mcpManifest, toolManifest)
 	}
 	return ListToolsResult{Tools: mcpManifest}, nil

--- a/internal/server/mcp/v20250326/manifests.go
+++ b/internal/server/mcp/v20250326/manifests.go
@@ -117,7 +117,7 @@ func GenerateListToolsResult(pMgr *primitives.PrimitiveManager, g group.Group, u
 		if err != nil {
 			return ListToolsResult{}, fmt.Errorf("error getting parameters for tool %q: %w", toolName, err)
 		}
-		toolManifest := generateToolManifest(toolName, tool.GetDescription(), tool.GetAuthRequired(), params, tool.GetAnnotations(), urlParams)
+		toolManifest := generateToolManifest(toolName, tool.GetDescription(), tool.GetAuthRequired(), params, tool.GetAnnotations(src), urlParams)
 		mcpManifest = append(mcpManifest, toolManifest)
 	}
 	return ListToolsResult{Tools: mcpManifest}, nil

--- a/internal/server/mcp/v20250618/manifests.go
+++ b/internal/server/mcp/v20250618/manifests.go
@@ -119,7 +119,7 @@ func GenerateListToolsResult(pMgr *primitives.PrimitiveManager, g group.Group, u
 		if err != nil {
 			return ListToolsResult{}, fmt.Errorf("error getting parameters for tool %q: %w", toolName, err)
 		}
-		toolManifest := generateToolManifest(toolName, tool.GetDescription(), tool.GetAuthRequired(), params, tool.GetAnnotations(), urlParams)
+		toolManifest := generateToolManifest(toolName, tool.GetDescription(), tool.GetAuthRequired(), params, tool.GetAnnotations(src), urlParams)
 		mcpManifest = append(mcpManifest, toolManifest)
 	}
 	return ListToolsResult{Tools: mcpManifest}, nil

--- a/internal/server/mcp/v20251125/manifests.go
+++ b/internal/server/mcp/v20251125/manifests.go
@@ -119,7 +119,7 @@ func GenerateListToolsResult(pMgr *primitives.PrimitiveManager, g group.Group, u
 		if err != nil {
 			return ListToolsResult{}, fmt.Errorf("error getting parameters for tool %q: %w", toolName, err)
 		}
-		toolManifest := generateToolManifest(toolName, tool.GetDescription(), tool.GetAuthRequired(), params, tool.GetAnnotations(), urlParams)
+		toolManifest := generateToolManifest(toolName, tool.GetDescription(), tool.GetAuthRequired(), params, tool.GetAnnotations(src), urlParams)
 		mcpManifest = append(mcpManifest, toolManifest)
 	}
 	return ListToolsResult{Tools: mcpManifest}, nil

--- a/internal/server/mcp/v20260728/manifests.go
+++ b/internal/server/mcp/v20260728/manifests.go
@@ -119,7 +119,7 @@ func GenerateListToolsResult(pMgr *primitives.PrimitiveManager, g group.Group, u
 		if err != nil {
 			return ListToolsResult{}, fmt.Errorf("error getting parameters for tool %q: %w", toolName, err)
 		}
-		toolManifest := generateToolManifest(toolName, tool.GetDescription(), tool.GetAuthRequired(), params, tool.GetAnnotations(), urlParams)
+		toolManifest := generateToolManifest(toolName, tool.GetDescription(), tool.GetAuthRequired(), params, tool.GetAnnotations(src), urlParams)
 		mcpManifest = append(mcpManifest, toolManifest)
 	}
 	res := ListToolsResult{

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -308,7 +308,7 @@ func initializeTools(ctx context.Context, cfg ServerConfig, sourcesMap map[strin
 			return nil, err
 		}
 
-		if t.ShouldSuppress(ctx, src) {
+		if tools.ShouldSuppress(ctx, t, src) {
 			continue
 		}
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -2111,8 +2111,6 @@ func TestShouldSuppressTool(t *testing.T) {
 	readOnlySource := &testutils.MockSource{MockSourceConfig: testutils.MockSourceConfig{Name: "readonly-db", ReadOnly: true}}
 	readWriteSource := &testutils.MockSource{MockSourceConfig: testutils.MockSourceConfig{Name: "readwrite-db", ReadOnly: false}}
 
-	boolPtr := func(b bool) *bool { return &b }
-
 	initTool := func(cfg testutils.MockToolConfig) tools.Tool {
 		t, err := cfg.Initialize(ctx)
 		if err != nil {
@@ -2142,19 +2140,19 @@ func TestShouldSuppressTool(t *testing.T) {
 		{
 			desc:   "write tool on read-write source (readOnlyHint: false) -> not suppressed",
 			source: readWriteSource,
-			tool:   initTool(testutils.MockToolConfig{ConfigBase: tools.ConfigBase{Name: "write-tool"}, Source: "readwrite-db", Annotations: &tools.ToolAnnotations{ReadOnlyHint: boolPtr(false)}}),
+			tool:   initTool(testutils.MockToolConfig{ConfigBase: tools.ConfigBase{Name: "write-tool"}, Source: "readwrite-db", Annotations: tools.NewWriteAnnotations()}),
 			want:   false,
 		},
 		{
 			desc:   "write tool on read-only source (readOnlyHint: false) -> suppressed",
 			source: readOnlySource,
-			tool:   initTool(testutils.MockToolConfig{ConfigBase: tools.ConfigBase{Name: "write-tool"}, Source: "readonly-db", Annotations: &tools.ToolAnnotations{ReadOnlyHint: boolPtr(false)}}),
+			tool:   initTool(testutils.MockToolConfig{ConfigBase: tools.ConfigBase{Name: "write-tool"}, Source: "readonly-db", Annotations: tools.NewWriteAnnotations()}),
 			want:   true,
 		},
 		{
 			desc:   "read-only tool on read-only source (readOnlyHint: true) -> not suppressed",
 			source: readOnlySource,
-			tool:   initTool(testutils.MockToolConfig{ConfigBase: tools.ConfigBase{Name: "readonly-tool"}, Source: "readonly-db", Annotations: &tools.ToolAnnotations{ReadOnlyHint: boolPtr(true)}}),
+			tool:   initTool(testutils.MockToolConfig{ConfigBase: tools.ConfigBase{Name: "readonly-tool"}, Source: "readonly-db", Annotations: tools.NewReadOnlyAnnotations()}),
 			want:   false,
 		},
 		{
@@ -2170,7 +2168,7 @@ func TestShouldSuppressTool(t *testing.T) {
 			want:   false,
 		},
 		{
-			desc:   "mysql-execute-sql on read-only source -> not suppressed (session locked at DB layer)",
+			desc:   "mysql-execute-sql on read-only source -> not suppressed (dynamically reports readOnlyHint: true)",
 			source: readOnlySource,
 			tool: func() tools.Tool {
 				t, err := mysqlexecutesql.Config{
@@ -2186,7 +2184,7 @@ func TestShouldSuppressTool(t *testing.T) {
 			want: false,
 		},
 		{
-			desc:   "postgres-execute-sql on read-only source -> not suppressed (session locked at DB layer)",
+			desc:   "postgres-execute-sql on read-only source -> not suppressed (dynamically reports readOnlyHint: true)",
 			source: readOnlySource,
 			tool: func() tools.Tool {
 				t, err := postgresexecutesql.Config{
@@ -2205,16 +2203,13 @@ func TestShouldSuppressTool(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			if tc.tool == nil {
-				return
-			}
-			got := tc.tool.ShouldSuppress(ctx, tc.source)
+			got := tools.ShouldSuppress(ctx, tc.tool, tc.source)
 			if got != tc.want {
-				t.Errorf("Tool.ShouldSuppress(ctx) = %v, want %v", got, tc.want)
+				t.Errorf("ShouldSuppress(ctx) = %v, want %v", got, tc.want)
 			}
-			gotNilLogger := tc.tool.ShouldSuppress(context.Background(), tc.source)
+			gotNilLogger := tools.ShouldSuppress(context.Background(), tc.tool, tc.source)
 			if gotNilLogger != tc.want {
-				t.Errorf("Tool.ShouldSuppress(nil logger) = %v, want %v", gotNilLogger, tc.want)
+				t.Errorf("ShouldSuppress(nil logger) = %v, want %v", gotNilLogger, tc.want)
 			}
 		})
 	}
@@ -2231,8 +2226,6 @@ func TestInitializeGroups(t *testing.T) {
 	}
 	ctx = util.WithInstrumentation(ctx, instrumentation)
 
-	boolPtr := func(b bool) *bool { return &b }
-
 	t.Run("suppressed tool is pruned from group", func(t *testing.T) {
 		cfg := server.ServerConfig{
 			SourceConfigs: server.SourceConfigs{
@@ -2242,12 +2235,12 @@ func TestInitializeGroups(t *testing.T) {
 				"allowed_read_tool": &testutils.MockToolConfig{
 					ConfigBase:  tools.ConfigBase{Name: "allowed_read_tool"},
 					Source:      "readonly-db",
-					Annotations: &tools.ToolAnnotations{ReadOnlyHint: boolPtr(true)},
+					Annotations: tools.NewReadOnlyAnnotations(),
 				},
 				"suppressed_write_tool": &testutils.MockToolConfig{
 					ConfigBase:  tools.ConfigBase{Name: "suppressed_write_tool"},
 					Source:      "readonly-db",
-					Annotations: &tools.ToolAnnotations{ReadOnlyHint: boolPtr(false)},
+					Annotations: tools.NewWriteAnnotations(),
 				},
 			},
 			GroupConfigs: server.GroupConfigs{
@@ -2294,12 +2287,12 @@ func TestInitializeGroups(t *testing.T) {
 				"write_tool_1": &testutils.MockToolConfig{
 					ConfigBase:  tools.ConfigBase{Name: "write_tool_1"},
 					Source:      "readonly-db",
-					Annotations: &tools.ToolAnnotations{ReadOnlyHint: boolPtr(false)},
+					Annotations: tools.NewWriteAnnotations(),
 				},
 				"write_tool_2": &testutils.MockToolConfig{
 					ConfigBase:  tools.ConfigBase{Name: "write_tool_2"},
 					Source:      "readonly-db",
-					Annotations: &tools.ToolAnnotations{ReadOnlyHint: boolPtr(false)},
+					Annotations: tools.NewWriteAnnotations(),
 				},
 			},
 			GroupConfigs: server.GroupConfigs{
@@ -2334,12 +2327,12 @@ func TestInitializeGroups(t *testing.T) {
 				"tool_1": &testutils.MockToolConfig{
 					ConfigBase:  tools.ConfigBase{Name: "tool_1"},
 					Source:      "readwrite-db",
-					Annotations: &tools.ToolAnnotations{ReadOnlyHint: boolPtr(false)},
+					Annotations: tools.NewWriteAnnotations(),
 				},
 				"tool_2": &testutils.MockToolConfig{
 					ConfigBase:  tools.ConfigBase{Name: "tool_2"},
 					Source:      "readwrite-db",
-					Annotations: &tools.ToolAnnotations{ReadOnlyHint: boolPtr(true)},
+					Annotations: tools.NewReadOnlyAnnotations(),
 				},
 			},
 			GroupConfigs: server.GroupConfigs{

--- a/internal/tools/looker/lookercreateagent/lookercreateagent_test.go
+++ b/internal/tools/looker/lookercreateagent/lookercreateagent_test.go
@@ -252,7 +252,7 @@ func TestAnnotations(t *testing.T) {
 		t.Fatalf("failed to initialize tool: %v", err)
 	}
 
-	annotations := tool.GetAnnotations()
+	annotations := tool.GetAnnotations(nil)
 	if annotations == nil {
 		t.Fatal("mcp manifest annotations is nil")
 	}

--- a/internal/tools/looker/lookercreatedashboardlayout/lookercreatedashboardlayout_test.go
+++ b/internal/tools/looker/lookercreatedashboardlayout/lookercreatedashboardlayout_test.go
@@ -170,7 +170,7 @@ func TestAnnotations(t *testing.T) {
 		t.Fatalf("failed to initialize tool: %v", err)
 	}
 
-	annotations := tool.GetAnnotations()
+	annotations := tool.GetAnnotations(nil)
 	if annotations == nil {
 		t.Fatal("mcp manifest annotations is nil")
 	}

--- a/internal/tools/looker/lookerdeleteagent/lookerdeleteagent_test.go
+++ b/internal/tools/looker/lookerdeleteagent/lookerdeleteagent_test.go
@@ -238,7 +238,7 @@ func TestAnnotations(t *testing.T) {
 		t.Fatalf("failed to initialize tool: %v", err)
 	}
 
-	annotations := tool.GetAnnotations()
+	annotations := tool.GetAnnotations(nil)
 	if annotations == nil {
 		t.Fatal("mcp manifest annotations is nil")
 	}

--- a/internal/tools/looker/lookergetagent/lookergetagent_test.go
+++ b/internal/tools/looker/lookergetagent/lookergetagent_test.go
@@ -236,7 +236,7 @@ func TestAnnotations(t *testing.T) {
 		t.Fatalf("failed to initialize tool: %v", err)
 	}
 
-	annotations := tool.GetAnnotations()
+	annotations := tool.GetAnnotations(nil)
 	if annotations == nil {
 		t.Fatal("mcp manifest annotations is nil")
 	}

--- a/internal/tools/looker/lookergetdashboard/lookergetdashboard_test.go
+++ b/internal/tools/looker/lookergetdashboard/lookergetdashboard_test.go
@@ -165,7 +165,7 @@ func TestAnnotations(t *testing.T) {
 		t.Fatalf("failed to initialize tool: %v", err)
 	}
 
-	annotations := tool.GetAnnotations()
+	annotations := tool.GetAnnotations(nil)
 	if annotations == nil {
 		t.Fatal("mcp manifest annotations is nil")
 	}

--- a/internal/tools/looker/lookerlistagents/lookerlistagents_test.go
+++ b/internal/tools/looker/lookerlistagents/lookerlistagents_test.go
@@ -188,7 +188,7 @@ func TestAnnotations(t *testing.T) {
 		t.Fatalf("failed to initialize tool: %v", err)
 	}
 
-	annotations := tool.GetAnnotations()
+	annotations := tool.GetAnnotations(nil)
 	if annotations == nil {
 		t.Fatal("mcp manifest annotations is nil")
 	}

--- a/internal/tools/looker/lookerupdateagent/lookerupdateagent_test.go
+++ b/internal/tools/looker/lookerupdateagent/lookerupdateagent_test.go
@@ -246,7 +246,7 @@ func TestAnnotations(t *testing.T) {
 		t.Fatalf("failed to initialize tool: %v", err)
 	}
 
-	annotations := tool.GetAnnotations()
+	annotations := tool.GetAnnotations(nil)
 	if annotations == nil {
 		t.Fatal("mcp manifest annotations is nil")
 	}

--- a/internal/tools/looker/lookerupdatedashboardelement/lookerupdatedashboardelement_test.go
+++ b/internal/tools/looker/lookerupdatedashboardelement/lookerupdatedashboardelement_test.go
@@ -181,7 +181,7 @@ func TestAnnotations(t *testing.T) {
 		t.Fatalf("failed to initialize tool: %v", err)
 	}
 
-	annotations := tool.GetAnnotations()
+	annotations := tool.GetAnnotations(nil)
 	if annotations == nil {
 		t.Fatal("mcp manifest annotations is nil")
 	}

--- a/internal/tools/looker/lookerupdatedashboardlayoutcomponent/lookerupdatedashboardlayoutcomponent_test.go
+++ b/internal/tools/looker/lookerupdatedashboardlayoutcomponent/lookerupdatedashboardlayoutcomponent_test.go
@@ -172,7 +172,7 @@ func TestAnnotations(t *testing.T) {
 		t.Fatalf("failed to initialize tool: %v", err)
 	}
 
-	annotations := tool.GetAnnotations()
+	annotations := tool.GetAnnotations(nil)
 	if annotations == nil {
 		t.Fatal("mcp manifest annotations is nil")
 	}

--- a/internal/tools/mysql/mysqlexecutesql/mysqlexecutesql.go
+++ b/internal/tools/mysql/mysqlexecutesql/mysqlexecutesql.go
@@ -127,9 +127,20 @@ func (t Tool) ValidateSource(source sources.Source) error {
 	return nil
 }
 
-// ShouldSuppress returns false because single execute_sql tools for MySQL
-// are secured at the database connection layer via connection-string locking parameters.
-// They must remain exposed in read-only mode.
-func (t Tool) ShouldSuppress(ctx context.Context, source sources.Source) bool {
-	return false
+// GetAnnotations dynamically returns readOnlyHint: true and destructiveHint: false
+// when the connected database source is in read-only mode.
+func (t Tool) GetAnnotations(src sources.Source) *tools.ToolAnnotations {
+	base := t.BaseTool.GetAnnotations(src)
+	if src == nil || !src.IsReadOnly() {
+		return base
+	}
+
+	res := tools.NewReadOnlyAnnotations()
+	if base != nil {
+		copied := *base
+		copied.ReadOnlyHint = res.ReadOnlyHint
+		copied.DestructiveHint = res.DestructiveHint
+		return &copied
+	}
+	return res
 }

--- a/internal/tools/mysql/mysqlexecutesql/mysqlexecutesql_test.go
+++ b/internal/tools/mysql/mysqlexecutesql/mysqlexecutesql_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/mcp-toolbox/internal/server"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/testutils"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/tools/mysql/mysqlexecutesql"
@@ -71,5 +72,79 @@ func TestParseFromYamlExecuteSql(t *testing.T) {
 			}
 		})
 	}
+}
 
+func TestGetAnnotations(t *testing.T) {
+	ctx, err := testutils.ContextWithNewLogger()
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	boolPtr := func(b bool) *bool { return &b }
+	readOnlySrc := &testutils.MockSource{MockSourceConfig: testutils.MockSourceConfig{ReadOnly: true}}
+	readWriteSrc := &testutils.MockSource{MockSourceConfig: testutils.MockSourceConfig{ReadOnly: false}}
+
+	tests := []struct {
+		desc        string
+		src         sources.Source
+		annotations *tools.ToolAnnotations
+		want        *tools.ToolAnnotations
+	}{
+		{
+			desc: "nil source returns default destructive annotations unmodified",
+			src:  nil,
+			want: tools.NewDestructiveAnnotations(),
+		},
+		{
+			desc: "read-write source returns default destructive annotations unmodified",
+			src:  readWriteSrc,
+			want: tools.NewDestructiveAnnotations(),
+		},
+		{
+			desc: "read-only source dynamically flips default destructive annotations to read-only",
+			src:  readOnlySrc,
+			want: tools.NewReadOnlyAnnotations(),
+		},
+		{
+			desc:        "read-only source with explicit read-only base remains read-only",
+			src:         readOnlySrc,
+			annotations: tools.NewReadOnlyAnnotations(),
+			want:        tools.NewReadOnlyAnnotations(),
+		},
+		{
+			desc: "read-only source preserves custom hints (idempotent, openWorld) when flipped",
+			src:  readOnlySrc,
+			annotations: &tools.ToolAnnotations{
+				DestructiveHint: boolPtr(true),
+				ReadOnlyHint:    boolPtr(false),
+				IdempotentHint:  boolPtr(true),
+				OpenWorldHint:   boolPtr(true),
+			},
+			want: &tools.ToolAnnotations{
+				ReadOnlyHint:   boolPtr(true),
+				IdempotentHint: boolPtr(true),
+				OpenWorldHint:  boolPtr(true),
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			cfg := mysqlexecutesql.Config{
+				ConfigBase:  tools.ConfigBase{Name: "mysql-execute-sql", Description: "execute sql query"},
+				Type:        "mysql-execute-sql",
+				Source:      "my-instance",
+				Annotations: tc.annotations,
+			}
+			tool, err := cfg.Initialize(ctx)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			got := tool.GetAnnotations(tc.src)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("GetAnnotations() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
 }

--- a/internal/tools/postgres/postgresexecutesql/postgresexecutesql.go
+++ b/internal/tools/postgres/postgresexecutesql/postgresexecutesql.go
@@ -124,9 +124,20 @@ func (t Tool) ValidateSource(source sources.Source) error {
 	return nil
 }
 
-// ShouldSuppress returns false because single execute_sql tools for Postgres/AlloyDB
-// are secured at the database connection layer via connection-string locking parameters
-// (cloudsql_session_read_only=locked). They must remain exposed in read-only mode.
-func (t Tool) ShouldSuppress(ctx context.Context, source sources.Source) bool {
-	return false
+// GetAnnotations dynamically returns readOnlyHint: true and destructiveHint: false
+// when the connected database source is in read-only mode.
+func (t Tool) GetAnnotations(src sources.Source) *tools.ToolAnnotations {
+	base := t.BaseTool.GetAnnotations(src)
+	if src == nil || !src.IsReadOnly() {
+		return base
+	}
+
+	res := tools.NewReadOnlyAnnotations()
+	if base != nil {
+		copied := *base
+		copied.ReadOnlyHint = res.ReadOnlyHint
+		copied.DestructiveHint = res.DestructiveHint
+		return &copied
+	}
+	return res
 }

--- a/internal/tools/postgres/postgresexecutesql/postgresexecutesql_test.go
+++ b/internal/tools/postgres/postgresexecutesql/postgresexecutesql_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/mcp-toolbox/internal/server"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/testutils"
 	"github.com/googleapis/mcp-toolbox/internal/tools"
 	"github.com/googleapis/mcp-toolbox/internal/tools/postgres/postgresexecutesql"
@@ -71,5 +72,79 @@ func TestParseFromYamlExecuteSql(t *testing.T) {
 			}
 		})
 	}
+}
 
+func TestGetAnnotations(t *testing.T) {
+	ctx, err := testutils.ContextWithNewLogger()
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	boolPtr := func(b bool) *bool { return &b }
+	readOnlySrc := &testutils.MockSource{MockSourceConfig: testutils.MockSourceConfig{ReadOnly: true}}
+	readWriteSrc := &testutils.MockSource{MockSourceConfig: testutils.MockSourceConfig{ReadOnly: false}}
+
+	tests := []struct {
+		desc        string
+		src         sources.Source
+		annotations *tools.ToolAnnotations
+		want        *tools.ToolAnnotations
+	}{
+		{
+			desc: "nil source returns default destructive annotations unmodified",
+			src:  nil,
+			want: tools.NewDestructiveAnnotations(),
+		},
+		{
+			desc: "read-write source returns default destructive annotations unmodified",
+			src:  readWriteSrc,
+			want: tools.NewDestructiveAnnotations(),
+		},
+		{
+			desc: "read-only source dynamically flips default destructive annotations to read-only",
+			src:  readOnlySrc,
+			want: tools.NewReadOnlyAnnotations(),
+		},
+		{
+			desc:        "read-only source with explicit read-only base remains read-only",
+			src:         readOnlySrc,
+			annotations: tools.NewReadOnlyAnnotations(),
+			want:        tools.NewReadOnlyAnnotations(),
+		},
+		{
+			desc: "read-only source preserves custom hints (idempotent, openWorld) when flipped",
+			src:  readOnlySrc,
+			annotations: &tools.ToolAnnotations{
+				DestructiveHint: boolPtr(true),
+				ReadOnlyHint:    boolPtr(false),
+				IdempotentHint:  boolPtr(true),
+				OpenWorldHint:   boolPtr(true),
+			},
+			want: &tools.ToolAnnotations{
+				ReadOnlyHint:   boolPtr(true),
+				IdempotentHint: boolPtr(true),
+				OpenWorldHint:  boolPtr(true),
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			cfg := postgresexecutesql.Config{
+				ConfigBase:  tools.ConfigBase{Name: "postgres-execute-sql", Description: "execute sql query"},
+				Type:        "postgres-execute-sql",
+				Source:      "my-instance",
+				Annotations: tc.annotations,
+			}
+			tool, err := cfg.Initialize(ctx)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			got := tool.GetAnnotations(tc.src)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("GetAnnotations() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
 }

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -127,7 +127,7 @@ type Tool interface {
 	GetSourceName() string
 	GetDescription() string
 	GetAuthRequired() []string
-	GetAnnotations() *ToolAnnotations
+	GetAnnotations(sources.Source) *ToolAnnotations
 	Invoke(context.Context, sources.Source, parameters.ParamValues, AccessToken) (any, util.ToolboxError)
 	EmbedParams(context.Context, parameters.ParamValues, PrimitiveManagerI) (parameters.ParamValues, error)
 	Manifest(sources.Source) (Manifest, error)
@@ -139,7 +139,6 @@ type Tool interface {
 	GetParameters(sources.Source) (parameters.Parameters, error)
 	GetScopesRequired() []string
 	ValidateSource(sources.Source) error
-	ShouldSuppress(context.Context, sources.Source) bool
 }
 
 // PrimitiveManagerI defines the minimal view of the primitives.PrimitiveManager
@@ -219,11 +218,11 @@ func NewBaseTool[T ToolMeta](cfg T, annotations *ToolAnnotations, metadata Manif
 	}
 }
 
-func (b BaseTool[T]) GetName() string                  { return b.Cfg.GetName() }
-func (b BaseTool[T]) GetDescription() string           { return b.Cfg.GetDescription() }
-func (b BaseTool[T]) GetAuthRequired() []string        { return b.Cfg.GetAuthRequired() }
-func (b BaseTool[T]) GetScopesRequired() []string      { return b.Cfg.GetScopesRequired() }
-func (b BaseTool[T]) GetAnnotations() *ToolAnnotations { return b.annotations }
+func (b BaseTool[T]) GetName() string                                  { return b.Cfg.GetName() }
+func (b BaseTool[T]) GetDescription() string                           { return b.Cfg.GetDescription() }
+func (b BaseTool[T]) GetAuthRequired() []string                        { return b.Cfg.GetAuthRequired() }
+func (b BaseTool[T]) GetScopesRequired() []string                      { return b.Cfg.GetScopesRequired() }
+func (b BaseTool[T]) GetAnnotations(_ sources.Source) *ToolAnnotations { return b.annotations }
 
 // Manifest returns the precomputed metadata. It and GetParameters stay trivial
 // and never call each other: embedded methods have no virtual dispatch, so a
@@ -265,16 +264,17 @@ func (b BaseTool[T]) EmbedParams(ctx context.Context, paramValues parameters.Par
 // By default, if the source is read-only and the tool's ReadOnlyHint is explicitly false,
 // the tool is suppressed. Unannotated tools (ReadOnlyHint == nil) or read-only tools
 // (ReadOnlyHint == true) are not suppressed.
-func (b BaseTool[T]) ShouldSuppress(ctx context.Context, src sources.Source) bool {
-	if src == nil || !src.IsReadOnly() {
+func ShouldSuppress(ctx context.Context, t Tool, src sources.Source) bool {
+	if t == nil || src == nil || !src.IsReadOnly() {
 		return false
 	}
 
-	toolName := b.GetName()
+	toolName := t.GetName()
 	l, _ := util.LoggerFromContext(ctx)
 
-	if b.annotations != nil && b.annotations.ReadOnlyHint != nil {
-		if !*b.annotations.ReadOnlyHint {
+	ann := t.GetAnnotations(src)
+	if ann != nil && ann.ReadOnlyHint != nil {
+		if !*ann.ReadOnlyHint {
 			if l != nil {
 				l.InfoContext(ctx, fmt.Sprintf("Suppressing write-capable tool %q bound to read-only source", toolName))
 			}

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -60,9 +60,8 @@ func TestBaseToolGetters(t *testing.T) {
 	if diff := cmp.Diff([]string{"google"}, b.GetAuthRequired()); diff != "" {
 		t.Errorf("GetAuthRequired() mismatch (-want +got):\n%s", diff)
 	}
-	got := b.GetAnnotations()
-	if got == nil || got.ReadOnlyHint == nil || !*got.ReadOnlyHint {
-		t.Errorf("GetAnnotations() = %+v, want ReadOnlyHint=true", got)
+	if diff := cmp.Diff(tools.NewReadOnlyAnnotations(), b.GetAnnotations(nil)); diff != "" {
+		t.Errorf("GetAnnotations() mismatch (-want +got):\n%s", diff)
 	}
 	gotManifest, err := b.Manifest(nil)
 	if err != nil {
@@ -145,7 +144,7 @@ func TestBaseToolEmbedParamsPassthrough(t *testing.T) {
 	}
 }
 
-func TestBaseToolShouldSuppress(t *testing.T) {
+func TestShouldSuppress(t *testing.T) {
 	roSource := testutils.MockSource{MockSourceConfig: testutils.MockSourceConfig{ReadOnly: true}}
 	rwSource := testutils.MockSource{MockSourceConfig: testutils.MockSourceConfig{ReadOnly: false}}
 
@@ -158,17 +157,23 @@ func TestBaseToolShouldSuppress(t *testing.T) {
 		{
 			desc:        "nil source -> not suppressed",
 			src:         nil,
-			annotations: tools.NewDestructiveAnnotations(),
+			annotations: tools.NewWriteAnnotations(),
 			want:        false,
 		},
 		{
 			desc:        "read-write source with write tool -> not suppressed",
 			src:         rwSource,
-			annotations: tools.NewDestructiveAnnotations(),
+			annotations: tools.NewWriteAnnotations(),
 			want:        false,
 		},
 		{
 			desc:        "read-only source with write tool (readOnlyHint: false) -> suppressed",
+			src:         roSource,
+			annotations: tools.NewWriteAnnotations(),
+			want:        true,
+		},
+		{
+			desc:        "read-only source with destructive write tool (readOnlyHint: false, destructiveHint: true) -> suppressed",
 			src:         roSource,
 			annotations: tools.NewDestructiveAnnotations(),
 			want:        true,
@@ -185,12 +190,35 @@ func TestBaseToolShouldSuppress(t *testing.T) {
 			annotations: nil,
 			want:        false,
 		},
+		{
+			desc: "read-only source with custom tool explicitly setting readOnlyHint: false -> suppressed",
+			src:  roSource,
+			annotations: &tools.ToolAnnotations{
+				ReadOnlyHint: func(b bool) *bool { return &b }(false),
+			},
+			want: true,
+		},
+		{
+			desc: "read-only source with custom tool explicitly setting readOnlyHint: true -> not suppressed",
+			src:  roSource,
+			annotations: &tools.ToolAnnotations{
+				ReadOnlyHint: func(b bool) *bool { return &b }(true),
+			},
+			want: false,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			b := tools.NewBaseTool(tools.ConfigBase{}, tt.annotations, tools.Manifest{}, nil)
-			if got := b.ShouldSuppress(context.Background(), tt.src); got != tt.want {
+			cfg := testutils.MockToolConfig{
+				ConfigBase:  tools.ConfigBase{Name: "my-tool"},
+				Annotations: tt.annotations,
+			}
+			tool, err := cfg.Initialize(context.Background())
+			if err != nil {
+				t.Fatalf("unexpected error initializing mock tool: %v", err)
+			}
+			if got := tools.ShouldSuppress(context.Background(), tool, tt.src); got != tt.want {
 				t.Errorf("ShouldSuppress() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
## Summary

Enables multi-mode tools (e.g., SQL execution tools) to dynamically advertise `readOnlyHint: true` and `destructiveHint: false` in MCP tool manifests when bound to a read-only data source, and centralizes tool suppression logic across the server.

## Context & Motivation

* Tools like `postgres-execute-sql` and `mysql-execute-sql` are multi-mode (capable of both reads and writes) and default to `readOnlyHint: false` / `destructiveHint: true`. When connected to a `readOnly: true` database source (where session-level locks prevent modifications), these tools should dynamically report `readOnlyHint: true` and `destructiveHint: false` to MCP clients without requiring separate read-only tool implementations.
* Refactored `ShouldSuppress` from a `BaseTool` method into a package-level function `tools.ShouldSuppress(ctx, t, src)` that operates on the `Tool` interface, allowing suppression to dynamically evaluate `t.GetAnnotations(src)` without requiring concrete tool method overrides.

## Changes

   * Updated `Tool.GetAnnotations(sources.Source) *ToolAnnotations` to make annotations source-aware (matching the design pattern of `GetParameters(sources.Source)` and `Manifest(sources.Source)`).
   * Updated `BaseTool.GetAnnotations(_ sources.Source)` to return static annotations by default.
   * Added `DynamicReadOnlyAnnotations(base *ToolAnnotations) *ToolAnnotations` in `internal/tools/tools.go` to safely copy base annotations and set `ReadOnlyHint: true` / `DestructiveHint: false` while preserving other custom hints (e.g. `idempotentHint`, `openWorldHint`).
   * Updated `postgres-execute-sql` and `mysql-execute-sql` to implement `GetAnnotations(src)` using `tools.DynamicReadOnlyAnnotations(t.BaseTool.GetAnnotations(src))` when `src.IsReadOnly()`.
   * Removed redundant `ShouldSuppress` method overrides from concrete SQL tool structs.
   * Updated all 5 MCP schema version generators (`v20241105`, `v20250326`, `v20250618`, `v20251125`, `v20260728`) in `internal/server/mcp/` to pass `src` into `tool.GetAnnotations(src)`.
   * Added table-driven tests for `tools.DynamicReadOnlyAnnotations` in `internal/tools/tools_test.go` verifying nil handling, default flipping, custom hint preservation, and pointer immutability.
   * Updated `internal/server/server_test.go` and `internal/tools/tools_test.go` to test `tools.ShouldSuppress` with both write and destructive tools using `tools.NewWriteAnnotations()` and `tools.NewDestructiveAnnotations()`.
   * Updated Looker unit test suites to pass `tool.GetAnnotations(nil)`.
