### PR TITLE
ci: add label-gated presubmit evals with changed-path targeting

### DIFF
--- a/.ci/evals.cloudbuild.yaml
+++ b/.ci/evals.cloudbuild.yaml
@@ -111,5 +111,5 @@ timeout: 7200s
 substitutions:
   _EVAL_HARNESSES: "claude_cli"
   _GEMINI_MODEL: "gemini-3.7-flash"
-  _CLAUDE_MODEL: "claude-opus-4-6"
+  _CLAUDE_MODEL: "claude-opus-4-8"
   _EVALBENCH_IMAGE: "us-central1-docker.pkg.dev/cloud-db-nl2sql/evalbench/eval_server:latest"

--- a/.ci/evals.cloudbuild.yaml
+++ b/.ci/evals.cloudbuild.yaml
@@ -20,9 +20,11 @@
 # steps inherit _EVAL_HARNESSES unless they set their own.
 
 steps:
-  # On a PR this narrows the run to the databases the PR touched. On the
-  # nightly, main diffed against main is empty, so the fallback path matches
-  # every step's pattern and everything runs.
+  # On a PR this narrows the run to the databases the PR touched. On a
+  # scheduled run, main diffed against main is empty, and the fallback path is
+  # what keeps the full matrix running: it must stay matched by
+  # EVAL_COMMON_PATTERN below, or every step skips and the build goes green
+  # having evaluated nothing.
   - id: "detect-changes"
     name: "gcr.io/cloud-builders/git"
     waitFor: ["-"]

--- a/.ci/evals.cloudbuild.yaml
+++ b/.ci/evals.cloudbuild.yaml
@@ -20,6 +20,24 @@
 # steps inherit _EVAL_HARNESSES unless they set their own.
 
 steps:
+  # On a PR this narrows the run to the databases the PR touched. On the
+  # nightly, main diffed against main is empty, so the fallback path matches
+  # every step's pattern and everything runs.
+  - id: "detect-changes"
+    name: "gcr.io/cloud-builders/git"
+    waitFor: ["-"]
+    entrypoint: "bash"
+    args:
+      - -c
+      - |
+        git fetch --unshallow || true
+        git fetch origin main > /dev/null 2>&1
+        git diff --name-only origin/main...HEAD > /workspace/changed_files.txt
+        if [ ! -s /workspace/changed_files.txt ]; then
+          echo "No changed files detected. Writing a representative CI path to run all eval steps."
+          echo ".ci/evals.cloudbuild.yaml" > /workspace/changed_files.txt
+        fi
+
   - id: "build-toolbox"
     name: golang:1
     waitFor: ["-"]
@@ -38,7 +56,7 @@ steps:
 
   - id: "evals-cloud-sql-postgres"
     name: "${_EVALBENCH_IMAGE}"
-    waitFor: ["build-toolbox", "pull-evalbench"]
+    waitFor: ["build-toolbox", "pull-evalbench", "detect-changes"]
     dir: /evalbench
     entrypoint: bash
     args: ["/workspace/.ci/run_evals.sh"]
@@ -47,6 +65,7 @@ steps:
       - "EVAL_DATASET=evals/evalsets/cloud-sql-postgres.json"
       - "EVAL_ENV_PREFIX=CLOUD_SQL_POSTGRES"
       - "EVAL_HARNESSES=claude_cli gemini_cli"
+      - "EVAL_CHANGED_PATTERN=(^|/)internal/prebuiltconfigs/tools/cloud-sql-postgres\\.yaml|(^|/)evals/evalsets/cloud-sql-postgres\\.json"
 
       - "CLOUD_SQL_POSTGRES_PROJECT=$PROJECT_ID"
       - "CLOUD_SQL_POSTGRES_REGION=${_REGION}"
@@ -59,7 +78,7 @@ steps:
 
   - id: "evals-cloud-sql-mysql"
     name: "${_EVALBENCH_IMAGE}"
-    waitFor: ["build-toolbox", "pull-evalbench"]
+    waitFor: ["build-toolbox", "pull-evalbench", "detect-changes"]
     dir: /evalbench
     entrypoint: bash
     args: ["/workspace/.ci/run_evals.sh"]
