### PR TITLE
docs(sdks): document secure parameters support and usage across Client SDKs

### DIFF
--- a/docs/en/documentation/configuration/tools/_index.md
+++ b/docs/en/documentation/configuration/tools/_index.md
@@ -89,6 +89,7 @@ parameters:
 | escape         |     string     |    false     | Only available for type `string`. Indicate the escaping delimiters used for the parameter. This field is intended to be used with templateParameters. Must be one of "single-quotes", "double-quotes", "backticks", "square-brackets". |
 | minValue       |  int or float  |    false     | Only available for type `integer` and `float`. Indicate the minimum value allowed.                                                                                                                                                     |
 | maxValue       |  int or float  |    false     | Only available for type `integer` and `float`. Indicate the maximum value allowed.                                                                                                                                                     |
+| secure         |      bool      |    false     | When `true`, marks the parameter as secure (sensitive application parameter supplied out-of-band; isolated from LLM context). Secure parameters cannot have `default`, `authServices`, or `required: false`. Requires protocol version `2026-07-28` and the `com.google.cloud/toolbox.v1` extension. Defaults to `false`. |
 
 ### Optional Parameters
 
@@ -234,7 +235,9 @@ parameters:
 
 Secure parameters are designed for sensitive runtime context (such as an end-user `customer_id`, tenant identifier, or session token) that **AI agents (LLMs) should not control or see** and that should not be transmitted in plain text through prompt completion requests, model context windows, or standard server logs.
 
-> **Note:** Secure parameters should be used for client-supplied runtime values (such as `customer_id` or end-user context). Database credentials (such as service account passwords or API keys) should be configured directly in the Data Source configuration rather than passed as per-request tool parameters.
+{{< notice note >}}
+Secure parameters should be used for client-supplied runtime values (such as `customer_id` or end-user context). Database credentials (such as service account passwords or API keys) should be configured directly in the Data Source configuration rather than passed as per-request tool parameters.
+{{< /notice >}}
 
 To configure a parameter as secure, set the `secure` field to `true` in your tool's parameter definition:
 
@@ -244,30 +247,154 @@ name: search_secure_data
 type: postgres-sql
 source: my-pg-instance
 statement: |
-  SELECT * FROM sessions WHERE customer_id = $1
+  SELECT * FROM sessions WHERE customer_id = $1 AND session_token = $2
 parameters:
   - name: customer_id
     type: string
     description: Sensitive customer identifier supplied out-of-band by the calling application
     secure: true
