### PR TITLE
chore(ci): Persist Github Token in Github Workflow to deploy Dev docs

### DIFF
--- a/.github/workflows/deploy_dev_docs_to_cf.yaml
+++ b/.github/workflows/deploy_dev_docs_to_cf.yaml
@@ -86,7 +86,6 @@ jobs:
         with:
           ref: cloudflare-pages
           path: cf-pages-temp
-          persist-credentials: false
 
       - name: Push to Cloudflare Branch
         env:


### PR DESCRIPTION
Removed 'persist-credentials' option from checkout action.

The GHA workflow is failing with 
`fatal: could not read Username for 'https://github.com/': No such device or address`

By persisting credentials at the end of the script, we can provide Github authentication