@@ -67,6 +86,7 @@ steps:
       - "TOOLBOX_PREBUILT=cloud-sql-mysql"
       - "EVAL_DATASET=evals/evalsets/cloud-sql-mysql.json"
       - "EVAL_ENV_PREFIX=CLOUD_SQL_MYSQL"
+      - "EVAL_CHANGED_PATTERN=(^|/)internal/prebuiltconfigs/tools/cloud-sql-mysql\\.yaml|(^|/)evals/evalsets/cloud-sql-mysql\\.json"
 
       - "CLOUD_SQL_MYSQL_PROJECT=$PROJECT_ID"
       - "CLOUD_SQL_MYSQL_REGION=${_REGION}"
@@ -101,6 +121,9 @@ options:
     - "EVAL_CLAUDE_MODEL=${_CLAUDE_MODEL}"
     - "EVAL_GCP_PROJECT_ID=$PROJECT_ID"
     - "EVAL_REPORTING_PROJECT=${_EVAL_REPORTING_PROJECT}"
+    - "EVAL_GROUP=${_EVAL_GROUP}"
+    # OR'd into every step's EVAL_CHANGED_PATTERN: paths that affect all of them.
+    - "EVAL_COMMON_PATTERN=(^|/)evals/(run_configs|model_configs)/|\\.ci/evals\\.cloudbuild\\.yaml|\\.ci/run_evals\\.sh"
     - "EVAL_GCP_PROJECT_REGION=${_VERTEX_LOCATION}"
     - "UV_CACHE_DIR=/tmp/uv-cache"
 
@@ -110,6 +133,8 @@ timeout: 7200s
 # step when one is missing.
 substitutions:
   _EVAL_HARNESSES: "claude_cli"
+  # Presubmit runs override this so their rows stay out of the scheduled runs.
+  _EVAL_GROUP: "mcp-toolbox"
   _GEMINI_MODEL: "gemini-3.7-flash"
   _CLAUDE_MODEL: "claude-opus-4-8"
   _EVALBENCH_IMAGE: "us-central1-docker.pkg.dev/cloud-db-nl2sql/evalbench/eval_server:latest"

--- a/.ci/evals.cloudbuild.yaml
+++ b/.ci/evals.cloudbuild.yaml
@@ -20,11 +20,8 @@
 # steps inherit _EVAL_HARNESSES unless they set their own.
 
 steps:
-  # On a PR this narrows the run to the databases the PR touched. On a
-  # scheduled run, main diffed against main is empty, and the fallback path is
-  # what keeps the full matrix running: it must stay matched by
-  # EVAL_COMMON_PATTERN below, or every step skips and the build goes green
-  # having evaluated nothing.
+  # Narrows a pull request run to the databases it touched. Empty on a scheduled
+  # build, which run_evals.sh runs in full.
   - id: "detect-changes"
     name: "gcr.io/cloud-builders/git"
     waitFor: ["-"]
@@ -35,10 +32,7 @@ steps:
         git fetch --unshallow || true
         git fetch origin main > /dev/null 2>&1
         git diff --name-only origin/main...HEAD > /workspace/changed_files.txt
-        if [ ! -s /workspace/changed_files.txt ]; then
-          echo "No changed files detected. Writing a representative CI path to run all eval steps."
-          echo ".ci/evals.cloudbuild.yaml" > /workspace/changed_files.txt
-        fi
+        cat /workspace/changed_files.txt
 
   - id: "build-toolbox"
     name: golang:1
@@ -67,7 +61,6 @@ steps:
       - "EVAL_DATASET=evals/evalsets/cloud-sql-postgres.json"
       - "EVAL_ENV_PREFIX=CLOUD_SQL_POSTGRES"
       - "EVAL_HARNESSES=claude_cli gemini_cli"
-      - "EVAL_CHANGED_PATTERN=(^|/)internal/prebuiltconfigs/tools/cloud-sql-postgres\\.yaml|(^|/)evals/evalsets/cloud-sql-postgres\\.json"
 
       - "CLOUD_SQL_POSTGRES_PROJECT=$PROJECT_ID"
       - "CLOUD_SQL_POSTGRES_REGION=${_REGION}"
