### PR TITLE
fix(config): compare env var offsets in rune space when skipping comments

### DIFF
--- a/cmd/internal/config.go
+++ b/cmd/internal/config.go
@@ -25,6 +25,7 @@ import (
 	"regexp"
 	"slices"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/goccy/go-yaml"
 	"github.com/goccy/go-yaml/lexer"
@@ -74,11 +75,19 @@ func (p *ConfigParser) parseEnv(input string) (string, error) {
 	matches := re.FindAllStringSubmatchIndex(input, -1)
 	var output strings.Builder
 	lastIndex := 0
+	// The lexer reports token positions as 1-based rune offsets, while the regexp
+	// reports byte offsets. Track the rune offset alongside so both use the same
+	// coordinate space; matches are ordered, so this only walks the input once.
+	runeOffset := 1
+	scannedBytes := 0
 	for _, match := range matches {
 		start, end := match[0], match[1]
 
+		runeOffset += utf8.RuneCountInString(input[scannedBytes:start])
+		scannedBytes = start
+
 		// Skip substitution if the variable is inside a comment
-		if isInsideComment(tokens, start) {
+		if isInsideComment(tokens, runeOffset) {
 			output.WriteString(input[lastIndex:end])
 			lastIndex = end
 			continue
@@ -141,11 +150,16 @@ func (p *ConfigParser) parseEnv(input string) (string, error) {
 	return output.String(), err
 }
 
-// isInsideComment checks if the given byte offset in the YAML input is within a comment token.
-func isInsideComment(tokens token.Tokens, offset int) bool {
+// isInsideComment checks if the given 1-based rune offset in the YAML input is
+// within a comment token. Token positions from the lexer are 1-based rune
+// offsets, so callers must convert byte offsets before calling this.
+func isInsideComment(tokens token.Tokens, runeOffset int) bool {
 	for _, t := range tokens {
 		if t.Type == token.CommentType && t.Position != nil {
-			if offset >= t.Position.Offset && offset < t.Position.Offset+len(t.Origin) {
+			// Position.Offset points at the "#", but Origin also carries any
+			// indentation that precedes it, so measure the length from the "#".
+			length := utf8.RuneCountInString(strings.TrimLeft(t.Origin, " \t"))
+			if runeOffset >= t.Position.Offset && runeOffset < t.Position.Offset+length {
 				return true
 			}
 		}

--- a/cmd/internal/config_test.go
+++ b/cmd/internal/config_test.go
@@ -140,6 +140,29 @@ func TestParseEnv(t *testing.T) {
 			want: "foo: bar_val\n# ${FOO}\nbaz: qux_val",
 		},
 		{
+			desc: "parse env vars after a comment containing multi-byte characters",
+			in: "# " + strings.Repeat("é", 30) + "\n" +
+				"foo: ${BAR}\n" +
+				"# " + strings.Repeat("é", 30) + "\n" +
+				"baz: ${QUX}\n",
+			env: map[string]string{
+				"BAR": "bar_val",
+				"QUX": "qux_val",
+			},
+			want: "# " + strings.Repeat("é", 30) + "\n" +
+				"foo: bar_val\n" +
+				"# " + strings.Repeat("é", 30) + "\n" +
+				"baz: qux_val\n",
+		},
+		{
+			desc: "skip commented out env var when comment contains multi-byte characters",
+			in:   "# " + strings.Repeat("é", 30) + " ${FOO}\nbar: ${BAR}\n",
+			env: map[string]string{
+				"BAR": "bar_val",
+			},
+			want: "# " + strings.Repeat("é", 30) + " ${FOO}\nbar: bar_val\n",
+		},
+		{
 			desc: "multiline yaml with mixed comments and env vars",
 			in: "database: my-db # Another comment in line ${SHOULD_BE_IGNORED}\n" +
 				"host: \"localhost\"\n" +


### PR DESCRIPTION
## Description

`parseEnv` skipped some `${VAR}` placeholders that were not inside comments,
leaving the literal `${VAR}` text as the configuration value with no error or
warning. It happened when the config contained comments with multi-byte
characters, so a config could start failing after only a comment was edited.

The offsets came from two different coordinate spaces. `re.FindAllStringSubmatchIndex`
returns byte offsets, while `token.Position.Offset` from the go-yaml lexer is a
1-based rune offset: the scanner converts its input with `[]rune(text)` and
starts counting at `1`. For input containing multi-byte characters the two drift
apart, and once the drift is large enough a placeholder that sits outside any
comment gets an offset that falls inside a later comment token's range.

The range end had the same problem, since it was computed with `len(t.Origin)`
in bytes. `Origin` also carries the indentation that precedes the `#` while
`Position.Offset` already points at the `#`, so the range could extend past the
end of the comment.

This is a regression from #3807.

### Solution

- Track a 1-based rune offset alongside the byte offset at the call site, so
  both sides of the comparison use the lexer's coordinate space. Matches are
  ordered, so the input is still only walked once.
- Measure the comment length in runes, from the `#`, so the range covers exactly
  the comment.
- Add two `TestParseEnv` cases: one asserting placeholders after a multi-byte
  comment are substituted, and one asserting placeholders inside a multi-byte
  comment are still skipped.

Verified that the new cases fail without the change and pass with it, and that
the existing `cmd/internal` tests, `gofmt` and `go vet` are clean.

## PR Checklist

- [x] Make sure you reviewed
  [CONTRIBUTING.md](https://github.com/googleapis/mcp-toolbox/blob/main/CONTRIBUTING.md)
- [x] Make sure to open an issue as a
  [bug/issue](https://github.com/googleapis/mcp-toolbox/issues/new/choose)
  before writing your code! That way we can discuss the change, evaluate
  designs, and agree on the general idea
- [x] Ensure you have manually reviewed the entire diff before requesting a
  review
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
- [ ] Make sure to add `!` if this involve a breaking change

🛠️ Fixes #3855
