### PR TITLE
docs: fix dead links to integration index pages

### DIFF
--- a/docs/en/integrations/alloydb-admin/_index.md
+++ b/docs/en/integrations/alloydb-admin/_index.md
@@ -1,4 +1,5 @@
 ---
 title: "AlloyDB Admin"
+type: docs
 weight: 1
 ---

--- a/docs/en/integrations/alloydb/_index.md
+++ b/docs/en/integrations/alloydb/_index.md
@@ -1,4 +1,5 @@
 ---
 title: "AlloyDB PostgreSQL"
+type: docs
 weight: 1
 ---

--- a/docs/en/integrations/bigquery/_index.md
+++ b/docs/en/integrations/bigquery/_index.md
@@ -1,4 +1,5 @@
 ---
 title: "BigQuery"
+type: docs
 weight: 1
 ---

--- a/docs/en/integrations/bigtable/_index.md
+++ b/docs/en/integrations/bigtable/_index.md
@@ -1,4 +1,5 @@
 ---
 title: "Bigtable"
+type: docs
 weight: 1
 ---

--- a/docs/en/integrations/cassandra/_index.md
+++ b/docs/en/integrations/cassandra/_index.md
@@ -1,4 +1,5 @@
 ---
 title: "Cassandra"
+type: docs
 weight: 1
 ---

--- a/docs/en/integrations/clickhouse/_index.md
+++ b/docs/en/integrations/clickhouse/_index.md
@@ -1,4 +1,5 @@
 ---
 title: "ClickHouse"
+type: docs
 weight: 1
 ---

--- a/docs/en/integrations/cloud-sql-admin/_index.md
+++ b/docs/en/integrations/cloud-sql-admin/_index.md
@@ -1,4 +1,5 @@
 ---
 title: "Cloud SQL Admin"
+type: docs
 weight: 1
 ---

--- a/docs/en/integrations/cloud-sql-mssql/_index.md
+++ b/docs/en/integrations/cloud-sql-mssql/_index.md
@@ -1,4 +1,5 @@
 ---
 title: "Cloud SQL for SQL Server"
+type: docs
 weight: 1
 ---

--- a/docs/en/integrations/cloud-sql-mysql/_index.md
+++ b/docs/en/integrations/cloud-sql-mysql/_index.md
@@ -1,4 +1,5 @@
 ---
 title: "Cloud SQL for MySQL"
+type: docs
 weight: 1
 ---

--- a/docs/en/integrations/cloud-sql-pg/_index.md
+++ b/docs/en/integrations/cloud-sql-pg/_index.md
@@ -1,4 +1,5 @@
 ---
 title: "Cloud SQL for PostgreSQL"
+type: docs
 weight: 1
 ---

--- a/docs/en/integrations/cloud-storage/_index.md
+++ b/docs/en/integrations/cloud-storage/_index.md
@@ -1,4 +1,5 @@
 ---
 title: "Cloud Storage"
+type: docs
 weight: 1
 ---

--- a/docs/en/integrations/cloudgda/_index.md
+++ b/docs/en/integrations/cloudgda/_index.md
@@ -1,4 +1,5 @@
 ---
 title: "Gemini Data Analytics"
+type: docs
 weight: 1
 ---

--- a/docs/en/integrations/cloudhealthcare/_index.md
+++ b/docs/en/integrations/cloudhealthcare/_index.md
@@ -1,4 +1,5 @@
 ---
 title: "Cloud Healthcare"
+type: docs
 weight: 1
 ---

--- a/docs/en/integrations/cloudloggingadmin/_index.md
+++ b/docs/en/integrations/cloudloggingadmin/_index.md
@@ -1,4 +1,5 @@
 ---
 title: "Cloud Logging Admin"
+type: docs
 weight: 1
 ---

--- a/docs/en/integrations/cloudmonitoring/_index.md
+++ b/docs/en/integrations/cloudmonitoring/_index.md
@@ -1,4 +1,5 @@
 ---
 title: "Cloud Monitoring"
+type: docs
 weight: 1
 ---

--- a/docs/en/integrations/cockroachdb/_index.md
+++ b/docs/en/integrations/cockroachdb/_index.md
@@ -1,4 +1,5 @@
 ---
 title: "CockroachDB"
+type: docs
 weight: 1
 ---

--- a/docs/en/integrations/couchbase/_index.md
+++ b/docs/en/integrations/couchbase/_index.md
@@ -1,4 +1,5 @@
 ---
 title: "Couchbase"
