### PR TITLE
feat(tool/mongodb-list-collections): add MongoDB collection discovery

### DIFF
--- a/cmd/internal/imports.go
+++ b/cmd/internal/imports.go
@@ -303,6 +303,7 @@ import (
 	_ "github.com/googleapis/mcp-toolbox/internal/tools/mongodb/mongodbfindone"
 	_ "github.com/googleapis/mcp-toolbox/internal/tools/mongodb/mongodbinsertmany"
 	_ "github.com/googleapis/mcp-toolbox/internal/tools/mongodb/mongodbinsertone"
+	_ "github.com/googleapis/mcp-toolbox/internal/tools/mongodb/mongodblistcollections"
 	_ "github.com/googleapis/mcp-toolbox/internal/tools/mongodb/mongodbupdatemany"
 	_ "github.com/googleapis/mcp-toolbox/internal/tools/mongodb/mongodbupdateone"
 	_ "github.com/googleapis/mcp-toolbox/internal/tools/mssql/mssqlexecutesql"

--- a/docs/en/integrations/mongodb/tools/mongodb-list-collections.md
+++ b/docs/en/integrations/mongodb/tools/mongodb-list-collections.md
@@ -1,0 +1,40 @@
+---
+title: "mongodb-list-collections"
+type: docs
+weight: 2
+description: >
+  A "mongodb-list-collections" tool lists collection names in a MongoDB database.
+---
+
+## About
+
+A `mongodb-list-collections` tool lists the names of collections in a configured
+MongoDB database. It helps agents discover available collections before invoking
+tools that operate on a collection.
+
+The tool returns a JSON array of collection names and does not require invocation
+parameters.
+
+## Compatible Sources
+
+{{< compatible-sources >}}
+
+## Example
+
+```yaml
+kind: tool
+name: list_collections
+type: mongodb-list-collections
+source: my-mongo-source
+database: app
+description: List collections in the app database.
+```
+
+## Reference
+
+| **field**   | **type** | **required** | **description**                                             |
+|:------------|:---------|:-------------|:------------------------------------------------------------|
+| type        | string   | true         | Must be `mongodb-list-collections`.                         |
+| source      | string   | true         | The name of the `mongodb` source to use.                    |
+| database    | string   | true         | The name of the MongoDB database whose collections to list. |
+| description | string   | true         | A description of the tool that is passed to the LLM.         |

--- a/internal/sources/mongodb/mongodb.go
+++ b/internal/sources/mongodb/mongodb.go
@@ -96,6 +96,10 @@ func (s *Source) MongoClient() *mongo.Client {
 	return s.Client
 }
 
+func (s *Source) ListCollections(ctx context.Context, database string) ([]string, error) {
+	return s.MongoClient().Database(database).ListCollectionNames(ctx, bson.D{})
+}
+
 func parseData(ctx context.Context, cur *mongo.Cursor) ([]any, error) {
 	var data = []any{}
 	err := cur.All(ctx, &data)

--- a/internal/tools/mongodb/mongodblistcollections/mongodblistcollections.go
+++ b/internal/tools/mongodb/mongodblistcollections/mongodblistcollections.go
@@ -107,5 +107,8 @@ func (t Tool) Invoke(ctx context.Context, s sources.Source, _ parameters.ParamVa
 	if err != nil {
 		return nil, util.ProcessGeneralError(err)
 	}
+	if resp == nil {
+		resp = []string{}
+	}
 	return resp, nil
 }

--- a/internal/tools/mongodb/mongodblistcollections/mongodblistcollections.go
+++ b/internal/tools/mongodb/mongodblistcollections/mongodblistcollections.go
@@ -1,0 +1,111 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mongodblistcollections
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/goccy/go-yaml"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
+	"github.com/googleapis/mcp-toolbox/internal/tools"
+	"github.com/googleapis/mcp-toolbox/internal/util"
+	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
+)
+
+const resourceType string = "mongodb-list-collections"
+
+func init() {
+	if !tools.Register(resourceType, newConfig) {
+		panic(fmt.Sprintf("tool type %q already registered", resourceType))
+	}
+}
+
+func newConfig(ctx context.Context, name string, decoder *yaml.Decoder) (tools.ToolConfig, error) {
+	actual := Config{ConfigBase: tools.ConfigBase{Name: name}}
+	if err := decoder.DecodeContext(ctx, &actual); err != nil {
+		return nil, err
+	}
+	return actual, nil
+}
+
+type compatibleSource interface {
+	ListCollections(context.Context, string) ([]string, error)
+}
+
+type Config struct {
+	tools.ConfigBase `yaml:",inline"`
+	Type             string                 `yaml:"type" validate:"required"`
+	Source           string                 `yaml:"source" validate:"required"`
+	Database         string                 `yaml:"database" validate:"required"`
+	Annotations      *tools.ToolAnnotations `yaml:"annotations,omitempty"`
+}
+
+var _ tools.ToolConfig = Config{}
+
+func (cfg Config) ToolConfigType() string {
+	return resourceType
+}
+
+func (cfg Config) Initialize(context.Context) (tools.Tool, error) {
+	if cfg.Description == "" {
+		return nil, fmt.Errorf("description is required for tool %q", cfg.Name)
+	}
+
+	params := parameters.Parameters{}
+	return Tool{
+		BaseTool: tools.NewBaseTool(
+			cfg,
+			tools.GetAnnotationsOrDefault(cfg.Annotations, tools.NewReadOnlyAnnotations),
+			tools.Manifest{Description: cfg.Description, Parameters: params.Manifest(), AuthRequired: cfg.AuthRequired},
+			params,
+		),
+	}, nil
+}
+
+var _ tools.Tool = Tool{}
+
+type Tool struct {
+	tools.BaseTool[Config]
+}
+
+func (t Tool) GetSourceName() string {
+	return t.Cfg.Source
+}
+
+func (t Tool) ToConfig() tools.ToolConfig {
+	return t.Cfg
+}
+
+func (t Tool) ValidateSource(source sources.Source) error {
+	_, ok := source.(compatibleSource)
+	if !ok {
+		return fmt.Errorf("invalid source for %q tool: source %q is not a compatible type", t.Cfg.Type, t.Cfg.Source)
+	}
+	return nil
+}
+
+func (t Tool) Invoke(ctx context.Context, s sources.Source, _ parameters.ParamValues, _ tools.AccessToken) (any, util.ToolboxError) {
+	source, ok := s.(compatibleSource)
+	if !ok {
+		return nil, util.NewClientServerError("source used is not compatible with the tool", http.StatusInternalServerError, nil)
+	}
+	resp, err := source.ListCollections(ctx, t.Cfg.Database)
+	if err != nil {
+		return nil, util.ProcessGeneralError(err)
+	}
+	return resp, nil
+}

--- a/internal/tools/mongodb/mongodblistcollections/mongodblistcollections_test.go
+++ b/internal/tools/mongodb/mongodblistcollections/mongodblistcollections_test.go
@@ -151,6 +151,9 @@ func TestInvokeNormalizesNilCollectionList(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected []string result, got %T", got)
 	}
+	if collections == nil {
+		t.Fatal("expected an initialized empty collection list")
+	}
 	encoded, err := json.Marshal(collections)
 	if err != nil {
 		t.Fatalf("unable to marshal collections: %s", err)

--- a/internal/tools/mongodb/mongodblistcollections/mongodblistcollections_test.go
+++ b/internal/tools/mongodb/mongodblistcollections/mongodblistcollections_test.go
@@ -16,6 +16,7 @@ package mongodblistcollections_test
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -42,6 +43,20 @@ func (s *fakeSource) ToConfig() sources.SourceConfig {
 func (s *fakeSource) ListCollections(_ context.Context, database string) ([]string, error) {
 	s.database = database
 	return []string{"customers", "orders"}, nil
+}
+
+type nilCollectionsSource struct{}
+
+func (s *nilCollectionsSource) SourceType() string {
+	return "mongodb"
+}
+
+func (s *nilCollectionsSource) ToConfig() sources.SourceConfig {
+	return nil
+}
+
+func (s *nilCollectionsSource) ListCollections(context.Context, string) ([]string, error) {
+	return nil, nil
 }
 
 func TestParseFromYamlMongoDBListCollections(t *testing.T) {
@@ -111,5 +126,36 @@ func TestInvokeListsConfiguredDatabaseCollections(t *testing.T) {
 	}
 	if source.database != "app" {
 		t.Fatalf("expected database %q, got %q", "app", source.database)
+	}
+}
+
+func TestInvokeNormalizesNilCollectionList(t *testing.T) {
+	ctx := context.Background()
+	cfg := mongodblistcollections.Config{
+		ConfigBase: tools.ConfigBase{Name: "list_collections", Description: "List collections"},
+		Type:       "mongodb-list-collections",
+		Source:     "mongo",
+		Database:   "app",
+	}
+
+	tool, err := cfg.Initialize(ctx)
+	if err != nil {
+		t.Fatalf("unable to initialize tool: %s", err)
+	}
+
+	got, tbErr := tool.Invoke(ctx, &nilCollectionsSource{}, parameters.ParamValues{}, "")
+	if tbErr != nil {
+		t.Fatalf("unexpected invocation error: %s", tbErr)
+	}
+	collections, ok := got.([]string)
+	if !ok {
+		t.Fatalf("expected []string result, got %T", got)
+	}
+	encoded, err := json.Marshal(collections)
+	if err != nil {
+		t.Fatalf("unable to marshal collections: %s", err)
+	}
+	if string(encoded) != `[]` {
+		t.Fatalf("expected empty collection list to marshal as [], got %s", encoded)
 	}
 }

--- a/internal/tools/mongodb/mongodblistcollections/mongodblistcollections_test.go
+++ b/internal/tools/mongodb/mongodblistcollections/mongodblistcollections_test.go
@@ -1,0 +1,115 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mongodblistcollections_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/mcp-toolbox/internal/server"
+	"github.com/googleapis/mcp-toolbox/internal/sources"
+	"github.com/googleapis/mcp-toolbox/internal/testutils"
+	"github.com/googleapis/mcp-toolbox/internal/tools"
+	"github.com/googleapis/mcp-toolbox/internal/tools/mongodb/mongodblistcollections"
+	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
+)
+
+type fakeSource struct {
+	database string
+}
+
+func (s *fakeSource) SourceType() string {
+	return "mongodb"
+}
+
+func (s *fakeSource) ToConfig() sources.SourceConfig {
+	return nil
+}
+
+func (s *fakeSource) ListCollections(_ context.Context, database string) ([]string, error) {
+	s.database = database
+	return []string{"customers", "orders"}, nil
+}
+
+func TestParseFromYamlMongoDBListCollections(t *testing.T) {
+	ctx, err := testutils.ContextWithNewLogger()
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	in := `
+kind: tool
+name: list_collections
+type: mongodb-list-collections
+source: my-mongo-source
+database: app
+description: List collections in MongoDB
+`
+	want := server.ToolConfigs{
+		"list_collections": mongodblistcollections.Config{
+			ConfigBase: tools.ConfigBase{
+				Name:         "list_collections",
+				Description:  "List collections in MongoDB",
+				AuthRequired: []string{},
+			},
+			Type:     "mongodb-list-collections",
+			Source:   "my-mongo-source",
+			Database: "app",
+		},
+	}
+
+	_, _, _, got, _, _, err := server.UnmarshalPrimitiveConfig(ctx, testutils.FormatYaml(in))
+	if err != nil {
+		t.Fatalf("unable to unmarshal: %s", err)
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("incorrect parse: diff %v", diff)
+	}
+}
+
+func TestInvokeListsConfiguredDatabaseCollections(t *testing.T) {
+	ctx := context.Background()
+	cfg := mongodblistcollections.Config{
+		ConfigBase: tools.ConfigBase{Name: "list_collections", Description: "List collections"},
+		Type:       "mongodb-list-collections",
+		Source:     "mongo",
+		Database:   "app",
+	}
+
+	tool, err := cfg.Initialize(ctx)
+	if err != nil {
+		t.Fatalf("unable to initialize tool: %s", err)
+	}
+	params, err := tool.GetParameters(nil)
+	if err != nil {
+		t.Fatalf("unable to get parameters: %s", err)
+	}
+	if len(params) != 0 {
+		t.Fatalf("expected no invocation parameters, got %d", len(params))
+	}
+
+	source := &fakeSource{}
+	got, tbErr := tool.Invoke(ctx, source, parameters.ParamValues{}, "")
+	if tbErr != nil {
+		t.Fatalf("unexpected invocation error: %s", tbErr)
+	}
+	if diff := cmp.Diff([]string{"customers", "orders"}, got); diff != "" {
+		t.Fatalf("unexpected collections (-want +got):\n%s", diff)
+	}
+	if source.database != "app" {
+		t.Fatalf("expected database %q, got %q", "app", source.database)
+	}
+}

--- a/tests/mongodb/mongodb_integration_test.go
+++ b/tests/mongodb/mongodb_integration_test.go
@@ -158,6 +158,29 @@ func TestMongoDBToolEndpoints(t *testing.T) {
 	runToolListCollectionsInvokeTest(t)
 }
 
+func collectionResultContains(result, expected string) (bool, error) {
+	var collections []string
+	if err := json.Unmarshal([]byte(result), &collections); err != nil {
+		return false, err
+	}
+	for _, collection := range collections {
+		if collection == expected {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func TestCollectionResultAcceptsAdditionalCollections(t *testing.T) {
+	contains, err := collectionResultContains(`["test_collection","target_collection"]`, "test_collection")
+	if err != nil {
+		t.Fatalf("unable to parse collections result: %s", err)
+	}
+	if !contains {
+		t.Fatal(`expected collections result to contain "test_collection"`)
+	}
+}
+
 func runToolListCollectionsInvokeTest(t *testing.T) {
 	t.Run("invoke list collections", func(t *testing.T) {
 		req, err := http.NewRequest(http.MethodPost, "http://127.0.0.1:5000/api/tool/my-list-collections-tool/invoke", bytes.NewBufferString(`{}`))
@@ -184,8 +207,13 @@ func runToolListCollectionsInvokeTest(t *testing.T) {
 		if !ok {
 			t.Fatalf("unable to find result in response body")
 		}
-		if got != `["test_collection"]` {
-			t.Fatalf("unexpected collections: got %q, want %q", got, `["test_collection"]`)
+
+		contains, err := collectionResultContains(got, "test_collection")
+		if err != nil {
+			t.Fatalf("unable to parse collections result %q: %s", got, err)
+		}
+		if !contains {
+			t.Fatalf("expected collections to contain %q, got %q", "test_collection", got)
 		}
 	})
 }

--- a/tests/mongodb/mongodb_integration_test.go
+++ b/tests/mongodb/mongodb_integration_test.go
@@ -155,6 +155,39 @@ func TestMongoDBToolEndpoints(t *testing.T) {
 	runToolAggregateInvokeTest(t, aggregate1Want, aggregateManyWant)
 
 	runToolRuntimeCollectionInvokeTest(t, select1Want)
+	runToolListCollectionsInvokeTest(t)
+}
+
+func runToolListCollectionsInvokeTest(t *testing.T) {
+	t.Run("invoke list collections", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodPost, "http://127.0.0.1:5000/api/tool/my-list-collections-tool/invoke", bytes.NewBufferString(`{}`))
+		if err != nil {
+			t.Fatalf("unable to create request: %s", err)
+		}
+		req.Header.Add("Content-type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("unable to send request: %s", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			bodyBytes, _ := io.ReadAll(resp.Body)
+			t.Fatalf("response status code is not 200, got %d: %s", resp.StatusCode, string(bodyBytes))
+		}
+
+		var body map[string]interface{}
+		if err = json.NewDecoder(resp.Body).Decode(&body); err != nil {
+			t.Fatalf("error parsing response body: %s", err)
+		}
+		got, ok := body["result"].(string)
+		if !ok {
+			t.Fatalf("unable to find result in response body")
+		}
+		if got != `["test_collection"]` {
+			t.Fatalf("unexpected collections: got %q, want %q", got, `["test_collection"]`)
+		}
+	})
 }
 
 func runToolRuntimeCollectionInvokeTest(t *testing.T, want string) {
@@ -578,6 +611,12 @@ func getMongoDBToolsConfig(sourceConfig map[string]any, toolType string) map[str
 				"filterParams":   []any{},
 				"projectPayload": `{ "_id": 1, "id": 1, "name" : 1 }`,
 				"database":       MongoDbDatabase,
+			},
+			"my-list-collections-tool": map[string]any{
+				"type":        "mongodb-list-collections",
+				"source":      "my-instance",
+				"description": "Tool to list MongoDB collections.",
+				"database":    MongoDbDatabase,
 			},
 			"my-tool": map[string]any{
 				"type":          toolType,


### PR DESCRIPTION
## Description

Adds a `mongodb-list-collections` MCP tool so agents can discover the collections available in a configured MongoDB database before invoking collection-scoped tools. This addresses #3848 and complements runtime collection selection without requiring users or agents to guess collection names.

The tool delegates to the existing MongoDB client and returns the driver's collection-name list for the configured database. It has no invocation parameters and is read-only.

## Changes

- Add `mongodb-list-collections` source/tool integration with the `list_collections` tool name.
- Register the tool with the application.
- Add unit coverage for YAML configuration and invocation behavior.
- Add MongoDB integration coverage and a tool reference page.

## Verification

- `go test -race -v ./internal/tools/mongodb/mongodblistcollections ./internal/sources/mongodb ./internal/tools/mongodb/...`
- `go test -race -v ./cmd/internal`
- `go vet ./cmd/... ./internal/...`
- `git diff --check`

The Docker-backed `./tests/mongodb` integration suite could not run in the development environment because Docker is not installed in the WSL distro; the test was added and is intended for the repository CI/integration environment.

## PR Checklist

- [x] Reviewed `CONTRIBUTING.md` and `DEVELOPER.md`
- [x] Opened an issue before writing code
- [x] Added unit and integration tests
- [x] Updated the relevant documentation
- [x] Ran focused tests, `go vet`, and diff checks
- [x] Signed the commit with DCO

Fixes #3848
