### PR TITLE
feat(tasks): add in-memory store and token encryption infra

### DIFF
--- a/internal/tasks/crypto.go
+++ b/internal/tasks/crypto.go
@@ -1,0 +1,91 @@
+package tasks
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"io"
+)
+
+var (
+	ErrInvalidKey       = errors.New("invalid key size: must be 16, 24, or 32 bytes")
+	ErrDecryptionFailed = errors.New("decryption failed")
+)
+
+// CryptoService provides AES-GCM encryption and decryption for task payloads.
+type CryptoService struct {
+	key []byte
+}
+
+// NewCryptoService initializes a new CryptoService with the provided symmetric key.
+func NewCryptoService(key []byte) (*CryptoService, error) {
+	if len(key) != 16 && len(key) != 24 && len(key) != 32 {
+		return nil, ErrInvalidKey
+	}
+	return &CryptoService{key: key}, nil
+}
+
+// EncryptPayload serializes and encrypts the given payload into a URL-safe base64 string.
+func (s *CryptoService) EncryptPayload(payload *EncryptedTaskPayload) (string, error) {
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+
+	block, err := aes.NewCipher(s.key)
+	if err != nil {
+		return "", err
+	}
+
+	aesGCM, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", err
+	}
+
+	nonce := make([]byte, aesGCM.NonceSize())
+	if _, err = io.ReadFull(rand.Reader, nonce); err != nil {
+		return "", err
+	}
+
+	ciphertext := aesGCM.Seal(nonce, nonce, data, nil)
+	return base64.URLEncoding.EncodeToString(ciphertext), nil
+}
+
+// DecryptPayload decrypts a URL-safe base64 string back into an EncryptedTaskPayload.
+func (s *CryptoService) DecryptPayload(token string) (*EncryptedTaskPayload, error) {
+	ciphertext, err := base64.URLEncoding.DecodeString(token)
+	if err != nil {
+		return nil, err
+	}
+
+	block, err := aes.NewCipher(s.key)
+	if err != nil {
+		return nil, err
+	}
+
+	aesGCM, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+
+	nonceSize := aesGCM.NonceSize()
+	if len(ciphertext) < nonceSize {
+		return nil, ErrDecryptionFailed
+	}
+
+	nonce, ciphertext := ciphertext[:nonceSize], ciphertext[nonceSize:]
+	plaintext, err := aesGCM.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return nil, ErrDecryptionFailed
+	}
+
+	var payload EncryptedTaskPayload
+	if err := json.Unmarshal(plaintext, &payload); err != nil {
+		return nil, err
+	}
+
+	return &payload, nil
+}

--- a/internal/tasks/crypto_test.go
+++ b/internal/tasks/crypto_test.go
@@ -1,0 +1,75 @@
+package tasks
+
+import (
+	"crypto/rand"
+	"testing"
+	"time"
+)
+
+func TestCryptoService_EncryptDecrypt(t *testing.T) {
+	key := make([]byte, 32)
+	_, err := rand.Read(key)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+
+	svc, err := NewCryptoService(key)
+	if err != nil {
+		t.Fatalf("failed to create crypto service: %v", err)
+	}
+
+	payload := &EncryptedTaskPayload{
+		SourceType: "postgres",
+		ProjectID:  "my-project",
+		NativeID:   "job-123",
+		CreatedAt:  time.Now().Unix(),
+	}
+
+	token, err := svc.EncryptPayload(payload)
+	if err != nil {
+		t.Fatalf("encryption failed: %v", err)
+	}
+	if token == "" {
+		t.Fatal("expected non-empty token")
+	}
+
+	decrypted, err := svc.DecryptPayload(token)
+	if err != nil {
+		t.Fatalf("decryption failed: %v", err)
+	}
+
+	if decrypted.SourceType != payload.SourceType {
+		t.Errorf("expected SourceType %q, got %q", payload.SourceType, decrypted.SourceType)
+	}
+	if decrypted.ProjectID != payload.ProjectID {
+		t.Errorf("expected ProjectID %q, got %q", payload.ProjectID, decrypted.ProjectID)
+	}
+	if decrypted.NativeID != payload.NativeID {
+		t.Errorf("expected NativeID %q, got %q", payload.NativeID, decrypted.NativeID)
+	}
+	if decrypted.CreatedAt != payload.CreatedAt {
+		t.Errorf("expected CreatedAt %d, got %d", payload.CreatedAt, decrypted.CreatedAt)
+	}
+}
+
+func TestCryptoService_InvalidKeySize(t *testing.T) {
+	_, err := NewCryptoService(make([]byte, 10))
+	if err != ErrInvalidKey {
+		t.Errorf("expected ErrInvalidKey, got %v", err)
+	}
+}
+
+func TestCryptoService_InvalidToken(t *testing.T) {
+	key := make([]byte, 32)
+	svc, _ := NewCryptoService(key)
+
+	_, err := svc.DecryptPayload("invalid-base64-!@#")
+	if err == nil {
+		t.Error("expected error decrypting invalid base64")
+	}
+
+	_, err = svc.DecryptPayload("YWJjZA==") // valid base64 but invalid ciphertext
+	if err == nil {
+		t.Error("expected error decrypting invalid ciphertext")
+	}
+}