+  - name: session_token
+    type: string
+    description: Sensitive session token supplied out-of-band by the calling application
+    secure: true
 ```
 
-When a parameter is marked as `secure: true`, it will not be presented to the agent as a configurable parameter. Instead, it relies on the application to set the parameter. If an application fails to set the parameter before the tool is called, execution returns a tool error indicating that the required parameter was not provided.
+#### How Secure Parameters Work
 
-> **Note:** Secure parameters are always required and cannot be optional. A parameter cannot have `secure: true` alongside `authServices`, `default`, or `required: false`.
+When a parameter is marked as `secure: true`:
 
-Here is how you set a secure parameter with the Toolbox Python SDK:
+1. **LLM Schema Isolation:** The parameter is published in `secureInputSchema` rather than `inputSchema` in the MCP manifest (`tools/list`). Toolbox SDKs and frameworks automatically strip it from public tool signatures, docstrings, and function declarations (such as Gemini declarations in ADK or parameter schemas in LangChain, LlamaIndex, and Genkit). The LLM never sees, requests, or hallucinates the parameter.
+2. **Out-of-Band Wire Transmission:** The host application binds the value in code. When the tool is executed, the parameter is transmitted out-of-band in the dedicated `secureArguments` field of the MCP `tools/call` JSON-RPC request, completely isolated from model `arguments`.
+3. **Fail-Closed Security & Prompt Injection Defense:**
+   * **Client SDK Fast-Fail:** Toolbox SDKs validate locally that all required secure parameters are bound before sending any request over the wire, raising an immediate client-side error if any are missing.
+   * **Prompt Injection Defense:** If a prompt-injected LLM or malicious client attempts to supply a secure parameter in standard `arguments`, the server detects the parameter collision and returns a tool execution error (`isError: true`), preventing the model from overriding secure values.
+   * **Protocol Enforcement:** If standard parameters are passed in `secureArguments` or required secure parameters are missing, the server rejects the request with a JSON-RPC protocol error (`-32602` `INVALID_PARAMS`). If an un-negotiated client attempts to invoke a secure tool directly, the server rejects the call with JSON-RPC error `-32021` (or `-32602` `INVALID_PARAMS` on protocol versions prior to `2026-07-28` where secure tools are completely hidden).
+   * **Dedicated APIs & Mutual Exclusivity:** SDKs provide dedicated methods (`bind_secure_param` / `bindSecureParam` / `WithBindSecureParam*`) that cannot be cross-mixed with regular parameter binding methods (`bind_param` / `bindParam` / `WithBindParam*`), throwing clear guidance errors if mismatched.
 
-```python
-# Pass secure_params when loading or calling a tool via the Python SDK
-auth_tool = await toolbox.load_tool(
+{{< notice note >}}
+Secure parameters are always required and cannot be optional. A parameter cannot have `secure: true` alongside `authServices`, `default`, or `required: false`.
+{{< /notice >}}
+
+#### SDK Usage Examples
+
+Below is how you bind secure parameters across our official SDKs:
+
+{{< tabpane persist=header >}}
+{{< tab header="Python" lang="python" >}}
+from toolbox_core import ToolboxClient
+
+async with ToolboxClient("http://127.0.0.1:5000") as toolbox:
+    # Option A: Bind when loading tool or toolset
+    bound_tool = await toolbox.load_tool(
+        "search_secure_data",
+        secure_params={"customer_id": "cust_12345", "session_token": "token-xyz"}
+    )
+    tools = await toolbox.load_toolset(
+        "my-toolset",
+        secure_params={"customer_id": "cust_12345"}
+    )
+
+    # Option B: Bind on an un-bound loaded tool (returns a new immutable tool instance)
+    raw_tool = await toolbox.load_tool("search_secure_data")
+    single_bound = raw_tool.bind_secure_param("customer_id", "cust_12345")
+    multi_bound = raw_tool.bind_secure_params({
+        "customer_id": "cust_12345",
+        "session_token": "token-xyz",
+    })
+
+    # Option C: Dynamic callable (evaluated per invocation)
+    dynamic_tool = raw_tool.bind_secure_param("customer_id", lambda: get_current_user_id())
+
+    # Execute tool (LLM only supplies standard arguments, secure parameters attached automatically)
+    result = await multi_bound()
+{{< /tab >}}
+{{< tab header="JavaScript / TypeScript" lang="javascript" >}}
+import { ToolboxClient } from '@toolbox-sdk/core';
+
+const client = new ToolboxClient("http://127.0.0.1:5000");
+
+// Option A: Pre-bind when loading tool or toolset
+const boundTool = await client.loadTool(
     "search_secure_data",
-    secure_params={"customer_id": "cust_12345"}
-)
-result = await auth_tool()
-```
+    null, // authTokenGetters
+    null, // boundParams
+    { customer_id: "cust_12345", session_token: "token-xyz" } // secureParams
+);
+const tools = await client.loadToolset(
+    "my-toolset",
+    null, // authTokenGetters
+    null, // boundParams
+    false, // strict (set to true to error if any tool lacks the bound params)
+    { customer_id: "cust_12345" } // secureParams
+);
 
-> **Note:** Secure parameters require MCP protocol version `2026-07-28` and the `com.google.cloud/toolbox.v1` extension. For more details on extension capabilities and client requirements, see the [Extension README](https://github.com/googleapis/mcp-toolbox/blob/main/extensions/2026-07-28/README.md).
+// Option B: Bind on an un-bound loaded tool (returns a new immutable tool instance)
+const rawTool = await client.loadTool("search_secure_data");
+const singleBound = rawTool.bindSecureParam("customer_id", "cust_12345");
+const multiBound = rawTool.bindSecureParams({
+    customer_id: "cust_12345",
+    session_token: "token-xyz",
+});
+
+// Option C: Dynamic function (evaluated per invocation)
+const dynamicTool = rawTool.bindSecureParam("customer_id", async () => getCurrentUserId());
+
+// Execute tool
+const result = await multiBound();
+{{< /tab >}}
+{{< tab header="Go" lang="go" >}}
+import (
+    "context"
+    "github.com/googleapis/mcp-toolbox-sdk-go/core"
+)
+
+ctx := context.Background()
+client, err := core.NewToolboxClient("http://127.0.0.1:5000")
+
+// Option A: Bind when loading tool or toolset
+boundTool, err := client.LoadTool("search_secure_data", ctx,
+    core.WithBindSecureParamString("customer_id", "cust_12345"),
+    core.WithBindSecureParamString("session_token", "token-xyz"),
+)
+tools, err := client.LoadToolset("my-toolset", ctx,
+    core.WithBindSecureParamString("customer_id", "cust_12345"),
+)
+
+// Option B: Set client-level defaults across all tools loaded by the client
+clientWithDefaults, err := core.NewToolboxClient("http://127.0.0.1:5000",
+    core.WithDefaultToolOptions(
+        core.WithBindSecureParamString("customer_id", "cust_12345"),
+    ),
+)
+
+// Option C: Bind on an un-bound loaded tool (returns a new immutable tool instance)
+rawTool, err := client.LoadTool("search_secure_data", ctx)
+postBoundTool, err := rawTool.ToolFrom(
+    core.WithBindSecureParamString("customer_id", "cust_12345"),
+    core.WithBindSecureParamString("session_token", "token-xyz"),
+)
+
+// Option D: Dynamic function (evaluated per invocation)
+dynamicTool, err := rawTool.ToolFrom(
+    core.WithBindSecureParamStringFunc("customer_id", func() (string, error) {
+        return getCurrentUserID(), nil
+    }),
+    core.WithBindSecureParamString("session_token", "token-xyz"),
+)
+
+// Execute tool
+result, err := boundTool.Invoke(ctx, map[string]any{})
+{{< /tab >}}
+{{< /tabpane >}}
+
+{{< notice note >}}
+Secure parameters require MCP protocol version `2026-07-28` and the `com.google.cloud/toolbox.v1` extension. For more details on extension capabilities and client requirements, see the [Extension README](https://github.com/googleapis/mcp-toolbox/blob/main/extensions/2026-07-28/README.md).
+
+For in-depth framework integration guides, see:
+* [Python SDK Secure Parameters](../../connect-to/toolbox-sdks/python-sdk/core/index.md#secure-parameters) ([ADK](../../connect-to/toolbox-sdks/python-sdk/adk/index.md#secure-parameters) | [LangChain](../../connect-to/toolbox-sdks/python-sdk/langchain/index.md#secure-parameters) | [LlamaIndex](../../connect-to/toolbox-sdks/python-sdk/llamaindex/index.md#secure-parameters))
+* [JavaScript / TypeScript SDK Secure Parameters](../../connect-to/toolbox-sdks/javascript-sdk/core/index.md#secure-parameters) ([ADK](../../connect-to/toolbox-sdks/javascript-sdk/adk/index.md#secure-parameters))
+* [Go SDK Secure Parameters](../../connect-to/toolbox-sdks/go-sdk/core/_index.md#secure-parameters) ([ADK](../../connect-to/toolbox-sdks/go-sdk/tbadk/_index.md#secure-parameters) | [Genkit](../../connect-to/toolbox-sdks/go-sdk/tbgenkit/_index.md#secure-parameters))
+{{< /notice >}}
 
 ### Authenticated Parameters
 

--- a/docs/en/documentation/connect-to/mcp-client/_index.md
+++ b/docs/en/documentation/connect-to/mcp-client/_index.md
@@ -26,6 +26,18 @@ Toolbox currently supports the following versions of MCP specification:
 * [2025-03-26](https://modelcontextprotocol.io/specification/2025-03-26)
 * [2024-11-05](https://modelcontextprotocol.io/specification/2024-11-05)
 
+### Secure Parameters and MCP Clients
+
+[Secure Parameters](../../configuration/tools/_index.md#secure-parameters) are supported on MCP protocol version `2026-07-28` or newer via the `com.google.cloud/toolbox.v1` extension.
+
+* **Extension Negotiation:** MCP clients declare support for this extension in `params._meta["io.modelcontextprotocol/clientCapabilities"].extensions["com.google.cloud/toolbox.v1"]`.
+* **Manifests (`tools/list`):** When negotiated, tools define application-controlled parameters under `secureInputSchema` alongside regular model parameters in `inputSchema`.
+* **Invocations (`tools/call`):** Secure parameters are passed out-of-band in `params.secureArguments`, while model-generated arguments are passed in `params.arguments`.
+* **Fallback for Generic MCP Clients:** Tools that require secure parameters are **automatically filtered out** from `tools/list` responses for clients that have not negotiated the `com.google.cloud/toolbox.v1` extension (or clients using protocol versions prior to `2026-07-28`). Attempting to call a secure tool directly without negotiated capability returns:
+  * On protocol `2026-07-28`: `MissingRequiredClientCapabilityError` (JSON-RPC code `-32021`).
+  * On protocol versions prior to `2026-07-28`: `ToolNotFoundError` / `INVALID_PARAMS` (JSON-RPC code `-32602`, "tool does not exist"), as secure tools are completely hidden from older protocols.
+* **Injection Defense:** If a client or model attempts to pass a secure parameter inside standard `arguments`, the server rejects the parameter and returns a tool execution error (`isError: true`).
+
 ### Toolbox AuthZ/AuthN Not Supported by MCP
 
 The auth implementation in Toolbox is not supported in MCP's auth specification.

--- a/docs/en/documentation/connect-to/toolbox-sdks/_index.md
+++ b/docs/en/documentation/connect-to/toolbox-sdks/_index.md
@@ -10,10 +10,20 @@ Our Toolbox Client SDKs provide the foundational building blocks for connecting 
 
 Whether you are writing a simple script to execute a single query or building a complex, multi-agent orchestration system, these SDKs handle the underlying Model Context Protocol (MCP) communication so you can focus on your business logic.
 
-By using our SDKs, your application can dynamically request tools, bind parameters, add authentication, and execute commands at runtime. We offer official support and deep framework integrations across three primary languages:
+By using our SDKs, your application can dynamically request tools, bind parameters, provide secure parameters out-of-band, add authentication, and execute commands at runtime. We offer official support and deep framework integrations across three primary languages:
 
 *   **[Python](./python-sdk/)**: Includes the Core SDK, along with native integrations for popular orchestrators like LangChain, LlamaIndex, and the ADK.
 *   **[JavaScript / TypeScript](./javascript-sdk/)**: Includes the Node.js Core SDK and integrations for the Agent Development Kit (ADK).
 *   **[Go](./go-sdk/)**: Includes the Core SDK, plus dedicated packages for building agents with Genkit (`tbgenkit`) and the ADK.
+
+## Secure Parameters Support Across SDKs
+
+[Secure Parameters](../../configuration/tools/_index.md#secure-parameters) enable developers to pass sensitive, application-controlled arguments (such as tenant IDs or session tokens) directly to tools out-of-band, completely isolated from LLM context and prompt injections.
+
+| Language / SDK | Packages | Minimum Package Version | Server Requirement |
+| :--- | :--- | :--- | :--- |
+| **[Python](./python-sdk/)** | `toolbox-core`, `toolbox-adk`, `toolbox-langchain`, `toolbox-llamaindex` | `>= 1.4.0` (`toolbox-llamaindex` `>= 0.9.0`) | MCP `2026-07-28` + `com.google.cloud/toolbox.v1` |
+| **[JavaScript / TypeScript](./javascript-sdk/)** | `@toolbox-sdk/core`, `@toolbox-sdk/adk` | `>= 1.2.0` | MCP `2026-07-28` + `com.google.cloud/toolbox.v1` |
+| **[Go](./go-sdk/)** | `core`, `tbadk`, `tbgenkit` | `core` / `tbadk` `>= v1.2.0`, `tbgenkit` `>= v0.10.0` | MCP `2026-07-28` + `com.google.cloud/toolbox.v1` |
 
 Select your preferred language to explore installation instructions, quickstart guides, and framework-specific implementations.

--- a/docs/en/documentation/connect-to/toolbox-sdks/go-sdk/_index.md
+++ b/docs/en/documentation/connect-to/toolbox-sdks/go-sdk/_index.md
@@ -16,10 +16,18 @@ The Go SDK act as clients for that service. They handle the communication needed
 * Fetch tool definitions from your running Toolbox instance.
 * Provide convenient Go structs representing those tools.
 * Invoke the tools (calling the underlying APIs/services configured in Toolbox).
-* Handle authentication and parameter binding as needed.
+* Handle authentication, parameter binding, and secure parameters as needed.
 
 By using the SDK, you can easily leverage your Toolbox-managed tools directly
 within your Go applications or AI orchestration frameworks.
+
+{{< notice note >}}
+[Secure parameters](../../../configuration/tools/_index.md#secure-parameters) are supported starting in:
+* `core` >= `v1.2.0`
+* `tbadk` >= `v1.2.0`
+* `tbgenkit` >= `v0.10.0`
+* Server requirement: MCP protocol version `2026-07-28` or newer with the `com.google.cloud/toolbox.v1` extension.
+{{< /notice >}}
 
 <a class="btn btn-primary" href="https://go.mcp-toolbox.dev" role="button"><i class="fa-brands fa-golang"></i> Go API Reference</a>
 

--- a/docs/en/documentation/connect-to/toolbox-sdks/go-sdk/core/_index.md
+++ b/docs/en/documentation/connect-to/toolbox-sdks/go-sdk/core/_index.md
@@ -529,6 +529,111 @@ dynamicBoundTool, err := tool.ToolFrom(core.WithBindParamStringFunc("param", get
 
 {{< notice info >}} You don't need to modify tool configurations to bind parameter values. {{< /notice >}}
 
+## Secure Parameters
+
+{{< notice note >}}
+Secure parameters are supported starting in [`github.com/googleapis/mcp-toolbox-sdk-go/core`](https://github.com/googleapis/mcp-toolbox-sdk-go/tree/main/core) version `v1.2.0` and require MCP [protocol version `2026-07-28`](#supported-protocols) or newer with the [`com.google.cloud/toolbox.v1` extension](https://github.com/googleapis/mcp-toolbox/blob/main/extensions/2026-07-28/README.md). For server configuration details, see [Secure Parameters](../../../../configuration/tools/_index.md#secure-parameters).
+{{< /notice >}}
+
+Secure parameters are designed for sensitive runtime context (such as an end-user `customer_id`, tenant identifier, or secret tokens) that LLMs must not see, control, or hallucinate.
+
+Unlike standard parameters, parameters marked as `secure: true` in your Toolbox server configuration:
+* **Schema Isolation:** The SDK completely strips secure parameters from the public tool declaration and parameter schemas (`tool.Parameters()` and `tool.InputSchema()`). Unbound secure parameters can be inspected separately via `tool.SecureParameters()`. The LLM is never aware of these parameters, keeping your model's context window clean and preventing credential exposure.
+* **Prompt Injection Defense:** If a model or caller attempts to provide a value for a secure parameter in standard arguments, the SDK rejects execution immediately.
+* **Fast-Fail Validation:** The SDK verifies all required secure parameters locally before sending a request over the wire. If any required secure parameter is missing, execution fails immediately.
+* **Wire Protocol Separation:** Secure parameters are transmitted out-of-band in the `secureArguments` field of the MCP 2026-07-28 `tools/call` JSON-RPC payload, isolated from regular arguments.
+
+### Option A: Add Default Secure Parameters to a Client
+
+You can set default secure parameters at the client level. Every tool or toolset loaded by the client inherits these bindings:
+
+```go
+ctx := context.Background()
+
+client, err := core.NewToolboxClient("http://127.0.0.1:5000",
+    core.WithDefaultToolOptions(
+        core.WithBindSecureParamString("customer_id", "cust_12345"),
+    ),
+)
+
+tool, err := client.LoadTool("search_secure_data", ctx)
+```
+
+### Option B: Binding Secure Parameters to a Loaded Tool
+
+Bind secure values to a tool object *after* it has been loaded. Each method returns a **new, immutable tool instance**, leaving the original unmodified.
+
+```go
+client, err := core.NewToolboxClient("http://127.0.0.1:5000")
+tool, err := client.LoadTool("search_secure_data", ctx)
+
+// Using ToolFrom with type-safe functional options
+boundTool, err := tool.ToolFrom(
+    core.WithBindSecureParamString("customer_id", "cust_12345"),
+    core.WithBindSecureParamString("session_token", "token-xyz"),
+)
+```
+
+### Option C: Binding Secure Parameters While Loading Tools
+
+Specify secure parameters directly when loading tools. This applies the binding only to the tools loaded in that specific call:
+
+```go
+// Load a single tool with secure parameters
+boundTool, err := client.LoadTool("search_secure_data", ctx,
+    core.WithBindSecureParamString("customer_id", "cust_12345"),
+)
+
+// Load an entire toolset with secure parameters
+boundTools, err := client.LoadToolset("my-toolset", ctx,
+    core.WithBindSecureParamString("customer_id", "cust_12345"),
+)
+```
+
+### Binding Dynamic Secure Values
+
+You can also bind a secure parameter to a function that is evaluated dynamically each time the tool is invoked:
+
+```go
+getDynamicToken := func() (string, error) {
+    return "dynamic-session-token-xyz", nil
+}
+
+dynamicBoundTool, err := tool.ToolFrom(
+    core.WithBindSecureParamStringFunc("auth_token", getDynamicToken),
+)
+```
+
+### Supported Type-Safe Option Helpers
+
+The Go SDK provides type-safe options for static values and dynamic getter functions across scalars, slices, and maps:
+
+| Category | Type | Static Option | Dynamic Function Option |
+| :--- | :--- | :--- | :--- |
+| **Scalars** | `string` | `core.WithBindSecureParamString(name, val)` | `core.WithBindSecureParamStringFunc(name, fn)` |
+| | `T` (`Integer`) | `core.WithBindSecureParamInt[T](name, val)` | `core.WithBindSecureParamIntFunc[T](name, fn)` |
+| | `T` (`Float`) | `core.WithBindSecureParamFloat[T](name, val)` | `core.WithBindSecureParamFloatFunc[T](name, fn)` |
+| | `bool` | `core.WithBindSecureParamBool(name, val)` | `core.WithBindSecureParamBoolFunc(name, fn)` |
+| **Slices** | `[]string` | `core.WithBindSecureParamStringArray(name, val)` | `core.WithBindSecureParamStringArrayFunc(name, fn)` |
+| | `[]T` (`Integer`) | `core.WithBindSecureParamIntArray[T](name, val)` | `core.WithBindSecureParamIntArrayFunc[T](name, fn)` |
+| | `[]T` (`Float`) | `core.WithBindSecureParamFloatArray[T](name, val)` | `core.WithBindSecureParamFloatArrayFunc[T](name, fn)` |
+| | `[]bool` | `core.WithBindSecureParamBoolArray(name, val)` | `core.WithBindSecureParamBoolArrayFunc(name, fn)` |
+| **Maps** | `map[string]string` | `core.WithBindSecureParamStringMap(name, val)` | `core.WithBindSecureParamStringMapFunc(name, fn)` |
+| | `map[string]T` (`Integer`) | `core.WithBindSecureParamIntMap[T](name, val)` | `core.WithBindSecureParamIntMapFunc[T](name, fn)` |
+| | `map[string]T` (`Float`) | `core.WithBindSecureParamFloatMap[T](name, val)` | `core.WithBindSecureParamFloatMapFunc[T](name, fn)` |
+| | `map[string]bool` | `core.WithBindSecureParamBoolMap(name, val)` | `core.WithBindSecureParamBoolMapFunc(name, fn)` |
+| | `map[string]any` | `core.WithBindSecureParamAnyMap(name, val)` | `core.WithBindSecureParamAnyMapFunc(name, fn)` |
+
+### Cross-Binding Guidance & Mutual Exclusivity
+
+To prevent accidental parameter leakage and enforce strict separation between model parameters and application parameters:
+
+* Passing `core.WithBindParam*` for a parameter configured with `secure: true` returns an error:  
+  `parameter "<name>" is a secure parameter; use WithBindSecureParam* instead`
+* Passing `core.WithBindSecureParam*` for a regular parameter returns an error:  
+  `parameter "<name>" is a regular parameter; use WithBindParam* instead`
+
+
 ## Default Parameters
 
 Tools defined in the MCP Toolbox server can specify default values for their optional parameters. When invoking a tool using the SDK, if an input for a parameter with a default value is not provided, the SDK will automatically populate the request with the default value.

--- a/docs/en/documentation/connect-to/toolbox-sdks/go-sdk/tbadk/_index.md
+++ b/docs/en/documentation/connect-to/toolbox-sdks/go-sdk/tbadk/_index.md
@@ -526,6 +526,65 @@ dynamicBoundTool, err := tool.ToolFrom(core.WithBindParamStringFunc("param", get
 You don't need to modify tool configurations to bind parameter values.
 {{< /notice >}}
 
+## Secure Parameters
+
+{{< notice note >}}
+Secure parameters are supported starting in [`github.com/googleapis/mcp-toolbox-sdk-go/tbadk`](https://github.com/googleapis/mcp-toolbox-sdk-go/tree/main/tbadk) version `v1.2.0` (with `core` >= `v1.2.0`) and require MCP [protocol version `2026-07-28`](#supported-protocols) or newer with the [`com.google.cloud/toolbox.v1` extension](https://github.com/googleapis/mcp-toolbox/blob/main/extensions/2026-07-28/README.md). For server configuration details, see [Secure Parameters](../../../../configuration/tools/_index.md#secure-parameters).
+{{< /notice >}}
+
+Secure parameters are designed for sensitive runtime values (such as an end-user `customer_id`, tenant identifier, or secret tokens) that LLMs must not see, control, or hallucinate.
+
+* **Schema Isolation:** When `ToolboxTool` is converted to an ADK tool or registered with an ADK agent, secure parameters are completely stripped from `tool.Declaration()`. The model never sees them, preventing credential exposure and prompt leakage.
+* **Prompt Injection Defense:** If a model attempts to supply arguments containing a secure parameter name, execution fails immediately.
+* **Fast-Fail Validation:** Missing required secure parameters are validated locally before invocation, preventing unwanted network calls.
+* **Binding Methods:** Secure parameters can be set as client defaults, bound when loading tools, or bound on existing tool instances using `core.WithBindSecureParam*` options:
+
+```go
+import (
+    "context"
+    "github.com/googleapis/mcp-toolbox-sdk-go/core"
+    "github.com/googleapis/mcp-toolbox-sdk-go/tbadk"
+)
+
+ctx := context.Background()
+
+// Option A: Set default secure parameters across all tools loaded by the client
+client, err := tbadk.NewToolboxClient("http://127.0.0.1:5000",
+    core.WithDefaultToolOptions(
+        core.WithBindSecureParamString("customer_id", "cust_12345"),
+    ),
+)
+
+// Option B: Bind secure parameters when loading a tool or toolset
+boundTool, err := client.LoadTool("search_secure_data", ctx,
+    core.WithBindSecureParamString("customer_id", "cust_12345"),
+)
+tools, err := client.LoadToolset("my-toolset", ctx,
+    core.WithBindSecureParamString("customer_id", "cust_12345"),
+)
+
+// Option C: Bind to an un-bound loaded tool (returns a new immutable tool)
+rawTool, err := client.LoadTool("search_secure_data", ctx)
+postBoundTool, err := rawTool.ToolFrom(
+    core.WithBindSecureParamString("customer_id", "cust_12345"),
+)
+
+// Option D: Dynamic runtime resolution
+dynamicTool, err := rawTool.ToolFrom(
+    core.WithBindSecureParamStringFunc("auth_token", func() (string, error) {
+        return fetchSessionToken(), nil
+    }),
+)
+```
+
+### Cross-Binding Guidance & Mutual Exclusivity
+
+* Passing `core.WithBindParam*` for a parameter configured with `secure: true` returns:  
+  `parameter "<name>" is a secure parameter; use WithBindSecureParam* instead`
+* Passing `core.WithBindSecureParam*` for a regular parameter returns:  
+  `parameter "<name>" is a regular parameter; use WithBindParam* instead`
+
+
 ## Default Parameters
 
 Tools defined in the MCP Toolbox server can specify default values for their optional parameters. When invoking a tool using the SDK, if an input for a parameter with a default value is not provided, the SDK will automatically populate the request with the default value.

--- a/docs/en/documentation/connect-to/toolbox-sdks/go-sdk/tbgenkit/_index.md
+++ b/docs/en/documentation/connect-to/toolbox-sdks/go-sdk/tbgenkit/_index.md
@@ -45,7 +45,46 @@ func main() {
 }
 ```
 
-# Using with Orchestration Frameworks
+## Secure Parameters
+
+{{< notice note >}}
+Secure parameters are supported starting in [`github.com/googleapis/mcp-toolbox-sdk-go/tbgenkit`](https://github.com/googleapis/mcp-toolbox-sdk-go/tree/main/tbgenkit) version `v0.10.0` (with `core` >= `v1.2.0`) and require MCP protocol version `2026-07-28` or newer with the [`com.google.cloud/toolbox.v1` extension](https://github.com/googleapis/mcp-toolbox/blob/main/extensions/2026-07-28/README.md). For server configuration details, see [Secure Parameters](../../../../configuration/tools/_index.md#secure-parameters).
+{{< /notice >}}
+
+Secure parameters are designed for sensitive runtime values (such as an end-user `customer_id`, tenant identifier, or secret tokens) that LLMs must not see, control, or hallucinate.
+
+* **Schema Isolation:** When converting a `ToolboxTool` into a Genkit tool via `tbgenkit.ToGenkitTool`, secure parameters are automatically excluded from the Genkit tool's input schema. Genkit models will never see or prompt for these parameters.
+* **Pre-Binding Required:** Secure parameters must be bound to the `ToolboxTool` (either during loading or via `tool.ToolFrom(...)`) before conversion. All type-safe `core.WithBindSecureParam*` and `core.WithBindSecureParam*Func` options are supported.
+* **Prompt Injection Defense:** If a model attempts to supply a secure parameter in standard inputs, execution fails immediately.
+* **Fast-Fail Validation:** If any required secure parameter is not bound, execution fails locally before making network requests.
+
+```go
+package main
+
+import (
+    "context"
+    "github.com/firebase/genkit/go/genkit"
+    "github.com/googleapis/mcp-toolbox-sdk-go/core"
+    "github.com/googleapis/mcp-toolbox-sdk-go/tbgenkit"
+)
+
+func main() {
+    ctx := context.Background()
+    toolboxClient, err := core.NewToolboxClient("http://127.0.0.1:5000")
+
+    // Load tool with secure parameter bound
+    tool, err := toolboxClient.LoadTool("search_secure_data", ctx,
+        core.WithBindSecureParamString("customer_id", "cust_12345"),
+    )
+
+    // Convert to Genkit tool
+    g, err := genkit.Init(ctx)
+    genkitTool, err := tbgenkit.ToGenkitTool(tool, g)
+}
+```
+
+
+## Using with Orchestration Frameworks
 
 To see how the MCP Toolbox Go SDK works with orchestration frameworks, check out these end-to-end examples given below.
 

--- a/docs/en/documentation/connect-to/toolbox-sdks/javascript-sdk/_index.md
+++ b/docs/en/documentation/connect-to/toolbox-sdks/javascript-sdk/_index.md
@@ -16,10 +16,14 @@ These JS SDKs act as clients for that service. They handle the communication nee
 * Fetch tool definitions from your running Toolbox instance.
 * Provide convenient JS objects or functions representing those tools.
 * Invoke the tools (calling the underlying APIs/services configured in Toolbox).
-* Handle authentication and parameter binding as needed.
+* Handle authentication, parameter binding, and secure parameters as needed.
 
 By using these SDKs, you can easily leverage your Toolbox-managed tools directly
 within your JS applications or AI orchestration frameworks.
+
+{{< notice note >}}
+[Secure parameters](../../../configuration/tools/_index.md#secure-parameters) are supported starting in `@toolbox-sdk/core` >= `1.2.0` and `@toolbox-sdk/adk` >= `1.2.0`, and require MCP protocol version `2026-07-28` or newer with the `com.google.cloud/toolbox.v1` extension.
+{{< /notice >}}
 
 <a class="btn btn-primary" href="https://js.mcp-toolbox.dev" role="button"><i class="fa-brands fa-js"></i> JavaScript API Reference</a>
 

--- a/docs/en/documentation/connect-to/toolbox-sdks/javascript-sdk/adk/index.md
+++ b/docs/en/documentation/connect-to/toolbox-sdks/javascript-sdk/adk/index.md
@@ -425,6 +425,64 @@ const dynamicBoundTool = tool.bindParam("param", getDynamicValue)
 You don't need to modify tool configurations to bind parameter values.
 {{< /notice >}}
 
+## Secure Parameters
+
+{{< notice note >}}
+Secure parameters are supported starting in `@toolbox-sdk/adk` version `1.2.0` (with `@toolbox-sdk/core` >= `1.2.0`) and require MCP protocol version `2026-07-28` or newer with the `com.google.cloud/toolbox.v1` extension. For server configuration details, see [Secure Parameters](../../../../configuration/tools/_index.md#secure-parameters).
+{{< /notice >}}
+
+Secure parameters are designed for sensitive runtime values (such as an end-user `customer_id`, tenant identifier, or secret tokens) that LLMs must not see or control.
+
+* **Schema Isolation:** When loaded tools are passed to an ADK `LlmAgent`, secure parameters are completely omitted from the tool parameter declarations (`tool.declaration`), ensuring the LLM never prompts for or hallucinates them.
+* **Prompt Injection Defense:** If an agent attempts to call a tool with a secure parameter supplied in standard arguments, execution fails immediately.
+* **Fast-Fail Validation:** Missing required secure parameters are validated locally before invocation, preventing unwanted network calls.
+* **Binding Methods:** Secure parameters can be pre-bound when loading tools or bound to tool instances:
+
+```javascript
+import { ToolboxClient } from '@toolbox-sdk/adk';
+
+const client = new ToolboxClient("http://127.0.0.1:5000");
+
+// Option A: Pre-bind secure parameters during loadTool / loadToolset
+const boundTool = await client.loadTool(
+    "search_secure_data",
+    null, // authTokenGetters
+    null, // boundParams
+    { customer_id: "cust_12345" } // secureParams
+);
+
+const tools = await client.loadToolset(
+    "my-toolset",
+    null, // authTokenGetters
+    null, // boundParams
+    false, // strict (set to true to error if any tool lacks the bound params)
+    { customer_id: "cust_12345" } // secureParams
+);
+
+// Option B: Bind on an un-bound loaded tool (returns a new immutable tool instance)
+const rawTool = await client.loadTool("search_secure_data");
+const singleBound = rawTool.bindSecureParam("customer_id", "cust_12345");
+const multiBound = rawTool.bindSecureParams({
+    customer_id: "cust_12345",
+    session_token: "token-xyz",
+});
+
+// Option C: Dynamic callable (evaluated per invocation)
+const dynamicTool = rawTool.bindSecureParam("auth_token", async () => fetchAuthToken());
+```
+
+### Cross-Binding Guidance & Mutual Exclusivity
+
+* Calling `tool.bindParam()` on a secure parameter throws an error:  
+  `Error: parameter '<name>' is a secure parameter; use bindSecureParam/bindSecureParams instead`
+* Calling `tool.bindSecureParam()` on a regular parameter throws an error:  
+  `Error: parameter '<name>' is a regular parameter; use bindParam/bindParams instead`
+
+### Accessing Core Tool
+
+To inspect or manipulate the underlying `@toolbox-sdk/core` tool instance from an ADK tool, call `tool.getCoreTool()`.
+
+
 # Using with ADK
 
 ADK JS:

--- a/docs/en/documentation/connect-to/toolbox-sdks/javascript-sdk/core/index.md
+++ b/docs/en/documentation/connect-to/toolbox-sdks/javascript-sdk/core/index.md
@@ -445,6 +445,102 @@ const dynamicBoundTool = tool.bindParam("param", getDynamicValue)
 You don't need to modify tool configurations to bind parameter values.
 {{< /notice >}}
 
+## Secure Parameters
+
+{{< notice note >}}
+Secure parameters are supported starting in `@toolbox-sdk/core` version `1.2.0` and require MCP protocol version `2026-07-28` or newer with the [`com.google.cloud/toolbox.v1` extension](https://github.com/googleapis/mcp-toolbox/blob/main/extensions/2026-07-28/README.md). For server configuration details, see [Secure Parameters](../../../../configuration/tools/_index.md#secure-parameters).
+{{< /notice >}}
+
+Secure parameters are designed for sensitive runtime context (such as an end-user `customer_id`, tenant identifier, or secret tokens) that LLMs must not see, control, or hallucinate.
+
+Unlike standard parameters, parameters marked as `secure: true` in your Toolbox server configuration:
+* **Schema Isolation:** The SDK completely strips secure parameters from the public tool declaration and parameter schema (`tool.getParamSchema()`). The LLM is never aware of these parameters, keeping your model's context window clean and preventing credential exposure.
+* **Prompt Injection Defense:** If a model or caller attempts to provide a value for a secure parameter in standard arguments, the SDK rejects execution immediately.
+* **Fast-Fail Validation:** The SDK verifies all required secure parameters locally before sending a request over the wire. If any required secure parameter is missing, execution throws an immediate error (e.g., `Missing required secure parameter(s) ... for tool "..."`).
+* **Wire Protocol Separation:** Secure parameters are transmitted out-of-band in the `secureArguments` field of the MCP 2026-07-28 `tools/call` JSON-RPC payload, isolated from regular arguments.
+
+### Option A: Binding Secure Parameters to a Loaded Tool
+
+Bind secure values to a tool object *after* it has been loaded. Each binding method returns a **new, immutable tool instance**, leaving the original unmodified.
+
+```javascript
+import { ToolboxClient } from '@toolbox-sdk/core';
+
+const client = new ToolboxClient("http://127.0.0.1:5000");
+const tool = await client.loadTool("search_secure_data");
+
+// Bind a single secure parameter
+const boundTool = tool.bindSecureParam("customer_id", "cust_12345");
+
+// OR bind multiple secure parameters at once
+const multiBoundTool = tool.bindSecureParams({
+    customer_id: "cust_12345",
+    session_token: "token-xyz"
+});
+```
+
+### Option B: Binding Secure Parameters While Loading Tools
+
+Pre-bind secure parameters directly when loading a tool or toolset. The SDK validates that all supplied keys exist as secure parameters on the target tools.
+
+```javascript
+import { ToolboxClient } from '@toolbox-sdk/core';
+
+const client = new ToolboxClient("http://127.0.0.1:5000");
+
+// Load a single tool with secure parameters
+const tool = await client.loadTool(
+    "search_secure_data",
+    null, // authTokenGetters
+    null, // boundParams
+    { customer_id: "cust_12345" } // secureParams
+);
+
+// Load an entire toolset with secure parameters
+const tools = await client.loadToolset(
+    "my-toolset",
+    null, // authTokenGetters
+    null, // boundParams
+    false, // strict (set to true to error if any tool lacks the bound params)
+    { customer_id: "cust_12345" } // secureParams
+);
+```
+
+### Binding Dynamic Secure Values
+
+You can also bind a secure parameter to a synchronous or asynchronous function. The function is evaluated at execution time each time the tool is invoked:
+
+```javascript
+async function getSessionToken() {
+    // Dynamically fetch session token or user identifier
+    return "session-token-xyz";
+}
+
+const secureTool = tool.bindSecureParam("auth_token", getSessionToken);
+```
+
+### Inspecting Secure Parameters
+
+You can inspect the tool's configured and bound secure parameters:
+
+```javascript
+// Returns an array of Parameter objects declared with secure: true that remain unbound
+const unboundSecureParams = tool.getSecureParams();
+
+// Returns a record of secure parameters that have already been bound to this tool instance
+const boundSecureParams = tool.getBoundSecureParams();
+```
+
+### Cross-Binding Guidance & Mutual Exclusivity
+
+To prevent accidental misconfigurations and enforce strict separation between model arguments and application arguments:
+
+* Calling `bindParam()` or `bindParams()` on a secure parameter throws:  
+  `Error: parameter '<name>' is a secure parameter; use bindSecureParam/bindSecureParams instead`
+* Calling `bindSecureParam()` or `bindSecureParams()` on a regular parameter throws:  
+  `Error: parameter '<name>' is a regular parameter; use bindParam/bindParams instead`
+
+
 # Using with Orchestration Frameworks
 
 <details open>

--- a/docs/en/documentation/connect-to/toolbox-sdks/python-sdk/_index.md
+++ b/docs/en/documentation/connect-to/toolbox-sdks/python-sdk/_index.md
@@ -17,10 +17,19 @@ These Python SDKs act as clients for that service. They handle the communication
 * Fetch tool definitions from your running Toolbox instance.
 * Provide convenient Python objects or functions representing those tools.
 * Invoke the tools (calling the underlying APIs/services configured in Toolbox).
-* Handle authentication and parameter binding as needed.
+* Handle authentication, parameter binding, and secure parameters as needed.
 
 By using these SDKs, you can easily leverage your Toolbox-managed tools directly
 within your Python applications or AI orchestration frameworks.
+
+{{< notice note >}}
+[Secure parameters](../../../configuration/tools/_index.md#secure-parameters) are supported starting in:
+* `toolbox-core` >= `1.4.0`
+* `toolbox-adk` >= `1.4.0`
+* `toolbox-langchain` >= `1.4.0`
+* `toolbox-llamaindex` >= `0.9.0`
+* Server requirement: MCP protocol version `2026-07-28` or newer with the `com.google.cloud/toolbox.v1` extension.
+{{< /notice >}}
 
 <a class="btn btn-primary" href="https://py.mcp-toolbox.dev" role="button"><i class="fa-brands fa-python"></i> Python API Reference</a>
 

--- a/docs/en/documentation/connect-to/toolbox-sdks/python-sdk/adk/index.md
+++ b/docs/en/documentation/connect-to/toolbox-sdks/python-sdk/adk/index.md
@@ -260,6 +260,56 @@ toolset = ToolboxToolset(
 )
 ```
 
+## Secure Parameters
+
+{{< notice note >}}
+Secure parameters are supported starting in `toolbox-adk` version `1.4.0` (with `toolbox-core` >= `1.4.0`) and require MCP protocol version `2026-07-28` or newer with the `com.google.cloud/toolbox.v1` extension. For server configuration details, see [Secure Parameters](../../../../configuration/tools/_index.md#secure-parameters).
+{{< /notice >}}
+
+Secure parameters are designed for sensitive runtime values (such as an end-user `customer_id`, tenant identifier, or secret tokens) that LLMs must not see or control.
+
+When tools define `secure: true` parameters in their Toolbox server configuration:
+* **Schema Isolation:** Secure parameters are completely stripped from the ADK Gemini tool declaration (`tool.declaration` / `tool._get_declaration()`), so the LLM model never sees them in prompt instructions or context windows.
+* **Prompt Injection Defense:** If a model attempts to generate arguments containing a secure parameter name, execution is rejected immediately.
+* **Fast-Fail Validation:** Missing required secure parameters fail locally prior to network transmission.
+* **Direct Application Injection:** Secure parameters must be supplied directly by your application out-of-band:
+
+```python
+from toolbox_adk import ToolboxToolset, ToolboxClient
+
+# Option A: Bind secure parameters globally on ToolboxToolset
+toolset = ToolboxToolset(
+    server_url="http://127.0.0.1:5000",
+    secure_params={
+        "customer_id": "cust_12345",
+        "session_token": lambda: get_session_token(),  # Sync or async callables supported
+    },
+)
+
+# Option B: Bind secure parameters when loading tools via ToolboxClient
+client = ToolboxClient("http://127.0.0.1:5000")
+bound_tool = await client.load_tool(
+    "search_secure_data",
+    secure_params={"customer_id": "cust_12345"}
+)
+
+# Option C: Bind to an un-bound loaded tool (returns a new immutable tool)
+raw_tool = await client.load_tool("search_secure_data")
+single_bound = raw_tool.bind_secure_param("customer_id", "cust_12345")
+multi_bound = raw_tool.bind_secure_params({
+    "customer_id": "cust_12345",
+    "session_token": "token-xyz",
+})
+```
+
+### Cross-Binding Guidance & Mutual Exclusivity
+
+* Calling `tool.bind_param()` on a secure parameter raises:  
+  `ValueError: parameter '<name>' is a secure parameter; use bind_secure_param/bind_secure_params instead`
+* Calling `tool.bind_secure_param()` on a regular parameter raises:  
+  `ValueError: parameter '<name>' is a regular parameter; use bind_param/bind_params instead`
+
+
 ## OpenTelemetry
 
 The SDK supports OpenTelemetry tracing and metrics via the `toolbox-core` layer, following the [MCP Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/mcp).

--- a/docs/en/documentation/connect-to/toolbox-sdks/python-sdk/core/index.md
+++ b/docs/en/documentation/connect-to/toolbox-sdks/python-sdk/core/index.md
@@ -565,6 +565,96 @@ async def get_dynamic_value():
 dynamic_bound_tool = tool.bind_param("param", get_dynamic_value)
 ```
 
+## Secure Parameters
+
+{{< notice note >}}
+Secure parameters are supported starting in `toolbox-core` version `1.4.0` and require MCP protocol version `2026-07-28` or newer with the [`com.google.cloud/toolbox.v1` extension](https://github.com/googleapis/mcp-toolbox/blob/main/extensions/2026-07-28/README.md). For server configuration details, see [Secure Parameters](../../../../configuration/tools/_index.md#secure-parameters).
+{{< /notice >}}
+
+Secure parameters are designed for sensitive runtime context (such as an end-user `customer_id`, tenant identifier, or secret tokens) that LLMs must not see, control, or hallucinate.
+
+Unlike standard parameters, parameters marked as `secure: true` in your Toolbox server configuration:
+* **Schema Isolation:** The SDK completely strips secure parameters from the public tool declaration, docstrings, and runtime function signature (reflected in `__signature__` and `inspect.signature(tool)`). The LLM is never aware of these parameters, keeping your model's context window clean and preventing credential exposure.
+* **Prompt Injection Defense:** If a model or caller attempts to provide a value for a secure parameter in standard arguments, the SDK rejects execution immediately.
+* **Fast-Fail Validation:** The SDK verifies all required secure parameters locally before sending a request over the wire. If any required secure parameter is missing, execution fails immediately.
+* **Wire Protocol Separation:** Secure parameters are transmitted out-of-band in the `secureArguments` field of the MCP 2026-07-28 `tools/call` JSON-RPC payload, isolated from regular arguments.
+
+### Option A: Binding Secure Parameters to a Loaded Tool
+
+Bind secure values to a tool object *after* it has been loaded. Each binding method returns a **new, immutable tool instance**, leaving the original unmodified.
+
+```python
+from toolbox_core import ToolboxClient
+
+async with ToolboxClient("http://127.0.0.1:5000") as toolbox:
+    tool = await toolbox.load_tool("search_secure_data")
+
+    # Bind a single secure parameter
+    bound_tool = tool.bind_secure_param("customer_id", "cust_12345")
+
+    # OR bind multiple secure parameters at once
+    multi_bound_tool = tool.bind_secure_params({
+        "customer_id": "cust_12345",
+        "session_token": "token-xyz"
+    })
+```
+
+### Option B: Binding Secure Parameters While Loading Tools
+
+Pre-bind secure parameters directly when loading a tool or toolset. The SDK validates that all supplied keys exist as secure parameters on the target tools.
+
+```python
+async with ToolboxClient("http://127.0.0.1:5000") as toolbox:
+    # Load a single tool with secure parameters
+    tool = await toolbox.load_tool(
+        "search_secure_data",
+        secure_params={"customer_id": "cust_12345"}
+    )
+
+    # Load an entire toolset with secure parameters
+    tools = await toolbox.load_toolset(
+        "my-toolset",
+        secure_params={"customer_id": "cust_12345"}
+    )
+```
+
+### Binding Dynamic Secure Values
+
+You can also bind a secure parameter to a synchronous or asynchronous callable. The callable is evaluated at execution time each time the tool is invoked:
+
+```python
+async def get_current_user_token() -> str:
+    # Dynamically fetch session token or user identifier
+    return "session-token-abc"
+
+secure_tool = tool.bind_secure_param("auth_token", get_current_user_token)
+```
+
+### Synchronous Usage
+
+Secure parameter binding is also available on `ToolboxSyncTool` when using `ToolboxSyncClient`:
+
+```python
+from toolbox_core import ToolboxSyncClient
+
+with ToolboxSyncClient("http://127.0.0.1:5000") as toolbox:
+    tool = toolbox.load_tool(
+        "search_secure_data",
+        secure_params={"customer_id": "cust_12345"}
+    )
+    result = tool()
+```
+
+### Cross-Binding Guidance & Mutual Exclusivity
+
+To prevent security misconfigurations and ensure strict separation between model arguments and application arguments:
+
+* Calling `bind_param()` or `bind_params()` on a secure parameter raises:  
+  `ValueError: parameter '<name>' is a secure parameter; use bind_secure_param/bind_secure_params instead`
+* Calling `bind_secure_param()` or `bind_secure_params()` on a regular parameter raises:  
+  `ValueError: parameter '<name>' is a regular parameter; use bind_param/bind_params instead`
+
+
 ## OpenTelemetry
 
 The SDK supports OpenTelemetry tracing and metrics following the [MCP Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/mcp). When enabled, each `tools/list` and `tools/call` operation produces a client span and records an operation-duration histogram, and W3C `traceparent`/`tracestate` headers are propagated to the Toolbox server for distributed tracing.

--- a/docs/en/documentation/connect-to/toolbox-sdks/python-sdk/langchain/index.md
+++ b/docs/en/documentation/connect-to/toolbox-sdks/python-sdk/langchain/index.md
@@ -423,6 +423,52 @@ dynamic_bound_tool = tool.bind_param("param", get_dynamic_value)
 You don’t need to modify tool configurations to bind parameter values.
 {{< /notice >}}
 
+## Secure Parameters
+
+{{< notice note >}}
+Secure parameters are supported starting in `toolbox-langchain` version `1.4.0` (with `toolbox-core` >= `1.4.0`) and require MCP protocol version `2026-07-28` or newer with the `com.google.cloud/toolbox.v1` extension. For server configuration details, see [Secure Parameters](../../../../configuration/tools/_index.md#secure-parameters).
+{{< /notice >}}
+
+Secure parameters are designed for sensitive runtime values (such as an end-user `customer_id`, tenant identifier, or secret tokens) that LLMs must not see or control.
+
+* **Schema Isolation:** Secure parameters are automatically excluded from LangChain's `tool.args_schema`, so models using `model.bind_tools(tools)` will never see or request them.
+* **Prompt Injection Defense:** If a model attempts to supply a secure parameter in standard arguments, execution fails immediately.
+* **Fast-Fail Validation:** Missing required secure parameters fail locally before invocation.
+* **Binding While Loading or After:** You can provide secure parameters when loading tools or bind them to loaded tools (both synchronous and asynchronous clients supported):
+
+```python
+from toolbox_langchain import ToolboxClient
+
+client = ToolboxClient("http://127.0.0.1:5000")
+
+# Option A: Bind secure parameters when loading tools (sync or async)
+bound_tool = client.load_tool("search_secure_data", secure_params={"customer_id": "cust_12345"})
+tools = client.load_toolset("my-set", secure_params={"customer_id": "cust_12345"})
+
+# Async client loading:
+# bound_tool = await client.aload_tool("search_secure_data", secure_params={"customer_id": "cust_12345"})
+# tools = await client.aload_toolset("my-set", secure_params={"customer_id": "cust_12345"})
+
+# Option B: Bind secure parameters to an un-bound loaded tool (returns a new immutable tool)
+raw_tool = client.load_tool("search_secure_data")
+single_bound = raw_tool.bind_secure_param("customer_id", "cust_12345")
+multi_bound = raw_tool.bind_secure_params({
+    "customer_id": "cust_12345",
+    "session_token": "token-xyz",
+})
+
+# Option C: Dynamic callable (evaluated per invocation)
+dynamic_tool = raw_tool.bind_secure_param("customer_id", lambda: get_current_user_id())
+```
+
+### Cross-Binding Guidance & Mutual Exclusivity
+
+* Calling `tool.bind_param()` on a secure parameter raises:  
+  `ValueError: parameter '<name>' is a secure parameter; use bind_secure_param/bind_secure_params instead`
+* Calling `tool.bind_secure_param()` on a regular parameter raises:  
+  `ValueError: parameter '<name>' is a regular parameter; use bind_param/bind_params instead`
+
+
 ## Asynchronous Usage
 
 For better performance through [cooperative

--- a/docs/en/documentation/connect-to/toolbox-sdks/python-sdk/llamaindex/index.md
+++ b/docs/en/documentation/connect-to/toolbox-sdks/python-sdk/llamaindex/index.md
@@ -408,6 +408,52 @@ dynamic_bound_tool = tool.bind_param("param", get_dynamic_value)
 You don't need to modify tool configurations to bind parameter values.
 {{< /notice >}}
 
+## Secure Parameters
+
+{{< notice note >}}
+Secure parameters are supported starting in `toolbox-llamaindex` version `0.9.0` (with `toolbox-core` >= `1.4.0`) and require MCP protocol version `2026-07-28` or newer with the `com.google.cloud/toolbox.v1` extension. For server configuration details, see [Secure Parameters](../../../../configuration/tools/_index.md#secure-parameters).
+{{< /notice >}}
+
+Secure parameters are designed for sensitive runtime values (such as an end-user `customer_id`, tenant identifier, or secret tokens) that LLMs must not see or control.
+
+* **Schema Isolation:** Secure parameters are automatically omitted from LlamaIndex's tool metadata and parameter definitions (`tool.metadata.fn_schema`), keeping model context clean and preventing parameter hallucination or leakage.
+* **Prompt Injection Defense:** If a model attempts to supply a secure parameter in standard arguments, execution fails immediately.
+* **Fast-Fail Validation:** Missing required secure parameters fail locally before invocation.
+* **Binding While Loading or After:** You can provide secure parameters when loading tools or bind them to loaded tools (both synchronous and asynchronous clients supported):
+
+```python
+from toolbox_llamaindex import ToolboxClient
+
+client = ToolboxClient("http://127.0.0.1:5000")
+
+# Option A: Bind secure parameters when loading tools (sync or async)
+bound_tool = client.load_tool("search_secure_data", secure_params={"customer_id": "cust_12345"})
+tools = client.load_toolset("my-set", secure_params={"customer_id": "cust_12345"})
+
+# Async client loading:
+# bound_tool = await client.aload_tool("search_secure_data", secure_params={"customer_id": "cust_12345"})
+# tools = await client.aload_toolset("my-set", secure_params={"customer_id": "cust_12345"})
+
+# Option B: Bind secure parameters to an un-bound loaded tool (returns a new immutable tool)
+raw_tool = client.load_tool("search_secure_data")
+single_bound = raw_tool.bind_secure_param("customer_id", "cust_12345")
+multi_bound = raw_tool.bind_secure_params({
+    "customer_id": "cust_12345",
+    "session_token": "token-xyz",
+})
+
+# Option C: Dynamic callable (evaluated per invocation)
+dynamic_tool = raw_tool.bind_secure_param("customer_id", lambda: get_current_user_id())
+```
+
+### Cross-Binding Guidance & Mutual Exclusivity
+
+* Calling `tool.bind_param()` on a secure parameter raises:  
+  `ValueError: parameter '<name>' is a secure parameter; use bind_secure_param/bind_secure_params instead`
+* Calling `tool.bind_secure_param()` on a regular parameter raises:  
+  `ValueError: parameter '<name>' is a regular parameter; use bind_param/bind_params instead`
+
+
 ## Asynchronous Usage
 
 For better performance through [cooperative


### PR DESCRIPTION
## Description

This PR adds comprehensive documentation for Secure Parameters across the MCP Toolbox documentation site, covering server-side tool configuration, generic MCP client protocol requirements, and native client SDK integrations across Python, JavaScript/TypeScript, and Go.

Secure parameters enable application developers to supply sensitive runtime arguments directly out-of-band to tools, completely isolated from LLM context windows and protected against prompt injection.

### Changes

* Documents the `secure: true` tool parameter configuration, validation constraints, and the separation between model parameters and sensitive runtime arguments.
* Details core security behaviors: model schema isolation via `secureInputSchema`, out-of-band wire delivery via `secureArguments`, prompt injection defense, and server error semantics.
* Explains MCP client capability negotiation for the `com.google.cloud/toolbox.v1` extension on protocol `2026-07-28`, including filtering behavior for generic MCP clients.
* Adds a unified compatibility matrix detailing minimum supported versions across all Python, JavaScript, and Go SDK packages.
* Documents dedicated binding workflows across all SDKs, including client-level defaults, load-time binding, immutable tool-level binding, and dynamic per-invocation callables.
* Details orchestration framework integrations demonstrating automatic schema stripping in Google ADK, LangChain, LlamaIndex, and Firebase Genkit.
* Covers mutual exclusivity enforcement and guidance errors preventing cross-use between regular and secure parameter binding methods.
* Outlines type-safe options and helper functions across Go scalars, slices, and maps.

### Minimum SDK Compatibility

| Language / SDK | Packages | Minimum Version | Server Requirement |
| :--- | :--- | :--- | :--- |
| **Python** | `toolbox-core`, `toolbox-adk`, `toolbox-langchain`, `toolbox-llamaindex` | `>= 1.4.0` (`toolbox-llamaindex >= 0.9.0`) | MCP `2026-07-28` + `com.google.cloud/toolbox.v1` |
| **JavaScript / TypeScript** | `@toolbox-sdk/core`, `@toolbox-sdk/adk` | `>= 1.2.0` | MCP `2026-07-28` + `com.google.cloud/toolbox.v1` |
| **Go** | `core`, `tbadk`, `tbgenkit` | `core` / `tbadk >= v1.2.0`, `tbgenkit >= v0.10.0` | MCP `2026-07-28` + `com.google.cloud/toolbox.v1` |

