### PR TITLE
fix: merge prebuilt tools when reloading custom config

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -223,7 +223,7 @@ func scanWatchedFiles(watchingFolder bool, folderToWatch string, watchedFiles ma
 }
 
 // watchChanges checks for changes in the provided yaml config(s) or folder.
-func watchChanges(ctx context.Context, watchDirs map[string]bool, watchedFiles map[string]bool, s *server.Server, pollTickerSecond int, onReload func() error) {
+func watchChanges(ctx context.Context, watchDirs map[string]bool, watchedFiles map[string]bool, s *server.Server, opts *internal.ToolboxOptions) {
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		panic(err)
@@ -267,6 +267,7 @@ func watchChanges(ctx context.Context, watchDirs map[string]bool, watchedFiles m
 
 	lastSeen := make(map[string]time.Time)
 	var pollTickerChan <-chan time.Time
+	pollTickerSecond := opts.Cfg.PollInterval
 	if pollTickerSecond > 0 {
 		ticker := time.NewTicker(time.Duration(pollTickerSecond) * time.Second)
 		defer ticker.Stop()
@@ -351,8 +352,21 @@ func watchChanges(ctx context.Context, watchDirs map[string]bool, watchedFiles m
 		case <-debounce.C:
 			debounce.Stop()
 			logger.DebugContext(ctx, "File change detected, attempting to reload server...")
-			if err := onReload(); err != nil {
+
+			// Create a copy to avoid mutating the original opts if validation/reload fails
+			reloadedOpts := *opts
+			reloadedOpts.PrebuiltConfigs = slices.Clone(opts.PrebuiltConfigs)
+			reloadedOpts.Configs = slices.Clone(opts.Configs)
+			reloadedOpts.Cfg.Version = versionString
+
+			if _, err := reloadedOpts.LoadConfig(ctx, &internal.ConfigParser{}); err != nil {
+				logger.WarnContext(ctx, fmt.Sprintf("Error reloading config: %s", err))
+				continue
+			}
+
+			if err := handleDynamicReload(ctx, reloadedOpts.Cfg, s); err != nil {
 				logger.WarnContext(ctx, fmt.Sprintf("Error reloading server: %s", err))
+				continue
 			}
 		}
 	}
@@ -495,23 +509,8 @@ func run(cmd *cobra.Command, opts *internal.ToolboxOptions) error {
 	if isCustomConfigured && !opts.Cfg.DisableReload {
 		watchDirs, watchedFiles := resolveWatcherInputs(opts.Config, opts.Configs, opts.ConfigFolder)
 
-		onReload := func() error {
-
-			// Create a copy to avoid mutating the original opts if validation/reload fails
-			reloadedOpts := *opts
-			reloadedOpts.PrebuiltConfigs = slices.Clone(opts.PrebuiltConfigs)
-			reloadedOpts.Configs = slices.Clone(opts.Configs)
-			reloadedOpts.Cfg.Version = versionString
-
-			if _, err := reloadedOpts.LoadConfig(ctx, &internal.ConfigParser{}); err != nil {
-				return fmt.Errorf("error reloading config: %w", err)
-			}
-
-			return handleDynamicReload(ctx, reloadedOpts.Cfg, s)
-		}
-
 		// start watching the file(s) or folder for changes to trigger dynamic reloading
-		go watchChanges(ctx, watchDirs, watchedFiles, s, opts.Cfg.PollInterval, onReload)
+		go watchChanges(ctx, watchDirs, watchedFiles, s, opts)
 	}
 
 	// wait for either the server to error out or the command's context to be canceled

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,7 +19,6 @@ import (
 	_ "embed"
 	"fmt"
 	"io"
-	"maps"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -133,13 +132,13 @@ func NewCommand(opts *internal.ToolboxOptions) *cobra.Command {
 	return cmd
 }
 
-func handleDynamicReload(ctx context.Context, toolsFile internal.Config, s *server.Server) error {
+func handleDynamicReload(ctx context.Context, cfg server.ServerConfig, s *server.Server) error {
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		panic(err)
 	}
 
-	sourcesMap, authServicesMap, embeddingModelsMap, toolsMap, promptsMap, groupsMap, err := validateReloadEdits(ctx, toolsFile)
+	sourcesMap, authServicesMap, embeddingModelsMap, toolsMap, promptsMap, groupsMap, err := validateReloadEdits(ctx, cfg)
 	if err != nil {
 		errMsg := fmt.Errorf("unable to validate reloaded edits: %w", err)
 		logger.WarnContext(ctx, errMsg.Error())
@@ -153,7 +152,7 @@ func handleDynamicReload(ctx context.Context, toolsFile internal.Config, s *serv
 
 // validateReloadEdits checks that the reloaded config configs can initialized without failing
 func validateReloadEdits(
-	ctx context.Context, toolsFile internal.Config,
+	ctx context.Context, cfg server.ServerConfig,
 ) (map[string]sources.Source, map[string]auth.AuthService, map[string]embeddingmodels.EmbeddingModel, map[string]tools.Tool, map[string]prompts.Prompt, map[string]group.Group, error,
 ) {
 	logger, err := util.LoggerFromContext(ctx)
@@ -171,18 +170,7 @@ func validateReloadEdits(
 	ctx, span := instrumentation.Tracer.Start(ctx, "toolbox/server/reload")
 	defer span.End()
 
-	reloadedConfig := server.ServerConfig{
-		Version:               versionString,
-		SourceConfigs:         toolsFile.Sources,
-		AuthServiceConfigs:    toolsFile.AuthServices,
-		EmbeddingModelConfigs: toolsFile.EmbeddingModels,
-		ToolConfigs:           toolsFile.Tools,
-		PromptConfigs:         toolsFile.Prompts,
-		GroupConfigs:          toolsFile.Groups,
-		IgnoreUnknownTools:    util.IgnoreUnknownToolsFromContext(ctx),
-	}
-
-	sourcesMap, authServicesMap, embeddingModelsMap, toolsMap, promptsMap, groupsMap, err := server.InitializeConfigs(ctx, reloadedConfig)
+	sourcesMap, authServicesMap, embeddingModelsMap, toolsMap, promptsMap, groupsMap, err := server.InitializeConfigs(ctx, cfg)
 	if err != nil {
 		errMsg := fmt.Errorf("unable to initialize reloaded configs: %w", err)
 		logger.WarnContext(ctx, errMsg.Error())
@@ -235,7 +223,7 @@ func scanWatchedFiles(watchingFolder bool, folderToWatch string, watchedFiles ma
 }
 
 // watchChanges checks for changes in the provided yaml config(s) or folder.
-func watchChanges(ctx context.Context, watchDirs map[string]bool, watchedFiles map[string]bool, s *server.Server, pollTickerSecond int) {
+func watchChanges(ctx context.Context, watchDirs map[string]bool, watchedFiles map[string]bool, s *server.Server, pollTickerSecond int, onReload func() error) {
 	logger, err := util.LoggerFromContext(ctx)
 	if err != nil {
 		panic(err)
@@ -362,30 +350,9 @@ func watchChanges(ctx context.Context, watchDirs map[string]bool, watchedFiles m
 
 		case <-debounce.C:
 			debounce.Stop()
-			var allFiles []string
-			parser := internal.ConfigParser{}
-			if watchingFolder {
-				logger.DebugContext(ctx, "Reloading config folder.")
-				allFiles, err = internal.GetPathsFromConfigFolder(ctx, folderToWatch)
-				if err != nil {
-					logger.WarnContext(ctx, fmt.Sprintf("error loading config folder %s", err))
-					continue
-				}
-			} else {
-				allFiles = slices.Collect(maps.Keys(watchedFiles))
-			}
-			logger.DebugContext(ctx, "Reloading tools file(s).")
-			reloadedConfig, err := parser.LoadAndMergeConfigs(ctx, allFiles)
-			if err != nil {
-				logger.WarnContext(ctx, fmt.Sprintf("error loading configs %s", err))
-				continue
-			}
-
-			err = handleDynamicReload(ctx, reloadedConfig, s)
-			if err != nil {
-				errMsg := fmt.Errorf("unable to parse reloaded config at %+v: %w", reloadedConfig, err)
-				logger.WarnContext(ctx, errMsg.Error())
-				continue
+			logger.DebugContext(ctx, "File change detected, attempting to reload server...")
+			if err := onReload(); err != nil {
+				logger.WarnContext(ctx, fmt.Sprintf("Error reloading server: %s", err))
 			}
 		}
 	}
@@ -527,8 +494,24 @@ func run(cmd *cobra.Command, opts *internal.ToolboxOptions) error {
 
 	if isCustomConfigured && !opts.Cfg.DisableReload {
 		watchDirs, watchedFiles := resolveWatcherInputs(opts.Config, opts.Configs, opts.ConfigFolder)
+
+		onReload := func() error {
+
+			// Create a copy to avoid mutating the original opts if validation/reload fails
+			reloadedOpts := *opts
+			reloadedOpts.PrebuiltConfigs = slices.Clone(opts.PrebuiltConfigs)
+			reloadedOpts.Configs = slices.Clone(opts.Configs)
+			reloadedOpts.Cfg.Version = versionString
+
+			if _, err := reloadedOpts.LoadConfig(ctx, &internal.ConfigParser{}); err != nil {
+				return fmt.Errorf("error reloading config: %w", err)
+			}
+
+			return handleDynamicReload(ctx, reloadedOpts.Cfg, s)
+		}
+
 		// start watching the file(s) or folder for changes to trigger dynamic reloading
-		go watchChanges(ctx, watchDirs, watchedFiles, s, opts.Cfg.PollInterval)
+		go watchChanges(ctx, watchDirs, watchedFiles, s, opts.Cfg.PollInterval, onReload)
 	}
 
 	// wait for either the server to error out or the command's context to be canceled

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -639,9 +639,7 @@ func TestSingleEdit(t *testing.T) {
 	watchedFiles := map[string]bool{cleanFileToWatch: true}
 	watchDirs := map[string]bool{watchDir: true}
 
-	go watchChanges(ctx, watchDirs, watchedFiles, mockServer, 0, func() error {
-		return nil
-	})
+	go watchChanges(ctx, watchDirs, watchedFiles, mockServer, &internal.ToolboxOptions{})
 
 	// escape backslash so regex doesn't fail on windows filepaths
 	regexEscapedPathFile := strings.ReplaceAll(cleanFileToWatch, `\`, `\\\\*\\`)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -639,7 +639,9 @@ func TestSingleEdit(t *testing.T) {
 	watchedFiles := map[string]bool{cleanFileToWatch: true}
 	watchDirs := map[string]bool{watchDir: true}
 
-	go watchChanges(ctx, watchDirs, watchedFiles, mockServer, 0)
+	go watchChanges(ctx, watchDirs, watchedFiles, mockServer, 0, func() error {
+		return nil
+	})
 
 	// escape backslash so regex doesn't fail on windows filepaths
 	regexEscapedPathFile := strings.ReplaceAll(cleanFileToWatch, `\`, `\\\\*\\`)


### PR DESCRIPTION
## Description

Fix bug that caused prebuilt tools to be dropped when Toolbox server was reloaded (via modifying a custom config file). 

**Problem:**
Previously, the `watchChanges` function was responsible for reloading and parsing the config file(s) after any reload. The results from this parsing were passed to `s.PrimitiveMgr.SetPrimitives(...)` which replaced all existing toolbox primitives, unintentionally removing any prebuilt tools loaded at startup.

**Fix:**
Refactored `watchChanges` trigger a reload callback which invokes `LoadConfig`, ensuring both prebuilt configurations and custom files are re-parsed, merged, and checked for conflict just like during startup.

🛠️ Fixes [#3859](https://github.com/googleapis/mcp-toolbox/issues/3859)
