### PR TITLE
feat(plugins): add answer-questions skill to build-with-mcp-toolbox

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -42,6 +42,7 @@ extraFiles:
     "gemini-extension.json",
     "pypi/src/toolbox_server/__init__.py",
     "plugins/build-with-mcp-toolbox/skills/getting-started/SKILL.md",
+    "plugins/build-with-mcp-toolbox/skills/answer-questions/SKILL.md",
     {
       "type": "json",
       "path": "plugins/build-with-mcp-toolbox/.claude-plugin/plugin.json",

--- a/plugins/build-with-mcp-toolbox/README.md
+++ b/plugins/build-with-mcp-toolbox/README.md
@@ -40,6 +40,7 @@ files rather than a checkout of the whole repository.
 ## Skills
 
 - [`getting-started`](skills/getting-started/SKILL.md)
+- [`answer-questions`](skills/answer-questions/SKILL.md)
 
 Each skill's `description` frontmatter is the authoritative statement of what it
 covers and when it triggers.

--- a/plugins/build-with-mcp-toolbox/README.md
+++ b/plugins/build-with-mcp-toolbox/README.md
@@ -57,8 +57,11 @@ rather than symlinking into the repo, so this directory stands alone.
 Skills live in `skills/<skill-name>/SKILL.md`. When adding one:
 
 - Link to the versioned docsite, never to `/dev/` or a moving branch path.
-- Wrap any version-bearing string in
-  `<!-- {x-release-please-start-version} -->` / `<!-- {x-release-please-end} -->`
-  and add the file to `extraFiles` in `.github/release-please.yml`.
+- Wrap version strings the reader acts on — docsite links, install URLs, `curl`
+  commands — in `<!-- {x-release-please-start-version} -->` /
+  `<!-- {x-release-please-end} -->`, and add the file to `extraFiles` in
+  `.github/release-please.yml`. Leave versions inside worked examples unwrapped:
+  the updater replaces the whole semver match, so a wrapped
+  `1.9.0+binary.darwin.arm64` would lose its build metadata.
 - Add a link to it under [Skills](#skills).
 - Validate before pushing: `claude plugin validate . --strict`

--- a/plugins/build-with-mcp-toolbox/skills/answer-questions/SKILL.md
+++ b/plugins/build-with-mcp-toolbox/skills/answer-questions/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: answer-questions
+description: >-
+  Answer a factual question about MCP Toolbox for Databases from the pinned docs
+  and source code instead of from memory, and label every claim with where it
+  came from and which version it holds for. Use whenever someone asks whether
+  Toolbox supports something, what fields a source or tool takes, what
+  `--prebuilt <x>` actually serves, what a flag or error means, what changed
+  between versions, or why a `tools.yaml` is rejected. Use it also whenever you
+  are about to state a config key, tool `type`, or flag name you have not just
+  read.
+---
+
+# Answer Toolbox questions from the docs and the code
+
+Toolbox ships roughly monthly across ~40 integrations, so config keys, tool
+`type` strings, and flags all move. Recalled answers fail in the most expensive
+way: a plausible field name that the server rejects at startup. Look it up, then
+say where you looked.
+
+**Never state a config key, tool `type`, flag, or "yes, it supports that"
+without reading it in this session.**
+
+Work the steps in order. Step 1 decides which URLs the rest of them fetch.
+
+## Step 1: Pin the version
+
+```bash
+toolbox --version    # toolbox version 1.9.0+binary.darwin.arm64
+```
+
+The git tag is `v` plus the part before `+` (here, `v1.9.0`). The first metadata
+field after `+` is the build type, which decides the tree to read:
+
+| Build type | Means | Read from |
+|---|---|---|
+| `binary`, `container` | A release | Tag `v<version>` |
+| `dev` | Built from source | The user's checkout, else `main` |
+
+No server installed yet (they are choosing a source, or asking an SDK question)?
+Use the latest release and say which one you assumed.
+
+Read docs and code at the **same** version. Skew is what makes you recommend a
+field that does not exist yet, and it explains nearly every apparent
+docs-versus-code conflict.
+
+## Step 2: Docs first
+
+Every version publishes a machine-readable page index:
+
+```
+https://mcp-toolbox.dev/v<version>/llms.txt
+```
+
+- **Format:** one line per page, `- [Title](permalink): description`. Fetch it,
+  find the permalink, then fetch that page.
+- **Size:** ~120 KB. Its sibling `llms-full.txt` holds the whole corpus at ~2 MB,
+  so reach for that only after a targeted page hunt has failed.
+- **Unreleased:** swap `/v<version>/` for `/dev/` to read `main`.
+
+Docs are authoritative for concepts, quickstarts, deployment, and anything the
+user will read themselves. They are not authoritative for the exact set of
+config keys, which is Step 3.
+
+## Step 3: Code for exact behavior
+
+Go to the code when the docs are silent, ambiguous, or stale, or when the
+question is what something exactly accepts or does. No checkout needed, and no
+auth:
+
+```
+https://raw.githubusercontent.com/googleapis/mcp-toolbox/v<version>/<path>
+```
+
+| Question | Path |
+|---|---|
+| Fields a source accepts | `internal/sources/<source>/<source>.go`, `Config` struct |
+| What a tool accepts and does | `internal/tools/<source>/<tooldir>/<tooldir>.go`, `Config` struct then `Invoke` |
+| What `--prebuilt <x>` serves, and which env vars it reads | `internal/prebuiltconfigs/tools/<x>.yaml`, the literal config: every tool name, every toolset, and the `${ENV_VAR}` behind each source field |
+| CLI flags | `cmd/root.go` |
+| Whether a source or tool exists at all | `https://api.github.com/repos/googleapis/mcp-toolbox/contents/internal/tools?ref=v<version>` |
+
+Deriving `<tooldir>`:
+
+- **It is the tool `type` with the hyphens removed**, nested under its source
+  family. `postgres-sql` becomes `internal/tools/postgres/postgressql/`, and
+  `firestore-list-collections` becomes
+  `internal/tools/firestore/firestorelistcollections/`.
+- **A 404 at the derived path is itself an answer:** that tool does not exist at
+  that version.
+- **Confirm the `type` string against the constant** near the top of the file.
+  Tools and sources name it differently:
+
+  ```go
+  const resourceType string = "postgres-sql"   // internal/tools/...
+  const SourceType   string = "postgres"       // internal/sources/...
+  ```
+
+### Reading a Config struct
+
+The struct tags are the config surface, so one block answers most "what can I
+set" questions:
+
+```go
+Host          string `yaml:"host" validate:"required"`
+QueryExecMode string `yaml:"queryExecMode" validate:"omitempty,oneof=cache_statement cache_describe describe_exec exec simple_protocol"`
+ConnectTimeout *int  `yaml:"connectTimeout" validate:"omitempty,gte=1"`
+```
+
+- `yaml:"..."` is the exact key in `tools.yaml`: camelCase, never the Go field
+  name.
+- `validate:"required"` means required. Anything else (`omitempty`, or no
+  `validate` tag at all) is optional.
+- `oneof=` is the **complete** allowed set. Nothing outside it is valid.
+- A pointer (`*bool`, `*int`) distinguishes unset from zero, usually meaning the
+  driver default applies when unset.
+- Tool configs inline `tools.ConfigBase`, which supplies `name`, `description`,
+  `authRequired`, and `scopesRequired`. Do not report those as missing just
+  because the tool's own struct omits them.
+
+## Step 4: Label every claim
+
+Attribute inline and carry the version. An unlabeled answer is indistinguishable
+from a guess.
+
+- `[docs v1.9.0]` plus the page link, so they can read it themselves
+- `[code v1.9.0 internal/sources/postgres/postgres.go:56]`
+- `[UNVERIFIED]` for reasoning or recall you could not confirm, with what would
+  confirm it
+
+**When docs and code disagree at the same version, code wins.** Answer from the
+code, say plainly that the docs are wrong, quote the line that settles it, and
+point the user at <https://github.com/googleapis/mcp-toolbox/issues> to file a
+docs bug.
+
+## Rules
+
+- **Answer for the user's version, not for `main`.** When something exists on
+  `main` but not their tag, say so precisely: "not in v1.9.0, landed after it,
+  currently in `dev`, shipping in the next release." Never hand a release user a
+  config key only `main` accepts.
+- **Do not invent field names or tool types.** If it is not in the struct tags,
+  the prebuilt YAML, or `--help`, it does not exist. Say that.
+- **Prefer what the user can verify locally.** `toolbox --help`, `toolbox invoke
+  <tool> '<json>' --config tools.yaml`, and the server's own startup error settle
+  a question about *their* setup better than any URL.
+- **"I could not find it" is a valid answer.** Say what you searched (version,
+  docs pages, code paths) so the next step is obvious. Do not fill the gap with a
+  plausible-looking key.
+- **Answer the question that was asked.** One line with a citation beats a tour
+  of the configuration system.
+
+## Reference
+
+<!-- {x-release-please-start-version} -->
+- [Configuration reference](https://mcp-toolbox.dev/v1.9.0/documentation/configuration/)
+- [All sources and tools](https://mcp-toolbox.dev/v1.9.0/integrations/)
+- [Source at the matching tag](https://github.com/googleapis/mcp-toolbox/tree/v1.9.0)
+<!-- {x-release-please-end} -->

--- a/plugins/build-with-mcp-toolbox/skills/answer-questions/SKILL.md
+++ b/plugins/build-with-mcp-toolbox/skills/answer-questions/SKILL.md
@@ -14,16 +14,21 @@ description: >-
 # Answer Toolbox questions from the docs and the code
 
 Toolbox ships roughly monthly across ~40 integrations, so config keys, tool
-`type` strings, and flags all move. Recalled answers fail in the most expensive
-way: a plausible field name that the server rejects at startup. Look it up, then
-say where you looked.
+`type` strings, and flags all move. Look it up, then say where you looked.
 
 **Never state a config key, tool `type`, flag, or "yes, it supports that"
 without reading it in this session.**
 
-Work the steps in order. Step 1 decides which URLs the rest of them fetch.
+## Which version
 
-## Step 1: Pin the version
+**Answer for the latest release and say so.** It is the version in the
+[Reference](#reference) links below, bumped by the same release-please run that
+ships the server. Do not go hunting for an installed binary: most questions (does
+Toolbox support X, what does this tool do, how do I start) never need one.
+
+Pin to the user's own build only when they ask something specific to a version:
+they quote a startup error, ask why their `tools.yaml` is rejected, ask what
+changed between releases, or name a version themselves.
 
 ```bash
 toolbox --version    # toolbox version 1.9.0+binary.darwin.arm64
@@ -37,14 +42,11 @@ field after `+` is the build type, which decides the tree to read:
 | `binary`, `container` | A release | Tag `v<version>` |
 | `dev` | Built from source | The user's checkout, else `main` |
 
-No server installed yet (they are choosing a source, or asking an SDK question)?
-Use the latest release and say which one you assumed.
-
-Read docs and code at the **same** version. Skew is what makes you recommend a
-field that does not exist yet, and it explains nearly every apparent
+Whichever version you land on, read docs and code at the **same** one. Skew makes
+you recommend fields that do not exist yet, and it explains nearly every apparent
 docs-versus-code conflict.
 
-## Step 2: Docs first
+## Step 1: Docs first
 
 Every version publishes a machine-readable page index:
 
@@ -60,13 +62,12 @@ https://mcp-toolbox.dev/v<version>/llms.txt
 
 Docs are authoritative for concepts, quickstarts, deployment, and anything the
 user will read themselves. They are not authoritative for the exact set of
-config keys, which is Step 3.
+config keys, which is Step 2.
 
-## Step 3: Code for exact behavior
+## Step 2: Code for exact behavior
 
 Go to the code when the docs are silent, ambiguous, or stale, or when the
-question is what something exactly accepts or does. No checkout needed, and no
-auth:
+question is exactly what something accepts or does. No checkout, no auth:
 
 ```
 https://raw.githubusercontent.com/googleapis/mcp-toolbox/v<version>/<path>
@@ -78,7 +79,7 @@ https://raw.githubusercontent.com/googleapis/mcp-toolbox/v<version>/<path>
 | What a tool accepts and does | `internal/tools/<source>/<tooldir>/<tooldir>.go`, `Config` struct then `Invoke` |
 | What `--prebuilt <x>` serves, and which env vars it reads | `internal/prebuiltconfigs/tools/<x>.yaml`, the literal config: every tool name, every toolset, and the `${ENV_VAR}` behind each source field |
 | CLI flags | `cmd/root.go` |
-| Whether a source or tool exists at all | The Step 2 `llms.txt` index — one line per tool page, titled with the exact `type` |
+| Whether a source or tool exists at all | The Step 1 `llms.txt` index (one line per tool page, titled with the exact `type`) |
 
 Deriving `<tooldir>`:
 
@@ -108,7 +109,9 @@ ConnectTimeout *int  `yaml:"connectTimeout" validate:"omitempty,gte=1"`
 ```
 
 - `yaml:"..."` is the exact key in `tools.yaml`: camelCase, never the Go field
-  name.
+  name. The one key absent from every Config is `kind`: it selects which struct
+  to decode into and is stripped before decoding, so do not call it invalid just
+  because no struct tag carries it.
 - `validate:"required"` means required. Anything else (`omitempty`, or no
   `validate` tag at all) is optional.
 - `oneof=` is the **complete** allowed set. Nothing outside it is valid.
@@ -118,7 +121,7 @@ ConnectTimeout *int  `yaml:"connectTimeout" validate:"omitempty,gte=1"`
   `authRequired`, and `scopesRequired`. Do not report those as missing just
   because the tool's own struct omits them.
 
-## Step 4: Label every claim
+## Step 3: Label every claim
 
 Attribute inline and carry the version. An unlabeled answer is indistinguishable
 from a guess.
@@ -135,18 +138,17 @@ docs bug.
 
 ## Rules
 
-- **Answer for the user's version, not for `main`.** When something exists on
-  `main` but not their tag, say so precisely: "not in v1.9.0, landed after it,
-  currently in `dev`, shipping in the next release." Never hand a release user a
-  config key only `main` accepts.
+- **Answer for the release, not for `main`.** When something exists on `main` but
+  not the version you are answering for, say so precisely: "not in v1.9.0, landed
+  after it, currently in `dev`, shipping in the next release." Never hand a
+  release user a config key only `main` accepts.
 - **Do not invent field names or tool types.** If it is not in the struct tags,
-  the prebuilt YAML, or `--help`, it does not exist. Say that.
+  the prebuilt YAML, or `--help`, it does not exist. Say so, and say what you
+  searched (version, docs pages, code paths) so the next step is obvious. "I
+  could not find it" is a valid answer; a plausible-looking key is not.
 - **Prefer what the user can verify locally.** `toolbox --help`, `toolbox invoke
   <tool> '<json>' --config tools.yaml`, and the server's own startup error settle
   a question about *their* setup better than any URL.
-- **"I could not find it" is a valid answer.** Say what you searched (version,
-  docs pages, code paths) so the next step is obvious. Do not fill the gap with a
-  plausible-looking key.
 - **Answer the question that was asked.** One line with a citation beats a tour
   of the configuration system.
 

--- a/plugins/build-with-mcp-toolbox/skills/answer-questions/SKILL.md
+++ b/plugins/build-with-mcp-toolbox/skills/answer-questions/SKILL.md
@@ -54,8 +54,10 @@ Every version publishes a machine-readable page index:
 https://mcp-toolbox.dev/v<version>/llms.txt
 ```
 
-- **Format:** one line per page, `- [Title](permalink): description`. Fetch it,
-  find the permalink, then fetch that page.
+- **Format:** one line per page, `- [Title](permalink): description`, indented
+  two spaces per nesting level. Tool pages sit six deep, so anchoring a search
+  at `^- [` finds only the six top-level sections. Fetch the index, find the
+  permalink, then fetch that page.
 - **Size:** ~120 KB. Its sibling `llms-full.txt` holds the whole corpus at ~2 MB,
   so reach for that only after a targeted page hunt has failed.
 - **Unreleased:** swap `/v<version>/` for `/dev/` to read `main`.

--- a/plugins/build-with-mcp-toolbox/skills/answer-questions/SKILL.md
+++ b/plugins/build-with-mcp-toolbox/skills/answer-questions/SKILL.md
@@ -78,7 +78,7 @@ https://raw.githubusercontent.com/googleapis/mcp-toolbox/v<version>/<path>
 | What a tool accepts and does | `internal/tools/<source>/<tooldir>/<tooldir>.go`, `Config` struct then `Invoke` |
 | What `--prebuilt <x>` serves, and which env vars it reads | `internal/prebuiltconfigs/tools/<x>.yaml`, the literal config: every tool name, every toolset, and the `${ENV_VAR}` behind each source field |
 | CLI flags | `cmd/root.go` |
-| Whether a source or tool exists at all | `https://api.github.com/repos/googleapis/mcp-toolbox/contents/internal/tools?ref=v<version>` |
+| Whether a source or tool exists at all | The Step 2 `llms.txt` index — one line per tool page, titled with the exact `type` |
 
 Deriving `<tooldir>`:
 
@@ -114,7 +114,7 @@ ConnectTimeout *int  `yaml:"connectTimeout" validate:"omitempty,gte=1"`
 - `oneof=` is the **complete** allowed set. Nothing outside it is valid.
 - A pointer (`*bool`, `*int`) distinguishes unset from zero, usually meaning the
   driver default applies when unset.
-- Tool configs inline `tools.ConfigBase`, which supplies `name`, `description`,
+- Tool configs embed `tools.ConfigBase`, which supplies `name`, `description`,
   `authRequired`, and `scopesRequired`. Do not report those as missing just
   because the tool's own struct omits them.
 


### PR DESCRIPTION
## Description

Adds a second skill, `answer-questions`, to the `build-with-mcp-toolbox` plugin.

The skill makes an agent look the answer up and say where it looked:

- **Pins the version first** from the build metadata in `toolbox --version`
  (`binary`/`container` means read the tag, `dev` means read the checkout or
  `main`), since that decides every URL fetched afterwards.
- **Reads docs** via the per-version `llms.txt` page index, and **code** via raw
  files at the matching tag. Both are public, so the skill works without a
  checkout or auth.
- **Labels every claim** `[docs v1.9.0]` / `[code v1.9.0 path:line]` /
  `[UNVERIFIED]`.
- **Code wins over docs**, but only once both are confirmed at the same version,
  since skew explains nearly every apparent conflict.

Also registers the skill in the plugin README and in `extraFiles` so
release-please bumps its version strings.

Stacked on #3868; that PR is the base and should merge first.