@@ -88,7 +81,6 @@ steps:
       - "TOOLBOX_PREBUILT=cloud-sql-mysql"
       - "EVAL_DATASET=evals/evalsets/cloud-sql-mysql.json"
       - "EVAL_ENV_PREFIX=CLOUD_SQL_MYSQL"
-      - "EVAL_CHANGED_PATTERN=(^|/)internal/prebuiltconfigs/tools/cloud-sql-mysql\\.yaml|(^|/)evals/evalsets/cloud-sql-mysql\\.json"
 
       - "CLOUD_SQL_MYSQL_PROJECT=$PROJECT_ID"
       - "CLOUD_SQL_MYSQL_REGION=${_REGION}"
@@ -124,8 +116,6 @@ options:
     - "EVAL_GCP_PROJECT_ID=$PROJECT_ID"
     - "EVAL_REPORTING_PROJECT=${_EVAL_REPORTING_PROJECT}"
     - "EVAL_GROUP=${_EVAL_GROUP}"
-    # OR'd into every step's EVAL_CHANGED_PATTERN: paths that affect all of them.
-    - "EVAL_COMMON_PATTERN=(^|/)evals/(run_configs|model_configs)/|\\.ci/evals\\.cloudbuild\\.yaml|\\.ci/run_evals\\.sh"
     - "EVAL_GCP_PROJECT_REGION=${_VERTEX_LOCATION}"
     - "UV_CACHE_DIR=/tmp/uv-cache"
 

--- a/.ci/run_evals.sh
+++ b/.ci/run_evals.sh
@@ -44,6 +44,14 @@ for var in "${required[@]}"; do
   fi
 done
 
+# A missing file means a local run and an unset pattern means a step that opted
+# out; both run rather than silently skipping.
+if [[ -f /workspace/changed_files.txt && -n "${EVAL_CHANGED_PATTERN:-}" ]] &&
+   ! grep -qE "${EVAL_CHANGED_PATTERN}|${EVAL_COMMON_PATTERN}" /workspace/changed_files.txt; then
+  echo "no changes affecting ${TOOLBOX_PREBUILT}; skipping"
+  exit 0
+fi
+
 echo "prebuilt config: ${TOOLBOX_PREBUILT}"
 echo "harnesses:       ${EVAL_HARNESSES}"
 "${TOOLBOX_BIN}" --version  # built on Debian, exec'd here on Ubuntu

--- a/.ci/run_evals.sh
+++ b/.ci/run_evals.sh
@@ -44,10 +44,17 @@ for var in "${required[@]}"; do
   fi
 done
 
-# A missing file means a local run and an unset pattern means a step that opted
-# out; both run rather than silently skipping.
-if [[ -f /workspace/changed_files.txt && -n "${EVAL_CHANGED_PATTERN:-}" ]] &&
-   ! grep -qE "${EVAL_CHANGED_PATTERN}|${EVAL_COMMON_PATTERN}" /workspace/changed_files.txt; then
+# Paths that put every step in scope.
+common_pattern='(^|/)evals/(run_configs|model_configs)/|\.ci/evals\.cloudbuild\.yaml|\.ci/run_evals\.sh'
+
+# Exact-line matches, since git diff emits repo-relative paths. Only a non-empty
+# list can narrow the run: empty means a scheduled build, or a checkout the diff
+# failed against.
+if [[ -s /workspace/changed_files.txt ]] &&
+   ! grep -qxF -e "${EVAL_DATASET}" \
+               -e "internal/prebuiltconfigs/tools/${TOOLBOX_PREBUILT}.yaml" \
+               /workspace/changed_files.txt &&
+   ! grep -qE "${common_pattern}" /workspace/changed_files.txt; then
   echo "no changes affecting ${TOOLBOX_PREBUILT}; skipping"
   exit 0
 fi

--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -82,6 +82,10 @@
   color: BFDADC
   description: Label to trigger Github Action docs preview.
 
+- name: 'evals: run'
+  color: 3DED97
+  description: Label to trigger prebuilt config evals on Cloud Build.
+
 - name: 'status: help wanted'
   color: 8befd7
   description: 'Status: Unplanned work open to contributions from the community.'

