### PR TITLE
ci: run eval builds on a larger Cloud Build worker

### DIFF
--- a/.ci/evals.cloudbuild.yaml
+++ b/.ci/evals.cloudbuild.yaml
@@ -137,6 +137,9 @@ options:
   logging: CLOUD_LOGGING_ONLY
   substitutionOption: "ALLOW_LOOSE"
   dynamicSubstitutions: true
+  # Steps share one worker, so databases evaluated in parallel contend for the
+  # same CPU.
+  machineType: E2_HIGHCPU_32
   env:
     - "TOOLBOX_BIN=/workspace/toolbox"
     - "EVAL_HARNESSES=${_EVAL_HARNESSES}"


### PR DESCRIPTION
Cloud Build runs every step of a build on a single worker, so the per-database eval steps all share one CPU allocation. The 2 vCPU default is already thin for two databases and won't hold as more prebuilt configs are onboarded, so this sizes the eval build at E2_HIGHCPU_32.