### PR TITLE
fix(postgres): filter background processes in postgres-list-active-queries

### DIFF
--- a/internal/tools/postgres/postgreslistactivequeries/postgreslistactivequeries.go
+++ b/internal/tools/postgres/postgreslistactivequeries/postgreslistactivequeries.go
@@ -46,6 +46,7 @@ const listActiveQueriesStatement = `
         query
     FROM pg_stat_activity
     WHERE state = 'active'
+        AND backend_type = 'client backend'
         AND ($1::INTERVAL IS NULL OR now() - query_start >= $1::INTERVAL)
         AND ($2::text IS NULL OR application_name NOT IN (SELECT trim(app) FROM unnest(string_to_array($2, ',')) AS app))
     ORDER BY query_duration DESC


### PR DESCRIPTION
## Description
This PR updates the `postgres-list-active-queries` tool statement to filter out internal PostgreSQL/AlloyDB system background processes by adding `AND backend_type = 'client backend'` to the `pg_stat_activity` query.

## Context
* Following the upgrade of our shared AlloyDB test instance from PG 15 to PG 17 ([screenshot](https://screenshot-v2.corp.google.com/3vi4uot403tmg)), AlloyDB's continuous replication streaming worker remained continuously active in `pg_stat_activity`.
* Because `postgres-list-active-queries` queries `pg_stat_activity WHERE state = 'active'` without filtering for client connections, this internal background worker was returned alongside user queries, causing `TestAlloyDBPgToolEndpoints/invoke_list_active_queries_when_the_system_is_idle` to fail on the idle check.
* When users run `postgres-list-active-queries`, they expect to see queries initiated by client applications/users, not internal database infrastructure workers.
* Adding `backend_type = 'client backend'` is the standard PostgreSQL mechanism (supported across PG 10+) to isolate user/client sessions from engine background processes.

## Changes
* Added `AND backend_type = 'client backend'` in `internal/tools/postgres/postgreslistactivequeries/postgreslistactivequeries.go`.