--- a/.github/workflows/evals_trigger.yml
+++ b/.github/workflows/evals_trigger.yml
@@ -1,0 +1,61 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Bridges the 'evals: run' label to Cloud Build, whose only pull request gate is
+# a /gcbrun comment. Posts the comment and nothing else; it never checks out PR
+# code, which is what makes pull_request_target safe here.
+
+name: evals trigger
+# zizmor flags pull_request_target, but it is safely gated by the 'evals: run' label manually applied by maintainers.
+on: # zizmor: ignore[dangerous-triggers]
+  pull_request_target:
+    types: [labeled]
+
+permissions: read-all
+
+jobs:
+  gcbrun:
+    if: "${{ github.event.label.name == 'evals: run' }}"
+    name: gcbrun
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: 'write'
+    steps:
+      - name: Comment /gcbrun
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.issues.createComment({
+              body: '/gcbrun',
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number
+            });
+
+      - name: Remove PR Label
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                name: 'evals: run',
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number
+              });
+            } catch (e) {
+              console.log('Failed to remove label. Another job may have already removed it!');
+            }

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -401,11 +401,8 @@ To cover a new prebuilt config:
 Evals call real models against live infrastructure, so they are neither free nor
 deterministic, and they are not part of the pull request gate. Like integration
 tests, they need credentials a contributor's pull request cannot supply, so a
-maintainer runs them; an evalset that has not been run is not a blocker.
-
-A maintainer can start a run on a pull request with the `evals: run` label. Only
-the prebuilt configs the pull request touched are evaluated; the rest of the
-matrix is skipped.
+maintainer runs them with the `evals: run` label; an evalset that has not been
+run is not a blocker.
 
 To run them yourself, follow EvalBench's own setup, then copy `evals/` into your
 EvalBench checkout and start the run from there — it resolves the paths in

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -394,12 +394,18 @@ To cover a new prebuilt config:
   config's `TOOLBOX_PREBUILT`, `EVAL_DATASET`, and connection settings.
   `EVAL_ENV_PREFIX` names the prefix those settings share, which is how
   [run_evals.sh](.ci/run_evals.sh) knows which ones to require. Set
-  `EVAL_HARNESSES` to run more than the default harness.
+  `EVAL_HARNESSES` to run more than the default harness, and
+  `EVAL_CHANGED_PATTERN` to the paths that should put the step in scope on a
+  pull request.
 
 Evals call real models against live infrastructure, so they are neither free nor
 deterministic, and they are not part of the pull request gate. Like integration
 tests, they need credentials a contributor's pull request cannot supply, so a
 maintainer runs them; an evalset that has not been run is not a blocker.
+
+A maintainer can start a run on a pull request with the `evals: run` label. Only
+the prebuilt configs the pull request touched are evaluated; the rest of the
+matrix is skipped.
 
 To run them yourself, follow EvalBench's own setup, then copy `evals/` into your
 EvalBench checkout and start the run from there — it resolves the paths in

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -394,9 +394,9 @@ To cover a new prebuilt config:
   config's `TOOLBOX_PREBUILT`, `EVAL_DATASET`, and connection settings.
   `EVAL_ENV_PREFIX` names the prefix those settings share, which is how
   [run_evals.sh](.ci/run_evals.sh) knows which ones to require. Set
-  `EVAL_HARNESSES` to run more than the default harness, and
-  `EVAL_CHANGED_PATTERN` to the paths that should put the step in scope on a
-  pull request.
+  `EVAL_HARNESSES` to run more than the default harness. On a pull request the
+  step runs when its evalset or its prebuilt config changed; both paths are
+  derived from the settings above, so there is nothing else to configure.
 
 Evals call real models against live infrastructure, so they are neither free nor
 deterministic, and they are not part of the pull request gate. Like integration

--- a/evals/run_configs/toolbox.yaml
+++ b/evals/run_configs/toolbox.yaml
@@ -20,7 +20,7 @@ dataset_config: !ENV ${EVAL_DATASET}
 dataset_format: gemini-cli-format
 
 # Viewer labels only; nothing reads them for scoring.
