### PR TITLE
test(bigtable): disable tests due to quota limit

### DIFF
--- a/.ci/integration.cloudbuild.yaml
+++ b/.ci/integration.cloudbuild.yaml
@@ -264,6 +264,7 @@ steps:
       - "BIGTABLE_PROJECT=$PROJECT_ID"
       - "BIGTABLE_INSTANCE=$_BIGTABLE_INSTANCE"
       - "SERVICE_ACCOUNT_EMAIL=$SERVICE_ACCOUNT_EMAIL"
+      - "COVERAGE_THRESHOLD=40"
     secretEnv: ["CLIENT_ID"]
     volumes:
       - name: "go"

--- a/.ci/integration.cloudbuild.yaml
+++ b/.ci/integration.cloudbuild.yaml
@@ -255,35 +255,34 @@ steps:
           exit 0
         fi
 
-  - id: "bigtable"
-    name: golang:1
-    waitFor: ["compile-test-binary", "detect-changes"]
-    entrypoint: /bin/bash
-    env:
-      - "GOPATH=/gopath"
-      - "BIGTABLE_PROJECT=$PROJECT_ID"
-      - "BIGTABLE_INSTANCE=$_BIGTABLE_INSTANCE"
-      - "SERVICE_ACCOUNT_EMAIL=$SERVICE_ACCOUNT_EMAIL"
-      - "COVERAGE_THRESHOLD=40"
-    secretEnv: ["CLIENT_ID"]
-    volumes:
-      - name: "go"
-        path: "/gopath"
-    args:
-      - -c
-      - |
-        PATTERN="(^|/)bigtable/|$$(cat .ci/core_pattern.txt)"
-
-        if grep -qE "$$PATTERN" /workspace/changed_files.txt; then
-          echo "Changes detected. Running Bigtable tests..."
-          .ci/test_with_coverage.sh \
-            "Bigtable" \
-            bigtable \
-            bigtable
-        else
-          echo "No relevant changes for Bigtable. Skipping shard."
-          exit 0
-        fi
+  # - id: "bigtable"
+  #   name: golang:1
+  #   waitFor: ["compile-test-binary", "detect-changes"]
+  #   entrypoint: /bin/bash
+  #   env:
+  #     - "GOPATH=/gopath"
+  #     - "BIGTABLE_PROJECT=$PROJECT_ID"
+  #     - "BIGTABLE_INSTANCE=$_BIGTABLE_INSTANCE"
+  #     - "SERVICE_ACCOUNT_EMAIL=$SERVICE_ACCOUNT_EMAIL"
+  #   secretEnv: ["CLIENT_ID"]
+  #   volumes:
+  #     - name: "go"
+  #       path: "/gopath"
+  #   args:
+  #     - -c
+  #     - |
+  #       PATTERN="(^|/)bigtable/|$$(cat .ci/core_pattern.txt)"
+  #
+  #       if grep -qE "$$PATTERN" /workspace/changed_files.txt; then
+  #         echo "Changes detected. Running Bigtable tests..."
+  #         .ci/test_with_coverage.sh \
+  #           "Bigtable" \
+  #           bigtable \
+  #           bigtable
+  #       else
+  #         echo "No relevant changes for Bigtable. Skipping shard."
+  #         exit 0
+  #       fi
 
   - id: "bigquery"
     name: golang:1

--- a/tests/bigtable/bigtable_integration_test.go
+++ b/tests/bigtable/bigtable_integration_test.go
@@ -151,7 +151,8 @@ func TestBigtableToolEndpoints(t *testing.T) {
 	)
 	tests.RunMCPToolCallMethod(t, mcpMyFailToolWant, mcpSelect1Want)
 	runBigTableAdminToolsGetTest(t)
-	runBigTableAdminToolsTest(t, sourceConfig["instance"].(string))
+	// TODO: re-enable once GCP write quota issues are resolved.
+	// runBigTableAdminToolsTest(t, sourceConfig["instance"].(string))
 	tests.RunToolInvokeWithTemplateParameters(t, tableNameTemplateParam,
 		tests.WithNameFieldArray(nameFieldArray),
 		tests.WithNameColFilter(nameColFilter),

--- a/tests/bigtable/bigtable_integration_test.go
+++ b/tests/bigtable/bigtable_integration_test.go
@@ -18,10 +18,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
-	"encoding/json"
 	"fmt"
 	"log"
-	"net/http"
 	"os"
 	"regexp"
 	"slices"
@@ -343,6 +341,7 @@ func addTemplateParamConfig(t *testing.T, config map[string]any) map[string]any 
 	return config
 }
 
+/*
 // assertMCPSuccess invokes an MCP tool and strictly asserts that the HTTP status is 200,
 // no JSON-RPC error is returned, and Result.IsError is false.
 func assertMCPSuccess(t *testing.T, toolName string, args map[string]any) *tests.MCPCallToolResponse {
@@ -409,7 +408,6 @@ func runBigTableAdminToolsTest(t *testing.T, instanceId string) {
 		t.Fatalf("bigtable-get-cluster unexpected output: %v", getClusterResp.Result.Content)
 	}
 
-	/* TEMPORARILY DISABLED DUE TO GCP QUOTA LIMITS (project_number:107716898620)
 	// Create test instance for lifecycle tools (createinstance, updateinstance, updatecluster, createcluster, deletecluster, deleteinstance)
 	testInstId := "testi-" + uniqueID[:8]
 	testClusterId1 := "testc1-" + uniqueID[:8]
@@ -471,7 +469,6 @@ func runBigTableAdminToolsTest(t *testing.T, instanceId string) {
 	if len(deleteClusterResp.Result.Content) == 0 || !strings.Contains(deleteClusterResp.Result.Content[0].Text, "cluster deleted successfully") {
 		t.Fatalf("bigtable-delete-cluster unexpected output: %v", deleteClusterResp.Result.Content)
 	}
-	*/
 
 	// Create table
 	createTableResp := assertMCPSuccess(t, "bigtable-create-table", map[string]any{
@@ -659,6 +656,7 @@ func runBigTableAdminToolsTest(t *testing.T, instanceId string) {
 		t.Fatalf("bigtable-list-materialized-views returned nil content")
 	}
 }
+*/
 
 func addBigTableAdminToolsConfig(t *testing.T, config map[string]any) map[string]any {
 	toolsMap, ok := config["tools"].(map[string]any)


### PR DESCRIPTION
Bigtable write quota exceeded on the testing project. Temporarily disable Bigtable tests before fixing the quota issue.