### PR TITLE
ci: speed up change detection using blobless git fetch

### DIFF
--- a/.ci/integration.cloudbuild.yaml
+++ b/.ci/integration.cloudbuild.yaml
@@ -20,13 +20,18 @@ steps:
     args:
       - -c
       - |
-        git fetch --unshallow || true
-        git fetch origin main > /dev/null 2>&1
-        git diff --name-only origin/main...HEAD > /workspace/changed_files.txt
+        target_branch="${_BASE_BRANCH:-main}"
+
+        # Blobless: --name-only needs tree entries, not file contents.
+        git fetch --unshallow --filter=blob:none || true
+        git fetch --filter=blob:none origin "${target_branch}" > /dev/null 2>&1
+        git diff --name-only "origin/${target_branch}...HEAD" > /workspace/changed_files.txt
         if [ ! -s /workspace/changed_files.txt ]; then
           echo "No changed files detected. Writing a representative CI path to run all test shards."
           echo ".ci/integration.cloudbuild.yaml" > /workspace/changed_files.txt
         fi
+        echo "Detected changed files:"
+        cat /workspace/changed_files.txt
 
 
   - id: "install-dependencies"


### PR DESCRIPTION
## Description

Updates `.ci/integration.cloudbuild.yaml`'s `detect-changes` step to use blobless git fetch (`--filter=blob:none`).

Because `git diff --name-only` only requires tree entries rather than file contents, fetching bloblessly avoids downloading ~1.9 GB of blob history while safely providing full commit and tree graphs. This eliminates `fatal: no merge base` errors on shallow CI clones and drastically accelerates change detection, mirroring the pattern established in `.ci/evals.cloudbuild.yaml` (#3904).

## PR Checklist

- [x] Make sure you reviewed [CONTRIBUTING.md](https://github.com/googleapis/mcp-toolbox/blob/main/CONTRIBUTING.md)
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/mcp-toolbox/issues/new/choose) before writing your code!
- [x] Ensure you have manually reviewed the entire diff before requesting a review
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
- [ ] Make sure to add `!` if this involve a breaking change

🛠️ Fixes #<issue_number_goes_here>