### PR TITLE
ci(test/alloydbainl): use explicit SQL alias prompts to stabilize AI

### DIFF
--- a/tests/alloydbainl/alloydb_ai_nl_mcp_test.go
+++ b/tests/alloydbainl/alloydb_ai_nl_mcp_test.go
@@ -138,7 +138,7 @@ func TestAlloyDBAINLCallTool(t *testing.T) {
 		{
 			name:     "invoke my-simple-tool",
 			toolName: "my-simple-tool",
-			args:     map[string]any{"question": "return the number 1"},
+			args:     map[string]any{"question": "SELECT the integer 1 and explicitly alias the output column as 'number_one'"},
 			want:     "{\"execute_nl_query\":{\"number_one\":1}}",
 			isErr:    false,
 		},
@@ -153,20 +153,20 @@ func TestAlloyDBAINLCallTool(t *testing.T) {
 		{
 			name:          "Invoke my-auth-tool with invalid auth token",
 			toolName:      "my-auth-tool",
-			args:          map[string]any{"question": "return the number 1"},
+			args:          map[string]any{"question": "SELECT the integer 1 and explicitly alias the output column as 'number_one'"},
 			requestHeader: map[string]string{"my-google-auth_token": "INVALID_TOKEN"},
 			isErr:         true,
 		},
 		{
 			name:     "Invoke my-auth-tool without auth token",
 			toolName: "my-auth-tool",
-			args:     map[string]any{"question": "return the number 1"},
+			args:     map[string]any{"question": "SELECT the integer 1 and explicitly alias the output column as 'number_one'"},
 			isErr:    true,
 		},
 		{
 			name:          "Invoke my-auth-required-tool with auth token",
 			toolName:      "my-auth-required-tool",
-			args:          map[string]any{"question": "return the number 1"},
+			args:          map[string]any{"question": "SELECT the integer 1 and explicitly alias the output column as 'number_one'"},
 			requestHeader: map[string]string{"my-google-auth_token": idToken},
 			isErr:         false,
 			want:          "{\"execute_nl_query\":{\"number_one\":1}}",
@@ -174,7 +174,7 @@ func TestAlloyDBAINLCallTool(t *testing.T) {
 		{
 			name:           "Invoke my-auth-required-tool with invalid auth token",
 			toolName:       "my-auth-required-tool",
-			args:           map[string]any{"question": "return the number 1"},
+			args:           map[string]any{"question": "SELECT the integer 1 and explicitly alias the output column as 'number_one'"},
 			requestHeader:  map[string]string{"my-google-auth_token": "INVALID_TOKEN"},
 			isErr:          true,
 			wantStatusCode: 401,
@@ -182,7 +182,7 @@ func TestAlloyDBAINLCallTool(t *testing.T) {
 		{
 			name:           "Invoke my-auth-required-tool without auth token",
 			toolName:       "my-auth-required-tool",
-			args:           map[string]any{"question": "return the number 1"},
+			args:           map[string]any{"question": "SELECT the integer 1 and explicitly alias the output column as 'number_one'"},
 			isErr:          true,
 			wantStatusCode: 401,
 		},


### PR DESCRIPTION
## Description

The prompt `return the number 1` is naturally flaky. It was sometimes returning errors like this:

`alloydb_ai_nl_mcp_test.go:234: unexpected value: got "{\"execute_nl_query\":{\"result\":1}}", want "{\"execute_nl_query\":{\"number_one\":1}}"`.

Swapped this for a more deterministic SQL style prompt, so the response format is far less likely to change from run to run.

- [ ] Make sure you reviewed
  [CONTRIBUTING.md](https://github.com/googleapis/mcp-toolbox/blob/main/CONTRIBUTING.md)
- [ ] Make sure to open an issue as a
  [bug/issue](https://github.com/googleapis/mcp-toolbox/issues/new/choose)
  before writing your code! That way we can discuss the change, evaluate
  designs, and agree on the general idea
- [ ] Ensure you have manually reviewed the entire diff before requesting a
  review
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
- [ ] Make sure to add `!` if this involve a breaking change

🛠️ Fixes #<issue_number_goes_here>