--- a/internal/tasks/manager.go
+++ b/internal/tasks/manager.go
@@ -1,0 +1,159 @@
+package tasks
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"sync"
+	"time"
+)
+
+var (
+	ErrTaskNotFound = errors.New("task not found")
+)
+
+// TaskManager handles the lifecycle, state, and cancellation of background tasks.
+type TaskManager struct {
+	mu      sync.RWMutex
+	tasks   map[string]*Task
+	cancels map[string]context.CancelFunc
+	ctx     context.Context
+	cancel  context.CancelFunc
+}
+
+// NewTaskManager creates a new TaskManager with a root cancellation context.
+func NewTaskManager(ctx context.Context) *TaskManager {
+	ctx, cancel := context.WithCancel(ctx)
+	return &TaskManager{
+		tasks:   make(map[string]*Task),
+		cancels: make(map[string]context.CancelFunc),
+		ctx:     ctx,
+		cancel:  cancel,
+	}
+}
+
+// generateTaskID generates a secure random 32-character hex string for task identification.
+func generateTaskID() string {
+	bytes := make([]byte, 16)
+	_, _ = rand.Read(bytes)
+	return hex.EncodeToString(bytes)
+}
+
+// StartGoroutineTask starts a new background task in a detached goroutine and tracks its state.
+func (m *TaskManager) StartGoroutineTask(ctx context.Context, fn func(taskCtx context.Context) (any, error), pollIntervalMs, ttlMs int64) (string, error) {
+	taskID := generateTaskID()
+	now := time.Now()
+
+	// Derive from m.ctx to survive HTTP requests but respect server shutdown
+	taskCtx, cancel := context.WithCancel(m.ctx)
+
+	var expiredAt *time.Time
+	if ttlMs > 0 {
+		exp := now.Add(time.Duration(ttlMs) * time.Millisecond)
+		expiredAt = &exp
+	}
+
+	var pollInterval *int64
+	if pollIntervalMs > 0 {
+		pollInterval = &pollIntervalMs
+	}
+
+	var taskTTL *int64
+	if ttlMs > 0 {
+		taskTTL = &ttlMs
+	}
+
+	t := &Task{
+		TaskID:         taskID,
+		Status:         TaskStatusWorking,
+		CreatedAt:      now,
+		LastUpdatedAt:  now,
+		TTLMs:          taskTTL,
+		PollIntervalMs: pollInterval,
+		ExpiredAt:      expiredAt,
+	}
+
+	m.mu.Lock()
+	m.tasks[taskID] = t
+	m.cancels[taskID] = cancel
+	m.mu.Unlock()
+
+	go func() {
+		defer cancel()
+		defer func() {
+			if r := recover(); r != nil {
+				m.mu.Lock()
+				defer m.mu.Unlock()
+				if task, ok := m.tasks[taskID]; ok {
+					task.Status = TaskStatusFailed
+					task.StatusMessage = "Task execution panicked"
+					task.Error = "Internal execution error"
+					task.LastUpdatedAt = time.Now()
+				}
+			}
+		}()
+		result, err := fn(taskCtx)
+
+		m.mu.Lock()
+		defer m.mu.Unlock()
+
+		task, ok := m.tasks[taskID]
+		if !ok {
+			return
+		}
+
+		if err != nil {
+			if errors.Is(err, context.Canceled) {
+				task.Status = TaskStatusCancelled
+				task.StatusMessage = "Task cancelled"
+			} else {
+				task.Status = TaskStatusFailed
+				task.StatusMessage = err.Error()
+				task.Error = err.Error()
+			}
+		} else {
+			task.Status = TaskStatusCompleted
+			task.Result = result
+		}
+		task.LastUpdatedAt = time.Now()
+	}()
+
+	return taskID, nil
+}
+
+// GetTask safely retrieves a copy of the specified task if it exists.
+func (m *TaskManager) GetTask(taskID string) (*Task, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	t, ok := m.tasks[taskID]
+	if !ok {
+		return nil, false
+	}
+
+	taskCopy := *t
+	return &taskCopy, true
+}
+
+// CancelTask requests cancellation for the specified task and updates its status.
+func (m *TaskManager) CancelTask(taskID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	cancel, ok := m.cancels[taskID]
+	if !ok {
+		return ErrTaskNotFound
+	}
+
+	task := m.tasks[taskID]
+	if task.Status != TaskStatusWorking {
+		return errors.New("cannot cancel a task that has already completed or failed")
+	}
+
+	cancel()
+	task.Status = TaskStatusCancelled
+	task.StatusMessage = "Task cancellation requested"
+	task.LastUpdatedAt = time.Now()
+
+	return nil
+}

