### PR TITLE
docs(groups): Add cache fields to groups docs

### DIFF
--- a/docs/en/documentation/configuration/groups/_index.md
+++ b/docs/en/documentation/configuration/groups/_index.md
@@ -14,12 +14,14 @@ Connecting to a group's endpoint (`/mcp/{name}`) scopes the corresponding MCP li
 
 Declare a group as a `kind: group` document in your configuration file. A group has the following fields:
 
-| Field         | Required | Description                                                              |
-| ------------- | -------- | ------------------------------------------------------------------------ |
-| `name`        | Yes\*    | Unique name for the group. Used as the endpoint path (`/mcp/{name}`).    |
-| `description` | No       | Human-readable description of the group.                                |
-| `tools`       | No       | List of tool names to include in the group.                             |
-| `prompts`     | No       | List of prompt names to include in the group.                           |
+| Field         | Required | Description                                                                                    |
+| ------------- | -------- | -----------------------------------------------------------------------------------------------|
+| `name`        | Yes\*    | Unique name for the group. Used as the endpoint path (`/mcp/{name}`).                          |
+| `description` | No       | Human-readable description of the group.                                                       |
+| `tools`       | No       | List of tool names to include in the group.                                                    |
+| `prompts`     | No       | List of prompt names to include in the group.                                                  |
+| `ttlMs`       | No       | Time-to-live in milliseconds for cached group list responses. Defaults to `300000` (5 minutes).|
+| `cacheScope`  | No       | Cache visibility for group list responses (either `public` or `private`). Defaults to `public`.|
 
 \* `name` is required for every named group. The single [default group](#the-default-group) omits it.
 
@@ -41,6 +43,8 @@ description: Administrative operations.
 tools:
   - create_user
   - list_users
+ttlMs: 3600000
+cacheScope: private
 ```
 
 ## The default group
@@ -62,6 +66,7 @@ At startup, Toolbox validates groups:
 - **One default group.** Declaring more than one nameless group is an error.
 - **Default group restrictions.** The default group may set only a `description`; declaring `tools`, `prompts`, or any other primitive list on it is an error.
 - **No duplicate names across toolsets and groups.** A `kind: toolset` is parsed as a group, so defining the same name as both a `kind: toolset` and a `kind: group` is a duplicate-name error.
+- **Valid caching parameters.** If specified, `ttlMs` must be non-negative (>=0), and `cacheScope` must be either `public` or `private`.
 
 ## Relationship to toolsets
 

--- a/docs/en/documentation/configuration/groups/_index.md
+++ b/docs/en/documentation/configuration/groups/_index.md
@@ -20,8 +20,8 @@ Declare a group as a `kind: group` document in your configuration file. A group 
 | `description` | No       | Human-readable description of the group.                                                       |
 | `tools`       | No       | List of tool names to include in the group.                                                    |
 | `prompts`     | No       | List of prompt names to include in the group.                                                  |
-| `ttlMs`       | No       | Time-to-live in milliseconds for cached group list responses. Defaults to `300000` (5 minutes).|
-| `cacheScope`  | No       | Cache visibility for group list responses (either `public` or `private`). Defaults to `public`.|
+| `ttlMs`       | No       | Time-to-live in milliseconds for cached group list responses. ([MCP TTL Spec](https://modelcontextprotocol.io/specification/2026-07-28/server/utilities/caching#time-to-live-ttl-field )). Defaults to `300000` (5 minutes).|
+| `cacheScope`  | No       | Cache visibility for group list responses (either `public` or `private`). ([MCP Cache Scope Spec](https://modelcontextprotocol.io/specification/2026-07-28/server/utilities/caching#cache-scope-field)). Defaults to `public`.|
 
 \* `name` is required for every named group. The single [default group](#the-default-group) omits it.
 
@@ -66,7 +66,7 @@ At startup, Toolbox validates groups:
 - **One default group.** Declaring more than one nameless group is an error.
 - **Default group restrictions.** The default group may set only a `description`; declaring `tools`, `prompts`, or any other primitive list on it is an error.
 - **No duplicate names across toolsets and groups.** A `kind: toolset` is parsed as a group, so defining the same name as both a `kind: toolset` and a `kind: group` is a duplicate-name error.
-- **Valid caching parameters.** If specified, `ttlMs` must be non-negative (>=0), and `cacheScope` must be either `public` or `private`.
+- **Valid parameters.** If specified, `ttlMs` must be non-negative (>=0), and `cacheScope` must be either `public` or `private`.
 
 ## Relationship to toolsets
 


### PR DESCRIPTION
## Description

Updates docs to include information about `ttlMs` and `cacheScope` fields recently added to groups in https://github.com/googleapis/mcp-toolbox/pull/3805.
