### PR TITLE
feat(embeddingmodels): add OrcaRouter embedding model provider

### DIFF
--- a/docs/en/documentation/configuration/embedding-models/orcarouter.md
+++ b/docs/en/documentation/configuration/embedding-models/orcarouter.md
@@ -1,0 +1,67 @@
+---
+title: "OrcaRouter Embedding"
+type: docs
+weight: 2
+description: >
+  Use OrcaRouter to route OpenAI-compatible embedding models from OpenAI,
+  Google and others behind a single API key.
+---
+
+## About
+
+[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible model routing
+gateway. It exposes embedding models from OpenAI (`text-embedding-3-small`,
+`text-embedding-3-large`, `text-embedding-ada-002`) and Google
+(`gemini-embedding-001`, `gemini-embedding-2-preview`) behind a single endpoint
+and API key, so you can switch embedding models without changing your Toolbox
+configuration.
+
+### Authentication
+
+OrcaRouter uses a single API key for all models. Provide `apiKey` in the YAML
+(or set the `ORCAROUTER_API_KEY` environment variable). Get an API key at
+[orcarouter.ai](https://www.orcarouter.ai); keys start with `sk-orca-`.
+
+## Behavior
+
+### Automatic Vectorization
+
+When a tool parameter is configured with `embeddedBy: <your-orcarouter-model-name>`,
+the Toolbox intercepts the raw text input from the client and sends it to the
+OrcaRouter `/embeddings` endpoint using the [OpenAI Embeddings API][openai-embeddings]
+format. The resulting numerical array is then formatted before being passed to
+your database source.
+
+### Dimension Matching
+
+The optional `dimension` field requests a specific output dimensionality and is
+passed through to the model. It must match the expected size of your database
+column (e.g., a `vector(3072)` column in PostgreSQL) and be supported by the
+selected embedding model. If unset, the model's default dimensionality is used.
+
+[openai-embeddings]: https://platform.openai.com/docs/api-reference/embeddings
+
+## Example
+
+```yaml
+kind: embeddingModel
+name: orcarouter-model
+type: orcarouter
+model: openai/text-embedding-3-small
+apiKey: ${ORCAROUTER_API_KEY}
+dimension: 1536
+```
+
+{{< notice tip >}} Use environment variable replacement with the format
+${ENV_NAME} instead of hardcoding your secrets into the configuration file.
+{{< /notice >}}
+
+## Reference
+
+| **field**   | **type** | **required** | **description**                                                                                                                                      |
+| ----------- | :------: | :----------: | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| type        |  string  |     true     | Must be `orcarouter`.                                                                                                                                |
+| model       |  string  |     true     | The OrcaRouter model ID to use (e.g., `openai/text-embedding-3-small`).                                                                              |
+| apiKey      |  string  |    false     | OrcaRouter API key. If unset, `ORCAROUTER_API_KEY` is used.                                                                                          |
+| baseUrl     |  string  |    false     | The gateway base URL. Defaults to `https://api.orcarouter.ai/v1`.                                                                                    |
+| dimension   | integer  |    false     | The number of dimensions in the output vector (e.g., `1536`).                                                                                        |

--- a/internal/embeddingmodels/orcarouter/orcarouter.go
+++ b/internal/embeddingmodels/orcarouter/orcarouter.go
@@ -1,0 +1,182 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package orcarouter implements an embedding model backed by the OrcaRouter
+// gateway. OrcaRouter exposes OpenAI-compatible embedding models (OpenAI,
+// Google, ...) behind a single API key and endpoint, so the provider simply
+// forwards the standard POST /embeddings request to the gateway.
+package orcarouter
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
+	"github.com/googleapis/mcp-toolbox/internal/util"
+)
+
+const EmbeddingModelType string = "orcarouter"
+
+// DefaultBaseURL is the default OrcaRouter API endpoint.
+const DefaultBaseURL string = "https://api.orcarouter.ai/v1"
+
+// validate interface
+var _ embeddingmodels.EmbeddingModelConfig = Config{}
+
+type Config struct {
+	Name      string `yaml:"name" validate:"required"`
+	Type      string `yaml:"type" validate:"required"`
+	Model     string `yaml:"model" validate:"required"`
+	ApiKey    string `yaml:"apiKey"`
+	BaseURL   string `yaml:"baseUrl"`
+	Dimension int32  `yaml:"dimension"`
+}
+
+// Returns the embedding model type
+func (cfg Config) EmbeddingModelConfigType() string {
+	return EmbeddingModelType
+}
+
+// Initialize an OrcaRouter embedding model
+func (cfg Config) Initialize(ctx context.Context) (embeddingmodels.EmbeddingModel, error) {
+	// Get API Key
+	apiKey := cfg.ApiKey
+	if apiKey == "" {
+		apiKey = os.Getenv("ORCAROUTER_API_KEY")
+	}
+	if apiKey == "" {
+		return nil, fmt.Errorf("missing credentials for OrcaRouter embedding: " +
+			"Provide 'apiKey' in YAML or set ORCAROUTER_API_KEY env var. " +
+			"See documentation for details: https://mcp-toolbox.dev/documentation/configuration/embedding-models/orcarouter/")
+	}
+
+	// Retrieve logger from context
+	l, err := util.LoggerFromContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("unable to retrieve logger: %w", err)
+	}
+
+	baseURL := cfg.BaseURL
+	if baseURL == "" {
+		baseURL = DefaultBaseURL
+	}
+
+	// Set user agent
+	ua, err := util.UserAgentFromContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get user agent from context: %w", err)
+	}
+
+	l.InfoContext(ctx, "Using OrcaRouter gateway for embedding", "model", cfg.Model)
+
+	return &EmbeddingModel{
+		Config:  cfg,
+		ApiKey:  apiKey,
+		BaseURL: baseURL,
+		Client:  &http.Client{Timeout: 60 * time.Second},
+		UA:      ua,
+	}, nil
+}
+
+var _ embeddingmodels.EmbeddingModel = EmbeddingModel{}
+
+type EmbeddingModel struct {
+	Config
+	ApiKey  string
+	BaseURL string
+	Client  *http.Client
+	UA      string
+}
+
+// Returns the embedding model type
+func (m EmbeddingModel) EmbeddingModelType() string {
+	return EmbeddingModelType
+}
+
+func (m EmbeddingModel) ToConfig() embeddingmodels.EmbeddingModelConfig {
+	return m.Config
+}
+
+func (m EmbeddingModel) EmbedParameters(ctx context.Context, parameters []string) ([][]float32, error) {
+	logger, err := util.LoggerFromContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get logger from ctx: %s", err)
+	}
+
+	reqBody := embeddingsRequest{
+		Model: m.Model,
+		Input: parameters,
+	}
+	if m.Dimension > 0 {
+		reqBody.Dimensions = &m.Dimension
+	}
+
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("unable to marshal embeddings request: %w", err)
+	}
+
+	url := strings.TrimSuffix(m.BaseURL, "/") + "/embeddings"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("unable to create embeddings request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+m.ApiKey)
+	req.Header.Set("User-Agent", m.UA)
+
+	resp, err := m.Client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("unable to call OrcaRouter embeddings API: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("OrcaRouter embeddings API returned status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var result embeddingsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("unable to decode embeddings response: %w", err)
+	}
+
+	embeddings := make([][]float32, 0, len(result.Data))
+	for _, item := range result.Data {
+		embeddings = append(embeddings, item.Embedding)
+	}
+
+	logger.InfoContext(ctx, "Successfully embedded %d text parameters using model %s", len(parameters), m.Model)
+
+	return embeddings, nil
+}
+
+type embeddingsRequest struct {
+	Model      string   `json:"model"`
+	Input      []string `json:"input"`
+	Dimensions *int32   `json:"dimensions,omitempty"`
+}
+
+type embeddingsResponse struct {
+	Data []struct {
+		Embedding []float32 `json:"embedding"`
+	} `json:"data"`
+}