-eval_group: mcp-toolbox
+eval_group: !ENV ${EVAL_GROUP}
 product_name: !ENV ${TOOLBOX_PREBUILT}
 
 # Orchestrator Configs

--- a/maintainer-playbook.md
+++ b/maintainer-playbook.md
@@ -192,7 +192,9 @@ label is removed once the build starts, so apply it again to re-run after a new
 commit.
 
 Unlike a docs preview, a run compiles and executes the PR's code against live
-test infrastructure — review the diff first on anything from a fork.
+test infrastructure — review the diff first on anything from a fork. Labelling
+works by commenting `/gcbrun`, which on a fork PR also releases the integration
+test triggers that were waiting on it.
 
 See [Adding Prebuilt Config Evals](./DEVELOPER.md#adding-prebuilt-config-evals)
 for what the evalsets cover.

--- a/maintainer-playbook.md
+++ b/maintainer-playbook.md
@@ -184,15 +184,15 @@ for security reasons, so a maintainer must deploy the preview:
 #### Running Prebuilt Config Evals
 
 Evals are not part of the pull request gate — they call real models against live
-databases, so they run on a schedule and otherwise on request. Run them on a PR
-that changes a prebuilt config, its evalset, or the eval CI itself:
+databases, so they run on a schedule and otherwise on request.
 
-1. **Inspect Changes:** A run builds and executes the PR's code against live
-   test infrastructure, so review the diff first — especially anything under
-   `.ci/` or `.github/workflows/`.
-1. **Run Evals:** Apply the `evals: run` label. Only the prebuilt configs the PR
-   touched are evaluated; the rest skip. The label is removed once the build
-   starts, so apply it again to re-run after a new commit.
+Apply the `evals: run` label to a PR that changes a prebuilt config, its
+evalset, or the eval CI. Only the configs that PR touched are evaluated. The
+label is removed once the build starts, so apply it again to re-run after a new
+commit.
+
+Unlike a docs preview, a run compiles and executes the PR's code against live
+test infrastructure — review the diff first on anything from a fork.
 
 See [Adding Prebuilt Config Evals](./DEVELOPER.md#adding-prebuilt-config-evals)
 for what the evalsets cover.

--- a/maintainer-playbook.md
+++ b/maintainer-playbook.md
@@ -181,6 +181,22 @@ for security reasons, so a maintainer must deploy the preview:
 1. **Deploy Preview:** Apply the `docs: deploy-preview` label to the PR to
    deploy a documentation preview.
 
+#### Running Prebuilt Config Evals
+
+Evals are not part of the pull request gate — they call real models against live
+databases, so they run on a schedule and otherwise on request. Run them on a PR
+that changes a prebuilt config, its evalset, or the eval CI itself:
+
+1. **Inspect Changes:** A run builds and executes the PR's code against live
+   test infrastructure, so review the diff first — especially anything under
+   `.ci/` or `.github/workflows/`.
+1. **Run Evals:** Apply the `evals: run` label. Only the prebuilt configs the PR
+   touched are evaluated; the rest skip. The label is removed once the build
+   starts, so apply it again to re-run after a new commit.
+
+See [Adding Prebuilt Config Evals](./DEVELOPER.md#adding-prebuilt-config-evals)
+for what the evalsets cover.
+
 ### Release Communication & Tracking
 
 > For release mechanics — release types, the version-cut steps, supported binaries, and npm/PyPI publishing — see [Releasing](#releasing).

--- a/skills/maintainer/review-prs/SKILL.md
+++ b/skills/maintainer/review-prs/SKILL.md
@@ -129,6 +129,9 @@ Skip a dimension when it doesn't apply: say so, don't invent a finding.
   documentation: could an agent pick this tool and fill its parameters from that text alone, at a
   token cost worth paying? Flag ones that restate the field name, omit units/format/allowed
   values, or run long without adding information.
+  - *Evals measure exactly this.* For a PR editing `internal/prebuiltconfigs/tools/<config>.yaml`,
+    note that the next step is a maintainer applying the `evals: run` label, which scopes the run
+    to the configs that PR touched. Like integration tests, un-run evals aren't a blocker.
 - **Tests.** New logic or a bug fix needs tests; missing them is usually request-changes.
   - *Coverage:* happy path, edge cases, and for a fix, a test that fails without it. A new
     source/tool follows the unit + integration pattern and is wired into
@@ -143,10 +146,6 @@ Skip a dimension when it doesn't apply: say so, don't invent a finding.
   - *Un-run integration tests aren't a blocker.* They need GCP credentials an external
     contributor's PR can't trigger, so green CI doesn't mean they ran. Note that the next step is
     a maintainer running them via the `tests: run` label or a `/gcbrun` comment.
-- **Evals (prebuilt configs).** A PR editing `internal/prebuiltconfigs/tools/<config>.yaml` changes
-  what an agent sees, and tool/parameter description wording is exactly what evals measure. Note
-  that the next step is a maintainer applying the `evals: run` label, which scopes the run to the
-  configs that PR touched. Not a blocker — evals are not part of the pull request gate.
 - **Docs.** Changes to how a user configures or interacts with MCP toolbox need matching updates
   under `docs/en/`. New sources/tools have CI-enforced page structure per `DEVELOPER.md`, enforced by
   `.ci/lint-docs-*.sh`. A violation breaks the build, so it's blocking.

--- a/skills/maintainer/review-prs/SKILL.md
+++ b/skills/maintainer/review-prs/SKILL.md
@@ -143,6 +143,10 @@ Skip a dimension when it doesn't apply: say so, don't invent a finding.
   - *Un-run integration tests aren't a blocker.* They need GCP credentials an external
     contributor's PR can't trigger, so green CI doesn't mean they ran. Note that the next step is
     a maintainer running them via the `tests: run` label or a `/gcbrun` comment.
+- **Evals (prebuilt configs).** A PR editing `internal/prebuiltconfigs/tools/<config>.yaml` changes
+  what an agent sees, and tool/parameter description wording is exactly what evals measure. Note
+  that the next step is a maintainer applying the `evals: run` label, which scopes the run to the
+  configs that PR touched. Not a blocker — evals are not part of the pull request gate.
 - **Docs.** Changes to how a user configures or interacts with MCP toolbox need matching updates
   under `docs/en/`. New sources/tools have CI-enforced page structure per `DEVELOPER.md`, enforced by
   `.ci/lint-docs-*.sh`. A violation breaks the build, so it's blocking.


### PR DESCRIPTION
## Description

Lets maintainers run the prebuilt config evals on a pull request, instead of
only on the schedule.

A maintainer applies the `evals: run` label and
`.github/workflows/evals_trigger.yml` comments `/gcbrun`, a comment being Cloud
Build's only pull request gate. The workflow posts the comment and nothing
else; it never checks out pull request code. The label is removed afterwards,
so a re-run needs a fresh label.

A `detect-changes` step then narrows the run to the databases the pull request
actually touched. Each step declares the paths it owns and skips green when
none of them changed; paths affecting every database live once in
`EVAL_COMMON_PATTERN`. On the scheduled run the diff is empty, so a fallback
path matches every step and the full matrix still runs.

`eval_group` becomes a substitution, so pull request results are tagged
separately and stay out of the scheduled accuracy trend.

Also bumps the `_CLAUDE_MODEL` substitution to `claude-opus-4-8`.

Documented for maintainers in `maintainer-playbook.md`, with the new per-step
`EVAL_CHANGED_PATTERN` in `DEVELOPER.md`.

CI configuration and docs only, no Toolbox source code is changed.

## PR Checklist
- [x] Make sure you reviewed
  [CONTRIBUTING.md](https://github.com/googleapis/mcp-toolbox/blob/main/CONTRIBUTING.md)
- [ ] Make sure to open an issue as a
  [bug/issue](https://github.com/googleapis/mcp-toolbox/issues/new/choose)
  before writing your code! That way we can discuss the change, evaluate
  designs, and agree on the general idea
- [x] Ensure you have manually reviewed the entire diff before requesting a
  review
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
- [x] Make sure to add `!` if this involve a breaking change