+type: docs
 weight: 1
 ---

--- a/docs/en/integrations/databaseinsights/_index.md
+++ b/docs/en/integrations/databaseinsights/_index.md
@@ -1,4 +1,5 @@
 ---
 title: "Database Insights"
+type: docs
 weight: 1
 ---

--- a/docs/en/integrations/datalineage/_index.md
+++ b/docs/en/integrations/datalineage/_index.md
@@ -1,4 +1,5 @@
 ---
 title: "Data Lineage"
+type: docs
 weight: 1
 ---

--- a/docs/en/integrations/dataproc/_index.md
+++ b/docs/en/integrations/dataproc/_index.md
@@ -1,4 +1,5 @@
 ---
 title: "Dataproc Clusters"
+type: docs
 weight: 1
 ---

--- a/docs/en/integrations/dgraph/_index.md
+++ b/docs/en/integrations/dgraph/_index.md
@@ -1,4 +1,5 @@
 ---
 title: "Dgraph"
+type: docs
 weight: 1
 ---

--- a/docs/en/integrations/elasticsearch/_index.md
+++ b/docs/en/integrations/elasticsearch/_index.md
@@ -1,4 +1,5 @@
 ---
 title: "Elasticsearch"
+type: docs
 weight: 1
 ---

--- a/docs/en/integrations/firebird/_index.md
+++ b/docs/en/integrations/firebird/_index.md
@@ -1,4 +1,5 @@
 ---
 title: "Firebird"
+type: docs
 weight: 1
 ---

--- a/docs/en/integrations/firestore/_index.md
+++ b/docs/en/integrations/firestore/_index.md
@@ -1,4 +1,5 @@
 ---
 title: "Firestore"
+type: docs
 weight: 1
 ---

--- a/docs/en/integrations/http/_index.md
+++ b/docs/en/integrations/http/_index.md
@@ -1,4 +1,5 @@
 ---
 title: "HTTP"
+type: docs
 weight: 1
 ---

--- a/docs/en/integrations/knowledge-catalog/_index.md
+++ b/docs/en/integrations/knowledge-catalog/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "Knowledge Catalog"
+type: docs
 weight: 1
 aliases:
   - /integrations/dataplex/

--- a/docs/en/integrations/looker/_index.md
+++ b/docs/en/integrations/looker/_index.md
@@ -1,4 +1,5 @@
 ---
 title: "Looker"
+type: docs
 weight: 1
 ---

--- a/docs/en/integrations/mariadb/_index.md
+++ b/docs/en/integrations/mariadb/_index.md
@@ -1,4 +1,5 @@
 ---
 title: "MariaDB"
+type: docs
 weight: 1
 ---

--- a/docs/en/integrations/mindsdb/_index.md
+++ b/docs/en/integrations/mindsdb/_index.md
@@ -1,4 +1,5 @@
 ---
 title: "MindsDB"
+type: docs
 weight: 1
 ---

--- a/docs/en/integrations/mongodb/_index.md
+++ b/docs/en/integrations/mongodb/_index.md
@@ -1,4 +1,5 @@
 ---
 title: "MongoDB"
+type: docs
 weight: 1
 ---

--- a/docs/en/integrations/mssql/_index.md
+++ b/docs/en/integrations/mssql/_index.md
@@ -1,4 +1,5 @@
 ---
 title: "SQL Server"
+type: docs
 weight: 1
 ---

--- a/docs/en/integrations/mysql/_index.md
+++ b/docs/en/integrations/mysql/_index.md
@@ -1,4 +1,5 @@
 ---
 title: "MySQL"
+type: docs
 weight: 1
 ---

--- a/docs/en/integrations/neo4j/_index.md
+++ b/docs/en/integrations/neo4j/_index.md
@@ -1,4 +1,5 @@
 ---
 title: "Neo4j"
+type: docs
 weight: 1
 ---

--- a/docs/en/integrations/oceanbase/_index.md
+++ b/docs/en/integrations/oceanbase/_index.md
@@ -1,4 +1,5 @@
 ---
 title: "OceanBase"
+type: docs
 weight: 1
 ---

--- a/docs/en/integrations/oracle/_index.md
+++ b/docs/en/integrations/oracle/_index.md
@@ -1,4 +1,5 @@
 ---
 title: "Oracle"
+type: docs
 weight: 1
 ---

--- a/docs/en/integrations/postgres/_index.md
+++ b/docs/en/integrations/postgres/_index.md
@@ -1,4 +1,5 @@
 ---
 title: "PostgreSQL"
