### PR TITLE
fix(server): make initialize handshake compliant with dual-era MCP spec

### DIFF
--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -838,10 +838,10 @@ func processMcpMessage(ctx context.Context, body []byte, s *Server, protocolVers
 
 		var version string
 		v := initReq.Params.ProtocolVersion
-		if slices.Contains(mcputil.GetSupportedVersions(s.enableDraftSpecs), v) {
+		if slices.Contains(mcputil.GetStatefulEraVersions(), v) {
 			version = v
 		} else {
-			version = mcputil.GetLatestSupportedVersion(s.enableDraftSpecs)
+			version = mcputil.GetLatestStatefulVersion()
 		}
 
 		result, err := mcp.ProcessMethod(ctx, version, baseMessage.Id, baseMessage.Method, group.Group{}, nil, body, nil)

--- a/internal/server/mcp/util/util.go
+++ b/internal/server/mcp/util/util.go
@@ -14,6 +14,8 @@
 
 package util
 
+import "slices"
+
 const (
 	VERSION_20241105 = "2024-11-05"
 	VERSION_20250326 = "2025-03-26"
@@ -22,22 +24,28 @@ const (
 	VERSION_20260728 = "2026-07-28"
 )
 
-// LATEST_PROTOCOL_VERSION is the latest version of the MCP protocol supported.
-// Update the version used in InitializeResponse when this value is updated.
-const LATEST_PROTOCOL_VERSION = VERSION_20251125
+// LATEST_STATEFUL_PROTOCOL_VERSION is the latest version of the MCP protocol
+// supported that uses the stateful initialize handshake (< 2026).
+// Update this value and InitializeResponse when a new stateful version is added.
+const LATEST_STATEFUL_PROTOCOL_VERSION = VERSION_20251125
 
-// LATEST_PROTOCOL_VERSION_NONSTABLE is the latest version of the MCP protocol
-// supported that includes non-stable version
-const LATEST_PROTOCOL_VERSION_NONSTABLE = VERSION_20260728
-
-// SUPPORTED_PROTOCOL_VERSIONS is the MCP protocol versions that are supported.
-var SUPPORTED_PROTOCOL_VERSIONS = []string{
+// STATEFUL_ERA_VERSIONS are the legacy MCP protocol versions
+// that support the stateful initialize handshake (< 2026).
+var STATEFUL_ERA_VERSIONS = []string{
 	VERSION_20241105,
 	VERSION_20250326,
 	VERSION_20250618,
 	VERSION_20251125,
+}
+
+// STATELESS_ERA_VERSIONS are the modern MCP protocol versions
+// that operate statelessly without an initialize handshake (>= 2026).
+var STATELESS_ERA_VERSIONS = []string{
 	VERSION_20260728,
 }
+
+// SUPPORTED_PROTOCOL_VERSIONS is the composite list of all supported MCP protocol versions across both eras.
+var SUPPORTED_PROTOCOL_VERSIONS = slices.Concat(STATEFUL_ERA_VERSIONS, STATELESS_ERA_VERSIONS)
 
 var SUPPORTED_PROTOCOL_VERSIONS_NONSTABLE = []string{}
 
@@ -48,9 +56,10 @@ func GetSupportedVersions(enableDraft bool) []string {
 	return SUPPORTED_PROTOCOL_VERSIONS
 }
 
-func GetLatestSupportedVersion(enableDraft bool) string {
-	if enableDraft {
-		return LATEST_PROTOCOL_VERSION_NONSTABLE
-	}
-	return LATEST_PROTOCOL_VERSION
+func GetStatefulEraVersions() []string {
+	return STATEFUL_ERA_VERSIONS
+}
+
+func GetLatestStatefulVersion() string {
+	return LATEST_STATEFUL_PROTOCOL_VERSION
 }

--- a/internal/server/mcp_test.go
+++ b/internal/server/mcp_test.go
@@ -2194,3 +2194,125 @@ func TestMcpPromptScopingByGroup(t *testing.T) {
 		})
 	}
 }
+
+func TestInitializeProtocolVersionNegotiation(t *testing.T) {
+	testCases := []struct {
+		name             string
+		enableDraftSpecs bool
+		reqVersion       string
+		wantVersion      string
+	}{
+		{
+			name:             "2026-07-28 downgrades to 2025-11-25 (default)",
+			enableDraftSpecs: false,
+			reqVersion:       "2026-07-28",
+			wantVersion:      "2025-11-25",
+		},
+		{
+			name:             "2026-07-28 downgrades to 2025-11-25 (draft specs enabled)",
+			enableDraftSpecs: true,
+			reqVersion:       "2026-07-28",
+			wantVersion:      "2025-11-25",
+		},
+		{
+			name:             "2025-11-25 returns 2025-11-25",
+			enableDraftSpecs: false,
+			reqVersion:       "2025-11-25",
+			wantVersion:      "2025-11-25",
+		},
+		{
+			name:             "2025-06-18 returns 2025-06-18",
+			enableDraftSpecs: false,
+			reqVersion:       "2025-06-18",
+			wantVersion:      "2025-06-18",
+		},
+		{
+			name:             "2025-03-26 returns 2025-03-26",
+			enableDraftSpecs: false,
+			reqVersion:       "2025-03-26",
+			wantVersion:      "2025-03-26",
+		},
+		{
+			name:             "2024-11-05 returns 2024-11-05",
+			enableDraftSpecs: false,
+			reqVersion:       "2024-11-05",
+			wantVersion:      "2024-11-05",
+		},
+		{
+			name:             "unknown future version 2999-01-01 downgrades to 2025-11-25",
+			enableDraftSpecs: false,
+			reqVersion:       "2999-01-01",
+			wantVersion:      "2025-11-25",
+		},
+		{
+			name:             "arbitrary string banana downgrades to 2025-11-25",
+			enableDraftSpecs: false,
+			reqVersion:       "banana",
+			wantVersion:      "2025-11-25",
+		},
+		{
+			name:             "empty string downgrades to 2025-11-25",
+			enableDraftSpecs: false,
+			reqVersion:       "",
+			wantVersion:      "2025-11-25",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var opts []func(*Server)
+			if tc.enableDraftSpecs {
+				opts = append(opts, withEnableDraftSpecs())
+			}
+			toolsMap, promptsMap, groups := testutils.SetUpResources(t, []testutils.MockTool{testutils.MockTool1, testutils.MockTool2}, nil)
+			r, shutdown := setUpServer(t, "mcp", toolsMap, promptsMap, groups, opts...)
+			defer shutdown()
+			ts := runServer(r, false)
+			defer ts.Close()
+
+			initReq := map[string]any{
+				"jsonrpc": jsonrpcVersion,
+				"id":      1,
+				"method":  "initialize",
+				"params": map[string]any{
+					"protocolVersion": tc.reqVersion,
+					"capabilities":    map[string]any{},
+					"clientInfo": map[string]any{
+						"name":    "probe",
+						"version": "0",
+					},
+				},
+			}
+			reqBytes, err := json.Marshal(initReq)
+			if err != nil {
+				t.Fatalf("unexpected marshal error: %v", err)
+			}
+
+			resp, body, err := runRequest(ts, http.MethodPost, "/", bytes.NewBuffer(reqBytes), nil)
+			if err != nil {
+				t.Fatalf("unexpected request error: %v", err)
+			}
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("unexpected status code: got %d, want %d, body: %s", resp.StatusCode, http.StatusOK, string(body))
+			}
+
+			var got map[string]any
+			if err := json.Unmarshal(body, &got); err != nil {
+				t.Fatalf("unexpected unmarshal error: %v, body: %s", err, string(body))
+			}
+
+			if got["error"] != nil {
+				t.Fatalf("expected error to be nil, got error: %+v", got["error"])
+			}
+
+			result, ok := got["result"].(map[string]any)
+			if !ok {
+				t.Fatalf("expected result object in response, got: %+v", got)
+			}
+
+			if result["protocolVersion"] != tc.wantVersion {
+				t.Errorf("negotiated protocolVersion mismatch: got %v, want %v", result["protocolVersion"], tc.wantVersion)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Overview

Fixes an issue where sending an MCP `initialize` request carrying `"protocolVersion": "2026-07-28"` fails with JSON-RPC error `-32601 Method Not Found` (`"invalid method initialize"`) on `1.8.0` and `1.9.0`, rather than gracefully negotiating down to `2025-11-25` as it did in `1.7.0`.

We do this by making MCP Toolbox `initialize` handshake fully compliant with the official [MCP Dual-Era Server Specification](https://modelcontextprotocol.io/specification/2026-07-28/basic/versioning#compatibility-matrix).

<img width="1520" height="582" alt="image" src="https://github.com/user-attachments/assets/8b0b8842-f0f9-42d8-a0f4-d5c1bda3f9e4" />

## Background

In `1.8.0` and `1.9.0`, `"2026-07-28"` was added to `SUPPORTED_PROTOCOL_VERSIONS` (https://github.com/googleapis/mcp-toolbox/pull/3699). When this was done, incoming `initialize` requests asking for `2026-07-28` were recognized as a supported version and routed directly to the 2026 handler ([here](https://github.com/googleapis/mcp-toolbox/blob/98c1213269522e4e50f879917bbc95634058da18/internal/server/mcp.go#L840-L845)). Because the 2026 handler is stateless and does not implement `initialize`, the request fell through to an unhandled method error (`-32601`).

> [!NOTE]
> Being included in the general supported versions list also bypassed the legacy downgrade path that unknown versions take.

## Specification

Under the official [MCP 2026-07-28 Spec](https://github.com/modelcontextprotocol/specification/blob/main/docs/specification/2026-07-28/basic/versioning.mdx#L126-L184), we see the spec for the dual-server behaviour specified for this case:
<img width="1506" height="502" alt="image" src="https://github.com/user-attachments/assets/b029b932-4a27-45c2-9f3e-9bf9f3ea8ca4" />
<img width="1625" height="1550" alt="image" src="https://github.com/user-attachments/assets/4ca3f2dc-dbf3-408d-80e1-4cb0358a690b" />

## Changes

1. Partitioned protocol versions into explicit stateful versions (`2024-11-05` through `2025-11-25`) and stateless versions (`2026-07-28`), while keeping the composite list for server discovery.
2. Cleaned up unused legacy draft constants.

3. Updated the `initialize` message router to check only against stateful versions. If the version is not in the stateful list (such as `2026-07-28` or an unknown future version), it correctly downgrades to `2025-11-25`.

4. Added test coverage verifying that `2026-07-28`, unknown versions, malformed strings, and all legitimate legacy versions negotiate to their exact expected protocol versions under both standard and draft server modes.

Fixes https://github.com/googleapis/mcp-toolbox/issues/3834