--- a/internal/tasks/manager_test.go
+++ b/internal/tasks/manager_test.go
@@ -1,0 +1,121 @@
+package tasks
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestTaskManager_StartAndComplete(t *testing.T) {
+	ctx := context.Background()
+	mgr := NewTaskManager(ctx)
+
+	taskID, err := mgr.StartGoroutineTask(ctx, func(taskCtx context.Context) (any, error) {
+		return "success-result", nil
+	}, 1000, 5000)
+
+	if err != nil {
+		t.Fatalf("StartGoroutineTask failed: %v", err)
+	}
+
+	task, ok := mgr.GetTask(taskID)
+	if !ok {
+		t.Fatalf("task not found")
+	}
+	if task.Status != TaskStatusWorking {
+		t.Errorf("expected working status, got %s", task.Status)
+	}
+
+	// wait for completion
+	time.Sleep(100 * time.Millisecond)
+
+	task, _ = mgr.GetTask(taskID)
+	if task.Status != TaskStatusCompleted {
+		t.Errorf("expected completed status, got %s", task.Status)
+	}
+	if task.Result != "success-result" {
+		t.Errorf("expected result 'success-result', got %v", task.Result)
+	}
+}
+
+func TestTaskManager_StartAndFail(t *testing.T) {
+	ctx := context.Background()
+	mgr := NewTaskManager(ctx)
+
+	expectedErr := errors.New("custom error")
+	taskID, err := mgr.StartGoroutineTask(ctx, func(taskCtx context.Context) (any, error) {
+		return nil, expectedErr
+	}, 1000, 5000)
+
+	if err != nil {
+		t.Fatalf("StartGoroutineTask failed: %v", err)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	task, _ := mgr.GetTask(taskID)
+	if task.Status != TaskStatusFailed {
+		t.Errorf("expected failed status, got %s", task.Status)
+	}
+	if task.Error != expectedErr.Error() {
+		t.Errorf("expected error %q, got %q", expectedErr.Error(), task.Error)
+	}
+}
+
+func TestTaskManager_CancelTask(t *testing.T) {
+	ctx := context.Background()
+	mgr := NewTaskManager(ctx)
+
+	waitCh := make(chan struct{})
+	taskID, err := mgr.StartGoroutineTask(ctx, func(taskCtx context.Context) (any, error) {
+		<-taskCtx.Done()
+		close(waitCh)
+		return nil, taskCtx.Err()
+	}, 1000, 5000)
+
+	if err != nil {
+		t.Fatalf("StartGoroutineTask failed: %v", err)
+	}
+
+	err = mgr.CancelTask(taskID)
+	if err != nil {
+		t.Fatalf("CancelTask failed: %v", err)
+	}
+
+	<-waitCh // wait for goroutine to exit
+
+	time.Sleep(50 * time.Millisecond) // let the goroutine update the status
+	task, _ := mgr.GetTask(taskID)
+	if task.Status != TaskStatusCancelled {
+		t.Errorf("expected cancelled status, got %s", task.Status)
+	}
+}
+
+func TestExpiredTaskPruner(t *testing.T) {
+	ctx := context.Background()
+	mgr := NewTaskManager(ctx)
+
+	// TTL is 50ms
+	taskID, _ := mgr.StartGoroutineTask(ctx, func(taskCtx context.Context) (any, error) {
+		return "done", nil
+	}, 0, 50)
+
+	pruner := NewExpiredTaskPruner(mgr, 20*time.Millisecond)
+	pruner.Start()
+	defer pruner.Stop()
+
+	// initial check
+	_, ok := mgr.GetTask(taskID)
+	if !ok {
+		t.Fatal("expected task to exist")
+	}
+
+	// wait for TTL to expire and pruner to run
+	time.Sleep(150 * time.Millisecond)
+
+	_, ok = mgr.GetTask(taskID)
+	if ok {
+		t.Fatal("expected task to be pruned")
+	}
+}

--- a/internal/tasks/pruner.go
+++ b/internal/tasks/pruner.go
@@ -1,0 +1,58 @@
+package tasks
+
+import (
+	"time"
+)
+
+// ExpiredTaskPruner periodically checks and removes tasks that have exceeded their time-to-live (TTL).
+type ExpiredTaskPruner struct {
+	manager *TaskManager
+	ticker  *time.Ticker
+	done    chan struct{}
+}
+
+// NewExpiredTaskPruner creates a new pruner that runs at the specified interval.
+func NewExpiredTaskPruner(manager *TaskManager, interval time.Duration) *ExpiredTaskPruner {
+	return &ExpiredTaskPruner{
+		manager: manager,
+		ticker:  time.NewTicker(interval),
+		done:    make(chan struct{}),
+	}
+}
+
+// Start begins the background pruning loop in a new goroutine.
+func (p *ExpiredTaskPruner) Start() {
+	go func() {
+		for {
+			select {
+			case <-p.ticker.C:
+				p.prune()
+			case <-p.done:
+				p.ticker.Stop()
+				return
+			}
+		}
+	}()
+}
+
+// Stop signals the pruning loop to terminate.
+func (p *ExpiredTaskPruner) Stop() {
+	close(p.done)
+}
+
+// prune iterates over all tasks, removing and cancelling those that have expired.
+func (p *ExpiredTaskPruner) prune() {
+	p.manager.mu.Lock()
+	defer p.manager.mu.Unlock()
+
+	now := time.Now()
+	for id, task := range p.manager.tasks {
+		if task.ExpiredAt != nil && now.After(*task.ExpiredAt) {
+			if cancel, ok := p.manager.cancels[id]; ok {
+				cancel()
+				delete(p.manager.cancels, id)
+			}
+			delete(p.manager.tasks, id)
+		}
+	}
+}

--- a/internal/tasks/types.go
+++ b/internal/tasks/types.go
@@ -1,0 +1,35 @@
+package tasks
+
+import "time"
+
+// TaskStatus represents the current state of a task.
+type TaskStatus string
+
+const (
+	TaskStatusWorking   TaskStatus = "working"
+	TaskStatusCompleted TaskStatus = "completed"
+	TaskStatusFailed    TaskStatus = "failed"
+	TaskStatusCancelled TaskStatus = "cancelled"
+)
+
+// Task represents a long-running asynchronous operation and its state.
+type Task struct {
+	TaskID         string
+	Status         TaskStatus
+	StatusMessage  string
+	CreatedAt      time.Time
+	LastUpdatedAt  time.Time
+	TTLMs          *int64
+	PollIntervalMs *int64
+	ExpiredAt      *time.Time
+	Result         any
+	Error          string
+}
+
+// EncryptedTaskPayload represents the native backend query ID state that is encrypted into the task ID token.
+type EncryptedTaskPayload struct {
+	SourceType string `json:"src"`
+	ProjectID  string `json:"prj"`
+	NativeID   string `json:"id"`
+	CreatedAt  int64  `json:"iat"`
+}


### PR DESCRIPTION
This PR implements the MVP for the Model Context Protocol (MCP) Tasks extension (io.modelcontextprotocol/tasks v2026-07-28). It introduces:

- in-memory TaskManager that executes jobs in detached goroutines.
- a CryptoService using AES-GCM to map native database queries into Base64 task ID tokens.
- a background ExpiredTaskPruner that enforces absolute timeouts (using ExpiredAt) to reliably clear stale tasks.