+type: docs
 weight: 1
 ---

--- a/docs/en/integrations/redis/_index.md
+++ b/docs/en/integrations/redis/_index.md
@@ -1,4 +1,5 @@
 ---
 title: "Redis"
+type: docs
 weight: 1
 ---

--- a/docs/en/integrations/scylladb/_index.md
+++ b/docs/en/integrations/scylladb/_index.md
@@ -1,4 +1,5 @@
 ---
 title: "ScyllaDB"
+type: docs
 weight: 1
 ---

--- a/docs/en/integrations/serverless-spark/_index.md
+++ b/docs/en/integrations/serverless-spark/_index.md
@@ -1,4 +1,5 @@
 ---
 title: "Serverless for Apache Spark"
+type: docs
 weight: 1
 ---

--- a/docs/en/integrations/singlestore/_index.md
+++ b/docs/en/integrations/singlestore/_index.md
@@ -1,4 +1,5 @@
 ---
 title: "SingleStore"
+type: docs
 weight: 1
 ---

--- a/docs/en/integrations/snowflake/_index.md
+++ b/docs/en/integrations/snowflake/_index.md
@@ -1,4 +1,5 @@
 ---
 title: "Snowflake"
+type: docs
 weight: 1
 ---

--- a/docs/en/integrations/spanner/_index.md
+++ b/docs/en/integrations/spanner/_index.md
@@ -1,4 +1,5 @@
 ---
 title: "Spanner"
+type: docs
 weight: 1
 ---

--- a/docs/en/integrations/sqlite/_index.md
+++ b/docs/en/integrations/sqlite/_index.md
@@ -1,4 +1,5 @@
 ---
 title: "SQLite"
+type: docs
 weight: 1
 ---

--- a/docs/en/integrations/tidb/_index.md
+++ b/docs/en/integrations/tidb/_index.md
@@ -1,4 +1,5 @@
 ---
 title: "TiDB"
+type: docs
 weight: 1
 ---

--- a/docs/en/integrations/trino/_index.md
+++ b/docs/en/integrations/trino/_index.md
@@ -1,4 +1,5 @@
 ---
 title: "Trino"
+type: docs
 weight: 1
 ---

--- a/docs/en/integrations/valkey/_index.md
+++ b/docs/en/integrations/valkey/_index.md
@@ -1,4 +1,5 @@
 ---
 title: "Valkey"
+type: docs
 weight: 1
 ---

--- a/docs/en/integrations/yuagbytedb/_index.md
+++ b/docs/en/integrations/yuagbytedb/_index.md
@@ -1,4 +1,5 @@
 ---
 title: "YugabyteDB"
+type: docs
 weight: 1
 ---


### PR DESCRIPTION
Every `/integrations/<name>/_index.md` page (47 of them) was missing the `type: docs` front matter key that its sibling pages already set explicitly: `source.md`, the tools pages, and the parent `/integrations/_index.md`.

Because of that, Hugo inferred content type `integrations` for these pages instead of `docs`, so they fell back to the Docsy theme's default section layout instead of this repo's own `layouts/docs/section.html`. That local override is what calls the `section-index` partial to auto-list a section's child pages (Source, Tools, Samples). Without it, visiting an integration's root — e.g. `/integrations/alloydb/` — rendered only the page chrome (title, nav, footer) with none of its own child links: a dead end, exactly as described in #3752.

3 integrations (`arcadedb`, `dataform`, `utility`) already had `type: docs` set and render correctly today — comparing those against the other 47 is what confirmed the root cause and the fix.

## Fix

Add `type: docs` to the front matter of the 47 affected `_index.md` files, matching the convention already used by their sibling pages. No template or layout changes — this makes the existing, already-imported Docsy `section-index` partial pick these pages up the same way it already does for the 3 that worked.

Fixes #3752

## Verification

Fetched the live site before/after reasoning about the fix:
- `https://mcp-toolbox.dev/integrations/alloydb/` (missing `type: docs`) — renders only page chrome, no links to Source/Tools.
- `https://mcp-toolbox.dev/integrations/arcadedb/` (already has `type: docs`) — renders a proper index with links to "ArcadeDB Source" and "Tools" (with individual tool pages listed).

This confirmed `type: docs` alone (no description or other params required — `utility` has none and still renders its Tools link) is the fix, so I applied it uniformly to all remaining integration index pages rather than writing per-page overview content or introducing a new redirect mechanism.

Scope: front-matter only, one line added per file, no other content changed.
