### PR TITLE
feat(alloydb): provide actionable error when read-only mode is used on pre-PG17

### DIFF
--- a/docs/en/integrations/alloydb/prebuilt-configs/alloydb-postgres.md
+++ b/docs/en/integrations/alloydb/prebuilt-configs/alloydb-postgres.md
@@ -19,7 +19,7 @@ description: "Details of the AlloyDB Postgres prebuilt configuration."
         user. Defaults to IAM authentication if unspecified.
     *   `ALLOYDB_POSTGRES_IP_TYPE`: (Optional) The IP type i.e. "Public" or
         "Private" (Default: Public).
-    *   `ALLOYDB_POSTGRES_READONLY`: (Optional) When set to `true`, enforces read-only execution at the database session level (`alloydb_session_read_only=locked`) and suppresses write-capable tools. Default: `false`.
+    *   `ALLOYDB_POSTGRES_READONLY`: (Optional) When set to `true`, enforces read-only execution at the database session level (`alloydb_session_read_only=locked`) and suppresses write-capable tools. If you encounter an unsupported parameter error, make sure your AlloyDB instance has Postgres version 17+. Default: `false`.
 *   **Permissions:**
     *   **AlloyDB Client** (`roles/alloydb.client`) to connect to the instance.
     *   Database-level permissions (e.g., `SELECT`, `INSERT`) are required to

--- a/docs/en/integrations/alloydb/source.md
+++ b/docs/en/integrations/alloydb/source.md
@@ -144,4 +144,4 @@ The interface is identical, so there's no additional configuration required on t
 | password  |  string  |    false     | Password of the Postgres user (e.g. "my-password"). Defaults to attempting IAM authentication if unspecified.            |
 | ipType    |  string  |    false     | IP Type of the AlloyDB instance; must be one of `public` or `private`. Default: `public`.                                |
 | sqlCommenter | boolean |  false     | Overrides the global `--sql-commenter` flag for this source. When set, it takes priority; when omitted, the global flag applies. |
-| readOnly  | boolean  |    false     | When set to `true`, enforces read-only execution at the database session level (`alloydb_session_read_only=locked`) and suppresses write-capable tools. Default: `false`. |
+| readOnly  | boolean  |    false     | When set to `true`, enforces read-only execution at the database session level (`alloydb_session_read_only=locked`) and suppresses write-capable tools. If you encounter an unsupported parameter error, make sure your AlloyDB instance has Postgres version 17+. Default: `false`. |

--- a/internal/sources/alloydbpg/alloydb_pg.go
+++ b/internal/sources/alloydbpg/alloydb_pg.go
@@ -76,6 +76,11 @@ func (r Config) Initialize(ctx context.Context, tracer trace.Tracer) (sources.So
 
 	err = pool.Ping(ctx)
 	if err != nil {
+		if r.ReadOnly &&
+			strings.Contains(err.Error(), "unrecognized configuration parameter") &&
+			strings.Contains(err.Error(), "alloydb_session_read_only") {
+			return nil, fmt.Errorf("failed to initialize AlloyDB source in read-only mode: 'alloydb_session_read_only' is not supported on this instance version. See documentation for details: https://mcp-toolbox.dev/integrations/alloydb/source/#reference: %w", err)
+		}
 		return nil, fmt.Errorf("unable to connect successfully: %w", err)
 	}
 


### PR DESCRIPTION
## Overview
Shows a clear, helpful error message if someone turns on `readOnly: true` on an older AlloyDB database that doesn't support read-only mode yet.

## Context
* AlloyDB locks connections into read-only mode using a special setting (`alloydb_session_read_only`).
* This setting works out of the box on newer Postgres versions (17+), but older versions that haven't received recent updates don't recognize it and fail with a cryptic database error (`unrecognized configuration parameter`).
* Previously, Toolbox just showed a generic `"unable to connect"` error, giving users no clue what went wrong.

## Changes
1. If an instance rejects the read-only setting, Toolbox now explains that the database version doesn't support it, tells the user to make sure their instance has the latest Postgres version, and links directly to our [AlloyDB documentation](https://mcp-toolbox.dev/integrations/alloydb/source/#reference).
2. Added a note to the documentation clarifying that if users run into this error, they should make sure their database has the latest Postgres updates.