### PR TITLE
refactor: use postgres testcontainers

### DIFF
--- a/tests/alloydbomni/alloydb_omni_integration_test.go
+++ b/tests/alloydbomni/alloydb_omni_integration_test.go
@@ -68,38 +68,12 @@ func setupAlloyDBContainer(ctx context.Context, t *testing.T) (string, string, f
 		},
 		WaitingFor: wait.ForAll(
 			wait.ForLog("database system was shut down at"),
-			wait.ForLog("database system is ready to accept connections"),
+			wait.ForLog("database system is ready to accept connections").WithOccurrence(2),
 			wait.ForExposedPort(),
 		),
 	}
 
-	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: req,
-		Started:          true,
-	})
-	if err != nil {
-		t.Fatalf("failed to start alloydb container: %s", err)
-	}
-
-	cleanup := func() {
-		if err := container.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate container: %s", err)
-		}
-	}
-
-	host, err := container.Host(ctx)
-	if err != nil {
-		cleanup()
-		t.Fatalf("failed to get container host: %s", err)
-	}
-
-	mappedPort, err := container.MappedPort(ctx, "5432")
-	if err != nil {
-		cleanup()
-		t.Fatalf("failed to get container mapped port: %s", err)
-	}
-
-	return host, mappedPort.Port(), cleanup
+	return tests.SetupGenericPostgresTestContainer(ctx, t, req)
 }
 
 func TestAlloyDBOmni(t *testing.T) {

--- a/tests/common.go
+++ b/tests/common.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"cloud.google.com/go/bigquery"
 	"cloud.google.com/go/bigtable"
@@ -32,6 +33,7 @@ import (
 	"github.com/googleapis/mcp-toolbox/internal/testutils"
 	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/testcontainers/testcontainers-go"
 	"google.golang.org/api/iterator"
 )
 
@@ -1176,4 +1178,39 @@ func CleanupBigtableTables(t *testing.T, ctx context.Context, adminClient *bigta
 			}
 		}
 	}
+}
+
+// SetupPostgresTestContainer spins up a generic PostgreSQL-compatible test container.
+func SetupGenericPostgresTestContainer(ctx context.Context, t *testing.T, req testcontainers.ContainerRequest) (string, string, func()) {
+	t.Helper()
+
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	if err != nil {
+		t.Fatalf("failed to start postgres container: %s", err)
+	}
+
+	cleanup := func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cleanupCancel()
+		if err := container.Terminate(cleanupCtx); err != nil {
+			t.Fatalf("failed to terminate container: %s", err)
+		}
+	}
+
+	host, err := container.Host(ctx)
+	if err != nil {
+		cleanup()
+		t.Fatalf("failed to get container host: %s", err)
+	}
+
+	mappedPort, err := container.MappedPort(ctx, "5432")
+	if err != nil {
+		cleanup()
+		t.Fatalf("failed to get container mapped port: %s", err)
+	}
+
+	return host, mappedPort.Port(), cleanup
 }

--- a/tests/postgres/postgres_integration_test.go
+++ b/tests/postgres/postgres_integration_test.go
@@ -28,26 +28,26 @@ import (
 	"github.com/googleapis/mcp-toolbox/internal/testutils"
 	"github.com/googleapis/mcp-toolbox/tests"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
 )
 
 var (
 	PostgresSourceType = "postgres"
 	PostgresToolType   = "postgres-sql"
 	PostgresDatabase   = os.Getenv("POSTGRES_DATABASE")
-	PostgresHost       = os.Getenv("POSTGRES_HOST")
-	PostgresPort       = os.Getenv("POSTGRES_PORT")
 	PostgresUser       = os.Getenv("POSTGRES_USER")
 	PostgresPass       = os.Getenv("POSTGRES_PASS")
 )
 
-func getPostgresVars(t *testing.T) map[string]any {
+func getPostgresVars(t *testing.T, host string, port string) map[string]any {
 	switch "" {
+	case host:
+		t.Fatal("'PostgresHost' was empty")
+	case port:
+		t.Fatal("'PostgressPort' was empty")
 	case PostgresDatabase:
 		t.Fatal("'POSTGRES_DATABASE' not set")
-	case PostgresHost:
-		t.Fatal("'POSTGRES_HOST' not set")
-	case PostgresPort:
-		t.Fatal("'POSTGRES_PORT' not set")
 	case PostgresUser:
 		t.Fatal("'POSTGRES_USER' not set")
 	case PostgresPass:
@@ -56,8 +56,8 @@ func getPostgresVars(t *testing.T) map[string]any {
 
 	return map[string]any{
 		"type":     PostgresSourceType,
-		"host":     PostgresHost,
-		"port":     PostgresPort,
+		"host":     host,
+		"port":     port,
 		"database": PostgresDatabase,
 		"user":     PostgresUser,
 		"password": PostgresPass,
@@ -81,10 +81,35 @@ func initPostgresConnectionPool(host, port, user, pass, dbname string) (*pgxpool
 	return pool, nil
 }
 
+func setupPostgresTestContainer(ctx context.Context, t *testing.T) (string, string, func()) {
+	t.Helper()
+
+	req := testcontainers.ContainerRequest{
+		Image:        "pgvector/pgvector:pg16",
+		Cmd:          []string{"postgres", "-c", "shared_preload_libraries=pg_stat_statements"},
+		ExposedPorts: []string{"5432/tcp"},
+		Env: map[string]string{
+			"POSTGRES_USER":     PostgresUser,
+			"POSTGRES_PASSWORD": PostgresPass,
+			"POSTGRES_DB":       PostgresDatabase,
+		},
+		WaitingFor: wait.ForAll(
+			wait.ForLog("database system is ready to accept connections").WithOccurrence(2),
+			wait.ForExposedPort(),
+		),
+	}
+
+	return tests.SetupGenericPostgresTestContainer(ctx, t, req)
+}
+
 func TestPostgres(t *testing.T) {
-	sourceConfig := getPostgresVars(t)
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
+
+	PostgresHost, PostgresPort, containerCleanup := setupPostgresTestContainer(ctx, t)
+	t.Cleanup(containerCleanup)
+
+	sourceConfig := getPostgresVars(t, PostgresHost, PostgresPort)
 
 	args := []string{"--enable-api"}
 


### PR DESCRIPTION
## Description

Refactor postgres tests to use Docker `testcontainers`.

Updates included:
- Swapped baseline image to `pgvector/pgvector:pg16` to guarantee the embedded database can successfully parse `CREATE EXTENSION vector;` ops during AI similarity tools testing.
- Enabled `pg_stat_statements` on startup via Postgres config overrides.
- Increased the overarching suite context timeout to `3*time.Minute` to accommodate cold-start image pulls on stateless CI runners.

## PR Checklist

- [✓] Make sure you reviewed [CONTRIBUTING.md](https://github.com/googleapis/mcp-toolbox/blob/main/CONTRIBUTING.md)
- [✓] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/mcp-toolbox/issues/new/choose) before writing your code! That way we can discuss the change, evaluate designs, and agree on the general idea
- [✓] Ensure you have manually reviewed the entire diff before requesting a review
- [✓] Ensure the tests and linter pass
- [✓] Code coverage does not decrease (if any source code was changed)
- [✓] Appropriate docs were updated (if necessary)
- [✓] Make sure to add `!` if this involve a breaking change

🛠️ Fixes #3707 (partially)