### PR TITLE
fix(tests): prevent resource leaks by using context.WithoutCancel

### DIFF
--- a/tests/bigquery/bigquery_integration_test.go
+++ b/tests/bigquery/bigquery_integration_test.go
@@ -411,7 +411,7 @@ func TestBigQueryWriteModeAllowed(t *testing.T) {
 		t.Fatalf("Failed to create dataset %q: %v", datasetName, err)
 	}
 	defer func() {
-		if err := dataset.DeleteWithContents(ctx); err != nil {
+		if err := dataset.DeleteWithContents(context.WithoutCancel(ctx)); err != nil {
 			t.Logf("failed to cleanup dataset %s: %v", datasetName, err)
 		}
 	}()
@@ -510,7 +510,7 @@ func TestBigQueryWriteModeProtected(t *testing.T) {
 		t.Fatalf("Failed to create dataset %q: %v", permanentDatasetName, err)
 	}
 	defer func() {
-		if err := dataset.DeleteWithContents(ctx); err != nil {
+		if err := dataset.DeleteWithContents(context.WithoutCancel(ctx)); err != nil {
 			t.Logf("failed to cleanup dataset %s: %v", permanentDatasetName, err)
 		}
 	}()
@@ -703,12 +703,12 @@ func setupBigQueryTable(t *testing.T, ctx context.Context, client *bigqueryapi.C
 	return func(t *testing.T) {
 		// tear down table
 		dropSQL := fmt.Sprintf("drop table %s", tableName)
-		dropJob, err := client.Query(dropSQL).Run(ctx)
+		dropJob, err := client.Query(dropSQL).Run(context.WithoutCancel(ctx))
 		if err != nil {
 			t.Errorf("Failed to start drop table job for %s: %v", tableName, err)
 			return
 		}
-		dropStatus, err := dropJob.Wait(ctx)
+		dropStatus, err := dropJob.Wait(context.WithoutCancel(ctx))
 		if err != nil {
 			t.Errorf("Failed to wait for drop table job for %s: %v", tableName, err)
 			return
@@ -719,11 +719,11 @@ func setupBigQueryTable(t *testing.T, ctx context.Context, client *bigqueryapi.C
 
 		// tear down dataset
 		datasetToTeardown := client.Dataset(datasetName)
-		tablesIterator := datasetToTeardown.Tables(ctx)
+		tablesIterator := datasetToTeardown.Tables(context.WithoutCancel(ctx))
 		_, err = tablesIterator.Next()
 
 		if err == iterator.Done {
-			if err := datasetToTeardown.Delete(ctx); err != nil {
+			if err := datasetToTeardown.Delete(context.WithoutCancel(ctx)); err != nil {
 				t.Errorf("Failed to delete dataset %s: %v", datasetName, err)
 			}
 		} else if err != nil {

--- a/tests/common.go
+++ b/tests/common.go
@@ -686,7 +686,7 @@ func SetupPostgresSQLTable(t *testing.T, ctx context.Context, pool *pgxpool.Pool
 
 	return func(t *testing.T) {
 		// tear down test
-		_, err = pool.Exec(ctx, fmt.Sprintf("DROP TABLE %s;", tableName))
+		_, err = pool.Exec(context.WithoutCancel(ctx), fmt.Sprintf("DROP TABLE %s;", tableName))
 		if err != nil {
 			t.Errorf("Teardown failed: %s", err)
 		}
@@ -715,7 +715,7 @@ func SetupMsSQLTable(t *testing.T, ctx context.Context, pool *sql.DB, createStat
 
 	return func(t *testing.T) {
 		// tear down test
-		_, err = pool.ExecContext(ctx, fmt.Sprintf("DROP TABLE %s;", tableName))
+		_, err = pool.ExecContext(context.WithoutCancel(ctx), fmt.Sprintf("DROP TABLE %s;", tableName))
 		if err != nil {
 			t.Errorf("Teardown failed: %s", err)
 		}
@@ -744,7 +744,7 @@ func SetupMySQLTable(t *testing.T, ctx context.Context, pool *sql.DB, createStat
 
 	return func(t *testing.T) {
 		// tear down test
-		_, err = pool.ExecContext(ctx, fmt.Sprintf("DROP TABLE %s;", tableName))
+		_, err = pool.ExecContext(context.WithoutCancel(ctx), fmt.Sprintf("DROP TABLE %s;", tableName))
 		if err != nil {
 			t.Errorf("Teardown failed: %s", err)
 		}

--- a/tests/dataplex/dataplex_integration_test.go
+++ b/tests/dataplex/dataplex_integration_test.go
@@ -744,7 +744,7 @@ func setupGcsBucket(t *testing.T, ctx context.Context, project string, bucketNam
 	}
 
 	return func(t *testing.T) {
-		if err := bucket.Delete(ctx); err != nil {
+		if err := bucket.Delete(context.WithoutCancel(ctx)); err != nil {
 			t.Logf("cleanup: failed to delete bucket %s: %v", bucketName, err)
 		}
 	}

--- a/tests/spanner/spanner_integration_test.go
+++ b/tests/spanner/spanner_integration_test.go
@@ -287,7 +287,7 @@ func setupSpannerTable(t *testing.T, ctx context.Context, adminClient *database.
 
 	return func(t *testing.T) {
 		// tear down test
-		op, err = adminClient.UpdateDatabaseDdl(ctx, &databasepb.UpdateDatabaseDdlRequest{
+		op, err = adminClient.UpdateDatabaseDdl(context.WithoutCancel(ctx), &databasepb.UpdateDatabaseDdlRequest{
 			Database:   dbString,
 			Statements: []string{fmt.Sprintf("DROP TABLE IF EXISTS %s", tableName)},
 		})
@@ -296,7 +296,7 @@ func setupSpannerTable(t *testing.T, ctx context.Context, adminClient *database.
 			return
 		}
 
-		opErr := op.Wait(ctx)
+		opErr := op.Wait(context.WithoutCancel(ctx))
 		if opErr != nil {
 			t.Errorf("Teardown failed: %s", opErr)
 		}
@@ -320,7 +320,7 @@ func setupSpannerGraph(t *testing.T, ctx context.Context, adminClient *database.
 
 	return func(t *testing.T) {
 		// tear down test
-		op, err = adminClient.UpdateDatabaseDdl(ctx, &databasepb.UpdateDatabaseDdlRequest{
+		op, err = adminClient.UpdateDatabaseDdl(context.WithoutCancel(ctx), &databasepb.UpdateDatabaseDdlRequest{
 			Database:   dbString,
 			Statements: []string{fmt.Sprintf("DROP PROPERTY GRAPH IF EXISTS %s", graphName)},
 		})
@@ -329,7 +329,7 @@ func setupSpannerGraph(t *testing.T, ctx context.Context, adminClient *database.
 			return
 		}
 
-		opErr := op.Wait(ctx)
+		opErr := op.Wait(context.WithoutCancel(ctx))
 		if opErr != nil {
 			t.Errorf("Teardown failed: %s", opErr)
 		}

--- a/tests/tool.go
+++ b/tests/tool.go
@@ -1294,7 +1294,7 @@ func setupPostgresSchemas(t *testing.T, ctx context.Context, pool *pgxpool.Pool,
 
 	return func() {
 		dropSchemaStmt := fmt.Sprintf("DROP SCHEMA %s CASCADE", schemaName)
-		_, err := pool.Exec(ctx, dropSchemaStmt)
+		_, err := pool.Exec(context.WithoutCancel(ctx), dropSchemaStmt)
 		if err != nil {
 			t.Fatalf("failed to drop schema: %v", err)
 		}
@@ -1496,7 +1496,7 @@ func setUpPostgresViews(t *testing.T, ctx context.Context, pool *pgxpool.Pool, v
 	}
 	return func() {
 		dropView := fmt.Sprintf("DROP VIEW %s", viewName)
-		_, err := pool.Exec(ctx, dropView)
+		_, err := pool.Exec(context.WithoutCancel(ctx), dropView)
 		if err != nil {
 			t.Fatalf("failed to drop view: %v", err)
 		}
@@ -1783,7 +1783,7 @@ func setupPostgresTrigger(t *testing.T, ctx context.Context, pool *pgxpool.Pool,
 
 	return func() {
 		dropSchemaStmt := fmt.Sprintf("DROP SCHEMA %s CASCADE", schemaName)
-		if _, err := pool.Exec(ctx, dropSchemaStmt); err != nil {
+		if _, err := pool.Exec(context.WithoutCancel(ctx), dropSchemaStmt); err != nil {
 			t.Fatalf("failed to drop schema %s: %v", schemaName, err)
 		}
 	}
@@ -1945,10 +1945,10 @@ func setupPostgresPublicationTable(t *testing.T, ctx context.Context, pool *pgxp
 
 	return func(t *testing.T) {
 		t.Helper()
-		if _, err := pool.Exec(ctx, fmt.Sprintf("DROP PUBLICATION IF EXISTS %s;", pubName)); err != nil {
+		if _, err := pool.Exec(context.WithoutCancel(ctx), fmt.Sprintf("DROP PUBLICATION IF EXISTS %s;", pubName)); err != nil {
 			t.Errorf("unable to drop publication %s: %v", pubName, err)
 		}
-		if _, err := pool.Exec(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s;", tableName)); err != nil {
+		if _, err := pool.Exec(context.WithoutCancel(ctx), fmt.Sprintf("DROP TABLE IF EXISTS %s;", tableName)); err != nil {
 			t.Errorf("unable to drop table %s: %v", tableName, err)
 		}
 	}
@@ -2293,7 +2293,7 @@ func setupPostgresIndex(t *testing.T, ctx context.Context, pool *pgxpool.Pool, s
 
 	return func(t *testing.T) {
 		t.Helper()
-		if _, err := pool.Exec(ctx, fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE;", schemaName)); err != nil {
+		if _, err := pool.Exec(context.WithoutCancel(ctx), fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE;", schemaName)); err != nil {
 			t.Errorf("unable to drop schema: %v", err)
 		}
 	}
@@ -2773,8 +2773,8 @@ func setUpDatabase(t *testing.T, ctx context.Context, pool *pgxpool.Pool, dbName
 		t.Fatalf("failed to create %s: %v", dbName, err)
 	}
 	return func() {
-		_, _ = pool.Exec(ctx, fmt.Sprintf("DROP DATABASE IF EXISTS %s;", dbName))
-		_, _ = pool.Exec(ctx, fmt.Sprintf("DROP ROLE IF EXISTS %s;", dbOwner))
+		_, _ = pool.Exec(context.WithoutCancel(ctx), fmt.Sprintf("DROP DATABASE IF EXISTS %s;", dbName))
+		_, _ = pool.Exec(context.WithoutCancel(ctx), fmt.Sprintf("DROP ROLE IF EXISTS %s;", dbOwner))
 	}
 }
 
@@ -2811,9 +2811,10 @@ func setupPostgresRoles(t *testing.T, ctx context.Context, pool *pgxpool.Pool) (
 
 	return adminUser, superUser, normalUser, func(t *testing.T) {
 		t.Helper()
-		_, _ = pool.Exec(ctx, fmt.Sprintf("DROP ROLE IF EXISTS %s;", normalUser))
-		_, _ = pool.Exec(ctx, fmt.Sprintf("DROP ROLE IF EXISTS %s;", superUser))
-		_, _ = pool.Exec(ctx, fmt.Sprintf("DROP ROLE IF EXISTS %s;", adminUser))
+		cleanupCtx := context.WithoutCancel(ctx)
+		_, _ = pool.Exec(cleanupCtx, fmt.Sprintf("DROP ROLE IF EXISTS %s;", normalUser))
+		_, _ = pool.Exec(cleanupCtx, fmt.Sprintf("DROP ROLE IF EXISTS %s;", superUser))
+		_, _ = pool.Exec(cleanupCtx, fmt.Sprintf("DROP ROLE IF EXISTS %s;", adminUser))
 	}
 }
 
@@ -3513,7 +3514,7 @@ func RunMySQLListTablesMissingUniqueIndexes(t *testing.T, ctx context.Context, p
 		}
 
 		return func() {
-			if _, err := pool.ExecContext(ctx, fmt.Sprintf("DROP TABLE %s", tableName)); err != nil {
+			if _, err := pool.ExecContext(context.WithoutCancel(ctx), fmt.Sprintf("DROP TABLE %s", tableName)); err != nil {
 				t.Errorf("failed to drop table %s: %v", tableName, err)
 			}
 		}
@@ -4518,10 +4519,10 @@ func CreateAndLockPostgresTable(t *testing.T, ctx context.Context, pool *pgxpool
 	}
 
 	return func() {
-		if err := tx.Rollback(ctx); err != nil {
+		if err := tx.Rollback(context.WithoutCancel(ctx)); err != nil {
 			t.Fatalf("unable to rollback transaction: %s", err)
 		}
-		if _, err := pool.Exec(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", pgx.Identifier{tableName}.Sanitize())); err != nil {
+		if _, err := pool.Exec(context.WithoutCancel(ctx), fmt.Sprintf("DROP TABLE IF EXISTS %s", pgx.Identifier{tableName}.Sanitize())); err != nil {
 			t.Fatalf("unable to drop table: %s", err)
 		}
 	}
@@ -4887,7 +4888,7 @@ func createPostgresExtension(t *testing.T, ctx context.Context, pool *pgxpool.Po
 	}
 	return func() {
 		dropExtensionCmd := fmt.Sprintf("DROP EXTENSION IF EXISTS %s", extensionName)
-		_, err := pool.Exec(ctx, dropExtensionCmd)
+		_, err := pool.Exec(context.WithoutCancel(ctx), dropExtensionCmd)
 		if err != nil {
 			t.Fatalf("failed to drop extension: %v", err)
 		}
@@ -5307,7 +5308,7 @@ func RunPostgresListStoredProcedureTest(t *testing.T, ctx context.Context, pool 
 	}
 	defer func() {
 		dropSchemaStmt := fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE", testSchemaName)
-		if _, err := pool.Exec(ctx, dropSchemaStmt); err != nil {
+		if _, err := pool.Exec(context.WithoutCancel(ctx), dropSchemaStmt); err != nil {
 			t.Logf("warning: unable to drop test schema: %v", err)
 		}
 	}()


### PR DESCRIPTION
## Description

Previously, test cleanups and teardown routines (such as dropping temporary tables, instances, or roles) were bound to the parent test context.Context. If a test suite exceeded its timeout, panicked, or failed early, the context was canceled, preventing the teardown loop from firing successfully and leaving abandoned resources on our GCP infrastructure.

## Solution
Wrapped cleanup invocations with context.WithoutCancel(ctx) across affected data sources (Bigtable, Spanner,
Dataplex, BigQuery, etc.). 

## PR Checklist

- [✅] Make sure you reviewed
  [CONTRIBUTING.md](https://github.com/googleapis/mcp-toolbox/blob/main/CONTRIBUTING.md)
- [✅] Make sure to open an issue as a
  [bug/issue](https://github.com/googleapis/mcp-toolbox/issues/new/choose)
  before writing your code! That way we can discuss the change, evaluate
  designs, and agree on the general idea
- [✅] Ensure you have manually reviewed the entire diff before requesting a
  review
- [✅] Ensure the tests and linter pass
- [✅] Code coverage does not decrease (if any source code was changed)
- [✅] Appropriate docs were updated (if necessary)
- [✅] Make sure to add `!` if this involve a breaking change

🛠️ Fixes #3707 (partially)
