### PR TITLE
docs: add self-review checkbox to the PR checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,7 +14,7 @@
   [bug/issue](https://github.com/googleapis/mcp-toolbox/issues/new/choose)
   before writing your code! That way we can discuss the change, evaluate
   designs, and agree on the general idea
-- [ ] I have manually reviewed the entire diff myself before requesting a
+- [ ] Ensure you have manually reviewed the entire diff before requesting a
   review
 - [ ] Ensure the tests and linter pass
 - [ ] Code coverage does not decrease (if any source code was changed)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,6 +14,8 @@
   [bug/issue](https://github.com/googleapis/mcp-toolbox/issues/new/choose)
   before writing your code! That way we can discuss the change, evaluate
   designs, and agree on the general idea
+- [ ] I have manually reviewed the entire diff myself before requesting a
+  review
 - [ ] Ensure the tests and linter pass
 - [ ] Code coverage does not decrease (if any source code was changed)
 - [ ] Appropriate docs were updated (if necessary)

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -140,7 +140,7 @@ A concise description of the changes (bug or feature), its impact, and a summary
 
 **2. PR Checklist**
 - [ ] Make sure to open an issue as a bug/issue before writing your code!
-- [ ] I have manually reviewed the entire diff myself before requesting a review
+- [ ] Ensure you have manually reviewed the entire diff before requesting a review
 - [ ] Ensure the tests and linter pass
 - [ ] Code coverage does not decrease (if any source code was changed)
 - [ ] Appropriate docs were updated (if necessary)

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -140,6 +140,7 @@ A concise description of the changes (bug or feature), its impact, and a summary
 
 **2. PR Checklist**
 - [ ] Make sure to open an issue as a bug/issue before writing your code!
+- [ ] I have manually reviewed the entire diff myself before requesting a review
 - [ ] Ensure the tests and linter pass
 - [ ] Code coverage does not decrease (if any source code was changed)
 - [ ] Appropriate docs were updated (if necessary)


### PR DESCRIPTION
Adds a checklist item asking PR authors to confirm they have manually reviewed their own diff before requesting a review. 