--- a/internal/embeddingmodels/orcarouter/orcarouter_test.go
+++ b/internal/embeddingmodels/orcarouter/orcarouter_test.go
@@ -1,0 +1,166 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package orcarouter_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
+	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels/orcarouter"
+	"github.com/googleapis/mcp-toolbox/internal/server"
+	"github.com/googleapis/mcp-toolbox/internal/testutils"
+)
+
+func TestParseFromYamlOrcaRouter(t *testing.T) {
+	tcs := []struct {
+		desc string
+		in   string
+		want server.EmbeddingModelConfigs
+	}{
+		{
+			desc: "basic example",
+			in: `
+			kind: embeddingModel
+			name: my-orcarouter-model
+			type: orcarouter
+			model: openai/text-embedding-3-small
+            `,
+			want: map[string]embeddingmodels.EmbeddingModelConfig{
+				"my-orcarouter-model": orcarouter.Config{
+					Name:  "my-orcarouter-model",
+					Type:  orcarouter.EmbeddingModelType,
+					Model: "openai/text-embedding-3-small",
+				},
+			},
+		},
+		{
+			desc: "full example with api key, base url and dimension",
+			in: `
+            kind: embeddingModel
+            name: complex-orcarouter
+            type: orcarouter
+            model: openai/text-embedding-3-large
+            apiKey: "test-api-key"
+            baseUrl: "https://api.orcarouter.ai/v1"
+            dimension: 3072
+            `,
+			want: map[string]embeddingmodels.EmbeddingModelConfig{
+				"complex-orcarouter": orcarouter.Config{
+					Name:      "complex-orcarouter",
+					Type:      orcarouter.EmbeddingModelType,
+					Model:     "openai/text-embedding-3-large",
+					ApiKey:    "test-api-key",
+					BaseURL:   "https://api.orcarouter.ai/v1",
+					Dimension: 3072,
+				},
+			},
+		},
+		{
+			desc: "config with env var api key",
+			in: `
+            kind: embeddingModel
+            name: env-key-orcarouter
+            type: orcarouter
+            model: google/gemini-embedding-001
+            apiKey: ${ORCAROUTER_API_KEY}
+            `,
+			want: map[string]embeddingmodels.EmbeddingModelConfig{
+				"env-key-orcarouter": orcarouter.Config{
+					Name:   "env-key-orcarouter",
+					Type:   orcarouter.EmbeddingModelType,
+					Model:  "google/gemini-embedding-001",
+					ApiKey: "${ORCAROUTER_API_KEY}",
+				},
+			},
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			// Parse contents
+			_, _, got, _, _, _, err := server.UnmarshalPrimitiveConfig(context.Background(), testutils.FormatYaml(tc.in))
+			if err != nil {
+				t.Fatalf("unable to unmarshal: %s", err)
+			}
+			if !cmp.Equal(tc.want, got) {
+				t.Fatalf("incorrect parse: %v", cmp.Diff(tc.want, got))
+			}
+		})
+	}
+}
+
+func TestFailParseFromYamlOrcaRouter(t *testing.T) {
+	tcs := []struct {
+		desc string
+		in   string
+		err  string
+	}{
+		{
+			desc: "missing required model field",
+			in: `
+            kind: embeddingModel
+            name: bad-model
+            type: orcarouter
+            `,
+			err: "error unmarshaling embeddingModel: unable to parse as \"bad-model\": Key: 'Config.Model' Error:Field validation for 'Model' failed on the 'required' tag",
+		},
+		{
+			desc: "unknown field",
+			in: `
+            kind: embeddingModel
+            name: bad-field
+            type: orcarouter
+            model: openai/text-embedding-3-small
+            invalid_param: true
+            `,
+			err: "error unmarshaling embeddingModel: unable to parse as \"bad-field\": [1:1] unknown field \"invalid_param\"\n>  1 | invalid_param: true\n       ^\n   2 | model: openai/text-embedding-3-small\n   3 | name: bad-field\n   4 | type: orcarouter",
+		},
+		{
+			desc: "missing credentials",
+			in: `
+        kind: embeddingModel
+        name: missing-creds
+        type: orcarouter
+        model: openai/text-embedding-3-small
+        `,
+			err: "missing credentials for OrcaRouter embedding: Provide 'apiKey' in YAML or set ORCAROUTER_API_KEY env var. See documentation for details: https://mcp-toolbox.dev/documentation/configuration/embedding-models/orcarouter/",
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Setenv("ORCAROUTER_API_KEY", "")
+
+			_, _, embeddingConfigs, _, _, _, err := server.UnmarshalPrimitiveConfig(context.Background(), testutils.FormatYaml(tc.in))
+			if err != nil {
+				if err.Error() != tc.err {
+					t.Fatalf("unexpected unmarshal error:\ngot:  %q\nwant: %q", err.Error(), tc.err)
+				}
+				return
+			}
+
+			for _, cfg := range embeddingConfigs {
+				_, err = cfg.Initialize(context.Background())
+				if err == nil {
+					t.Fatalf("expect initialization to fail for case: %s", tc.desc)
+				}
+				if !strings.Contains(err.Error(), tc.err) {
+					t.Fatalf("unexpected init error:\ngot:  %q\nwant: %q", err.Error(), tc.err)
+				}
+			}
+		})
+	}
+}

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -30,6 +30,7 @@ import (
 	"github.com/googleapis/mcp-toolbox/internal/auth/google"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels"
 	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels/gemini"
+	"github.com/googleapis/mcp-toolbox/internal/embeddingmodels/orcarouter"
 	"github.com/googleapis/mcp-toolbox/internal/group"
 	"github.com/googleapis/mcp-toolbox/internal/prompts"
 	"github.com/googleapis/mcp-toolbox/internal/sources"
@@ -439,18 +440,27 @@ func UnmarshalYAMLEmbeddingModelConfig(ctx context.Context, name string, r map[s
 	if !ok {
 		return nil, fmt.Errorf("missing 'type' field or it is not a string")
 	}
-	if resourceType != gemini.EmbeddingModelType {
-		return nil, fmt.Errorf("%s is not a valid type of embedding model", resourceType)
-	}
 	dec, err := util.NewStrictDecoder(r)
 	if err != nil {
 		return nil, fmt.Errorf("error creating decoder: %s", err)
 	}
-	actual := gemini.Config{Name: name}
-	if err := dec.DecodeContext(ctx, &actual); err != nil {
-		return nil, fmt.Errorf("unable to parse as %q: %w", name, err)
+
+	switch resourceType {
+	case gemini.EmbeddingModelType:
+		actual := gemini.Config{Name: name}
+		if err := dec.DecodeContext(ctx, &actual); err != nil {
+			return nil, fmt.Errorf("unable to parse as %q: %w", name, err)
+		}
+		return actual, nil
+	case orcarouter.EmbeddingModelType:
+		actual := orcarouter.Config{Name: name}
+		if err := dec.DecodeContext(ctx, &actual); err != nil {
+			return nil, fmt.Errorf("unable to parse as %q: %w", name, err)
+		}
+		return actual, nil
+	default:
+		return nil, fmt.Errorf("%s is not a valid type of embedding model", resourceType)
 	}
-	return actual, nil
 }
 
 func UnmarshalYAMLToolConfig(ctx context.Context, name string, r map[string]any) (tools.ToolConfig, error) {


### PR DESCRIPTION
## Description

Adds [OrcaRouter](https://www.orcarouter.ai) as a named embedding-model provider rather than relying on the generic path, mirroring how this repo already treats `gemini` as a first-class embedding model type. Named providers such as `openai/text-embedding-3-small` route through the gateway per request. OrcaRouter is an OpenAI-compatible gateway that exposes 150+ embedding and chat models (OpenAI, Google, ...) behind a single API key, and it also provides gateway-level security controls for AI agents.

I'm an engineer on the OrcaRouter team.

### What changed

The `embeddingModels` config previously accepted only `type: gemini`; `UnmarshalYAMLEmbeddingModelConfig` rejected any other type. This adds a second, OpenAI-compatible embedding model type:

- `internal/embeddingmodels/orcarouter/orcarouter.go` — new provider implementing `EmbeddingModelConfig`/`EmbeddingModel`. `Initialize` reads `apiKey` (or `ORCAROUTER_API_KEY`), `model`, optional `baseUrl` (defaults to `https://api.orcarouter.ai/v1`) and optional `dimension`. `EmbedParameters` sends the standard OpenAI `POST /embeddings` request (`input` array, optional `dimensions`) and maps `data[].embedding` to the Toolbox vector formatter.
- `internal/server/config.go` — `UnmarshalYAMLEmbeddingModelConfig` now dispatches on `type`: `gemini` and `orcarouter` (anything else still errors).
- `internal/embeddingmodels/orcarouter/orcarouter_test.go` — YAML parse tests (basic / full / env-var key) and failure tests (missing `model`, unknown field, missing credentials).
- `docs/en/documentation/configuration/embedding-models/orcarouter.md` — configuration reference page mirroring the existing `gemini` page.

### Verification

- `go build ./...` and `go test ./internal/embeddingmodels/... ./internal/server/...` pass.
- Live against the real gateway through the exact provider path (YAML `type: orcarouter` → `Initialize` → `EmbedParameters`): `POST https://api.orcarouter.ai/v1/embeddings` with `openai/text-embedding-3-small` returned 200 with two 1536-dimension vectors; an invalid key was rejected with 401.
- All embedding model IDs in the docs page exist in the live catalog (`GET /v1/models`, 207 models).

### PR Checklist

- [x] Reviewed [CONTRIBUTING.md](https://github.com/googleapis/mcp-toolbox/blob/main/CONTRIBUTING.md)
- [ ] Opened an issue for this change (small additive provider; happy to open one if required)
- [x] Manually reviewed the entire diff
- [x] Tests pass (`go test ./internal/embeddingmodels/... ./internal/server/...`)
- [x] Code coverage does not decrease (new package has parse + failure tests)
- [x] Docs updated (`embedding-models/orcarouter.md`)
