### PR TITLE
feat(config): support Compose-style env-var interpolation modifiers

### DIFF
--- a/cmd/internal/config.go
+++ b/cmd/internal/config.go
@@ -59,18 +59,31 @@ type ConfigParser struct {
 	AllowMissingEnvVars bool
 }
 
-// parseEnv replaces environment variables ${ENV_NAME} with their values.
-// also support ${ENV_NAME:default_value}.
+// parseEnv expands ${ENV_NAME...} placeholders using Compose-style rules.
+//
+// Forms:
+//   ${VAR}            error if unset; empty set values are kept
+//   ${VAR:default}    default only when unset (empty set values are kept)
+//   ${VAR:-default}   default when unset or empty
+//   ${VAR:?[message]} error when unset or empty
 func (p *ConfigParser) parseEnv(input string) (string, error) {
-	re := regexp.MustCompile(`\$\{(\w+)(:([^}]*))?\}`)
+	re := regexp.MustCompile(`\$\{(\w+)(?:(:-|:\?|:)([^}]*))?\}`)
 
 	if p.EnvVars == nil {
 		p.EnvVars = make(map[string]string)
 	}
 
+	type missingEnvVar struct {
+		name             string
+		message          string
+		line             int
+		column           int
+		requiredNonEmpty bool
+	}
+
 	tokens := lexer.Tokenize(input)
 
-	var missing []string
+	var missing []missingEnvVar
 	seenMissing := make(map[string]bool)
 	matches := re.FindAllStringSubmatchIndex(input, -1)
 	var output strings.Builder
@@ -96,11 +109,14 @@ func (p *ConfigParser) parseEnv(input string) (string, error) {
 		output.WriteString(input[lastIndex:start])
 
 		variableName := input[match[2]:match[3]]
-		defaultValue := ""
-		defaultProvided := match[4] != -1 && match[5] != -1
-		if defaultProvided {
-			defaultValue = input[match[6]:match[7]]
+		operator := ""
+		operand := ""
+		if match[4] != -1 && match[5] != -1 {
+			operator = input[match[4]:match[5]]
+			operand = input[match[6]:match[7]]
 		}
+		defaultProvided := operator == ":" || operator == ":-"
+		requiredNonEmpty := operator == ":?"
 
 		if defaultProvided {
 			p.OptionalEnvVars = append(p.OptionalEnvVars, variableName)
@@ -108,20 +124,34 @@ func (p *ConfigParser) parseEnv(input string) (string, error) {
 			p.requiredEnvVars = append(p.requiredEnvVars, variableName)
 		}
 
-		if value, found := os.LookupEnv(variableName); found {
+		value, found := os.LookupEnv(variableName)
+		useDefault := defaultProvided && !found
+		if operator == ":-" && value == "" {
+			useDefault = true
+		}
+		missingRequired := requiredNonEmpty && (!found || value == "")
+
+		switch {
+		case found && !useDefault && !missingRequired:
 			p.EnvVars[variableName] = value
 			output.WriteString(value)
-		} else if defaultProvided {
-			p.EnvVars[variableName] = defaultValue
-			output.WriteString(defaultValue)
-		} else {
-			if p.AllowMissingEnvVars {
-				p.EnvVars[variableName] = variableName
-				output.WriteString(variableName)
-			} else if !seenMissing[variableName] {
+		case useDefault:
+			p.EnvVars[variableName] = operand
+			output.WriteString(operand)
+		case p.AllowMissingEnvVars:
+			p.EnvVars[variableName] = variableName
+			output.WriteString(variableName)
+		default:
+			if !seenMissing[variableName] {
 				seenMissing[variableName] = true
 				line, column := lineColumnAt(input, start)
-				missing = append(missing, fmt.Sprintf("%q (line %d, column %d)", variableName, line, column))
+				missing = append(missing, missingEnvVar{
+					name:             variableName,
+					message:          operand,
+					line:             line,
+					column:           column,
+					requiredNonEmpty: requiredNonEmpty,
+				})
 			}
 		}
 
@@ -139,11 +169,47 @@ func (p *ConfigParser) parseEnv(input string) (string, error) {
 	p.OptionalEnvVars = finalOptional
 
 	var err error
-	if len(missing) > 0 {
-		if len(missing) == 1 {
-			err = fmt.Errorf("environment variable not found: %s", missing[0])
+	if len(missing) == 1 {
+		item := missing[0]
+		if item.requiredNonEmpty {
+			message := fmt.Sprintf("required environment variable is unset or empty: %q", item.name)
+			if item.message != "" {
+				message += ": " + item.message
+			}
+			err = fmt.Errorf("%s (line %d, column %d)", message, item.line, item.column)
 		} else {
-			err = fmt.Errorf("environment variables not found:\n  - %s", strings.Join(missing, "\n  - "))
+			err = fmt.Errorf("environment variable not found: %q (line %d, column %d)", item.name, item.line, item.column)
+		}
+	} else if len(missing) > 1 {
+		allLegacyMissing := true
+		for _, item := range missing {
+			if item.requiredNonEmpty {
+				allLegacyMissing = false
+				break
+			}
+		}
+
+		details := make([]string, 0, len(missing))
+		for _, item := range missing {
+			if allLegacyMissing {
+				details = append(details, fmt.Sprintf("%q (line %d, column %d)", item.name, item.line, item.column))
+				continue
+			}
+
+			message := fmt.Sprintf("environment variable not found: %q", item.name)
+			if item.requiredNonEmpty {
+				message = fmt.Sprintf("required environment variable is unset or empty: %q", item.name)
+				if item.message != "" {
+					message += ": " + item.message
+				}
+			}
+			details = append(details, fmt.Sprintf("%s (line %d, column %d)", message, item.line, item.column))
+		}
+
+		if allLegacyMissing {
+			err = fmt.Errorf("environment variables not found:\n  - %s", strings.Join(details, "\n  - "))
+		} else {
+			err = fmt.Errorf("environment variable expansion errors:\n  - %s", strings.Join(details, "\n  - "))
 		}
 	}
 

--- a/cmd/internal/config_test.go
+++ b/cmd/internal/config_test.go
@@ -47,49 +47,71 @@ func TestParseEnv(t *testing.T) {
 		err          bool
 		errString    string
 		wantOptional []string
+		wantRequired []string
 		lenient      bool
 	}{
 		{
-			desc:      "without default without env",
-			in:        "${FOO}",
-			want:      "",
-			err:       true,
-			errString: `environment variable not found: "FOO" (line 1, column 1)`,
+			desc:         "without default without env",
+			in:           "${FOO}",
+			want:         "",
+			err:          true,
+			errString:    `environment variable not found: "FOO" (line 1, column 1)`,
+			wantRequired: []string{"FOO"},
 		},
 		{
-			desc:      "multiple missing required vars reported together",
-			in:        "host: ${HOST}, user: ${USER_NAME}, pass: ${PASSWORD}",
-			want:      "host: , user: , pass: ",
-			err:       true,
-			errString: "environment variables not found:\n  - \"HOST\" (line 1, column 7)\n  - \"USER_NAME\" (line 1, column 22)\n  - \"PASSWORD\" (line 1, column 42)",
+			desc:         "multiple missing required vars reported together",
+			in:           "host: ${HOST}, user: ${USER_NAME}, pass: ${PASSWORD}",
+			want:         "host: , user: , pass: ",
+			err:          true,
+			errString:    "environment variables not found:\n  - \"HOST\" (line 1, column 7)\n  - \"USER_NAME\" (line 1, column 22)\n  - \"PASSWORD\" (line 1, column 42)",
+			wantRequired: []string{"HOST", "USER_NAME", "PASSWORD"},
 		},
 		{
-			desc:      "repeated missing required var reported once",
-			in:        "a: ${HOST}, b: ${HOST}",
-			want:      "a: , b: ",
-			err:       true,
-			errString: `environment variable not found: "HOST" (line 1, column 4)`,
+			desc:         "repeated missing required var reported once",
+			in:           "a: ${HOST}, b: ${HOST}",
+			want:         "a: , b: ",
+			err:          true,
+			errString:    `environment variable not found: "HOST" (line 1, column 4)`,
+			wantRequired: []string{"HOST", "HOST"},
 		},
 		{
-			desc:    "without default without env, lenient",
-			in:      "${FOO}",
-			want:    "FOO",
-			lenient: true,
+			desc:         "legacy and non-empty errors reported together",
+			in:           "${TEST_LEGACY_UNSET_3635} ${TEST_REQUIRED_UNSET_3635:?must be set}",
+			want:         " ",
+			err:          true,
+			errString:    "environment variable expansion errors:\n  - environment variable not found: \"TEST_LEGACY_UNSET_3635\" (line 1, column 1)\n  - required environment variable is unset or empty: \"TEST_REQUIRED_UNSET_3635\": must be set (line 1, column 27)",
+			wantRequired: []string{"TEST_LEGACY_UNSET_3635", "TEST_REQUIRED_UNSET_3635"},
 		},
 		{
-			desc:    "missing required mixed with env, lenient",
-			in:      "project: ${PROJECT}, region: ${REGION}",
-			env:     map[string]string{"REGION": "us-central1"},
-			want:    "project: PROJECT, region: us-central1",
-			lenient: true,
+			desc:         "without default without env, lenient",
+			in:           "${FOO}",
+			want:         "FOO",
+			wantRequired: []string{"FOO"},
+			lenient:      true,
+		},
+		{
+			desc:         "missing required mixed with env, lenient",
+			in:           "project: ${PROJECT}, region: ${REGION}",
+			env:          map[string]string{"REGION": "us-central1"},
+			want:         "project: PROJECT, region: us-central1",
+			wantRequired: []string{"PROJECT", "REGION"},
+			lenient:      true,
 		},
 		{
 			desc: "without default with env",
 			env: map[string]string{
 				"FOO": "bar",
 			},
-			in:   "${FOO}",
-			want: "bar",
+			in:           "${FOO}",
+			want:         "bar",
+			wantRequired: []string{"FOO"},
+		},
+		{
+			desc:         "without default with empty env",
+			env:          map[string]string{"FOO": ""},
+			in:           "${FOO}",
+			want:         "",
+			wantRequired: []string{"FOO"},
 		},
 		{
 			desc: "skip commented out env var",
@@ -112,7 +134,8 @@ func TestParseEnv(t *testing.T) {
 			env: map[string]string{
 				"PORT": "9090",
 			},
-			want: "port: 9090 # default is ${DEFAULT_PORT}",
+			want:         "port: 9090 # default is ${DEFAULT_PORT}",
+			wantRequired: []string{"PORT"},
 		},
 		{
 			desc: "do not skip env var with hash inside double quotes",
@@ -120,7 +143,8 @@ func TestParseEnv(t *testing.T) {
 			env: map[string]string{
 				"ANCHOR": "section1",
 			},
-			want: `url: "http://example.com/#section1"`,
+			want:         `url: "http://example.com/#section1"`,
+			wantRequired: []string{"ANCHOR"},
 		},
 		{
 			desc: "do not skip env var with hash inside single quotes",
@@ -128,7 +152,8 @@ func TestParseEnv(t *testing.T) {
 			env: map[string]string{
 				"ANCHOR": "section1",
 			},
-			want: `url: 'http://example.com/#section1'`,
+			want:         `url: 'http://example.com/#section1'`,
+			wantRequired: []string{"ANCHOR"},
 		},
 		{
 			desc: "skip commented out env var but parse non-commented ones",
@@ -137,7 +162,8 @@ func TestParseEnv(t *testing.T) {
 				"BAR": "bar_val",
 				"QUX": "qux_val",
 			},
-			want: "foo: bar_val\n# ${FOO}\nbaz: qux_val",
+			want:         "foo: bar_val\n# ${FOO}\nbaz: qux_val",
+			wantRequired: []string{"BAR", "QUX"},
 		},
 		{
 			desc: "parse env vars after a comment containing multi-byte characters",
@@ -153,6 +179,7 @@ func TestParseEnv(t *testing.T) {
 				"foo: bar_val\n" +
 				"# " + strings.Repeat("é", 30) + "\n" +
 				"baz: qux_val\n",
+			wantRequired: []string{"BAR", "QUX"},
 		},
 		{
 			desc: "skip commented out env var when comment contains multi-byte characters",
@@ -160,7 +187,8 @@ func TestParseEnv(t *testing.T) {
 			env: map[string]string{
 				"BAR": "bar_val",
 			},
-			want: "# " + strings.Repeat("é", 30) + " ${FOO}\nbar: bar_val\n",
+			want:         "# " + strings.Repeat("é", 30) + " ${FOO}\nbar: bar_val\n",
+			wantRequired: []string{"BAR"},
 		},
 		{
 			desc: "multiline yaml with mixed comments and env vars",
@@ -178,6 +206,7 @@ func TestParseEnv(t *testing.T) {
 				"port: 5432\n" +
 				"user: my_user\n",
 			wantOptional: []string{"DB_PORT"},
+			wantRequired: []string{"DB_USER"},
 		},
 		{
 			desc:         "with default without env",
@@ -201,6 +230,74 @@ func TestParseEnv(t *testing.T) {
 			wantOptional: []string{"FOO"},
 		},
 		{
+			desc:         "legacy default preserves empty env",
+			env:          map[string]string{"FOO": ""},
+			in:           "${FOO:bar}",
+			want:         "",
+			wantOptional: []string{"FOO"},
+		},
+		{
+			desc:         "non-empty default without env",
+			in:           "${TEST_NONEMPTY_DEFAULT_UNSET_3635:-bar}",
+			want:         "bar",
+			wantOptional: []string{"TEST_NONEMPTY_DEFAULT_UNSET_3635"},
+		},
+		{
+			desc:         "non-empty default with empty env",
+			env:          map[string]string{"FOO": ""},
+			in:           "${FOO:-bar}",
+			want:         "bar",
+			wantOptional: []string{"FOO"},
+		},
+		{
+			desc:         "non-empty default with env",
+			env:          map[string]string{"FOO": "hello"},
+			in:           "${FOO:-bar}",
+			want:         "hello",
+			wantOptional: []string{"FOO"},
+		},
+		{
+			desc:         "required non-empty without env",
+			in:           "${TEST_REQUIRED_UNSET_3635:?}",
+			want:         "",
+			err:          true,
+			errString:    `required environment variable is unset or empty: "TEST_REQUIRED_UNSET_3635" (line 1, column 1)`,
+			wantRequired: []string{"TEST_REQUIRED_UNSET_3635"},
+		},
+		{
+			desc:         "required non-empty with empty env",
+			env:          map[string]string{"FOO": ""},
+			in:           "${FOO:?}",
+			want:         "",
+			err:          true,
+			errString:    `required environment variable is unset or empty: "FOO" (line 1, column 1)`,
+			wantRequired: []string{"FOO"},
+		},
+		{
+			desc:         "required non-empty with custom error",
+			env:          map[string]string{"FOO": ""},
+			in:           "value: ${FOO:?FOO must be set}",
+			want:         "value: ",
+			err:          true,
+			errString:    `required environment variable is unset or empty: "FOO": FOO must be set (line 1, column 8)`,
+			wantRequired: []string{"FOO"},
+		},
+		{
+			desc:         "required non-empty with env",
+			env:          map[string]string{"FOO": "hello"},
+			in:           "${FOO:?FOO must be set}",
+			want:         "hello",
+			wantRequired: []string{"FOO"},
+		},
+		{
+			desc:         "required non-empty with empty env, lenient",
+			env:          map[string]string{"FOO": ""},
+			in:           "${FOO:?FOO must be set}",
+			want:         "FOO",
+			wantRequired: []string{"FOO"},
+			lenient:      true,
+		},
+		{
 			desc: "multiple variables",
 			in:   "user: ${USER_NAME:}, password: ${PASSWORD:}, ip: ${IP:public}, region: ${REGION}",
 			env: map[string]string{
@@ -208,6 +305,7 @@ func TestParseEnv(t *testing.T) {
 			},
 			want:         "user: , password: , ip: public, region: us-central1",
 			wantOptional: []string{"USER_NAME", "PASSWORD", "IP"},
+			wantRequired: []string{"REGION"},
 		},
 		{
 			desc: "variable required in one place and optional in another",
@@ -217,6 +315,27 @@ func TestParseEnv(t *testing.T) {
 			},
 			want:         "project_req: my_project, project_opt: my_project",
 			wantOptional: []string{}, // Because it was marked required at least once
+			wantRequired: []string{"PROJECT_ID"},
+		},
+		{
+			desc: "variable required non-empty in one place and optional in another",
+			in:   "project_req: ${PROJECT_ID:?}, project_opt: ${PROJECT_ID:-default}",
+			env: map[string]string{
+				"PROJECT_ID": "my_project",
+			},
+			want:         "project_req: my_project, project_opt: my_project",
+			wantOptional: []string{},
+			wantRequired: []string{"PROJECT_ID"},
+		},
+		{
+			desc: "unsupported non-colon default remains unchanged",
+			in:   "${FOO-default}",
+			want: "${FOO-default}",
+		},
+		{
+			desc: "unsupported non-colon required remains unchanged",
+			in:   "${FOO?message}",
+			want: "${FOO?message}",
 		},
 	}
 	for _, tc := range tcs {
@@ -247,8 +366,65 @@ func TestParseEnv(t *testing.T) {
 					t.Errorf("OptionalEnvVars element %d mismatch: got %q, want %q", i, v, tc.wantOptional[i])
 				}
 			}
+			if diff := cmp.Diff(tc.wantRequired, parser.requiredEnvVars); diff != "" {
+				t.Errorf("requiredEnvVars mismatch (-want +got):\n%s", diff)
+			}
 		})
 	}
+}
+
+func TestParseConfigEnvExpansion(t *testing.T) {
+	ctx, err := testutils.ContextWithNewLogger()
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	t.Run("expands non-empty default and required value", func(t *testing.T) {
+		t.Setenv("EMPTY_BASE_URL", "")
+		t.Setenv("REQUIRED_HEADER", "actual-header")
+		parser := ConfigParser{}
+		config, err := parser.ParseConfig(ctx, []byte(`
+kind: source
+name: my-http-instance
+type: http
+baseUrl: ${EMPTY_BASE_URL:-https://example.com}
+headers:
+  Required: ${REQUIRED_HEADER:?header is required}
+`))
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		source, ok := config.Sources["my-http-instance"].(httpsrc.Config)
+		if !ok {
+			t.Fatalf("unexpected source type: %T", config.Sources["my-http-instance"])
+		}
+		if source.BaseURL != "https://example.com" {
+			t.Errorf("BaseURL mismatch: got %q, want %q", source.BaseURL, "https://example.com")
+		}
+		if got := source.DefaultHeaders["Required"]; got != "actual-header" {
+			t.Errorf("required header mismatch: got %q, want %q", got, "actual-header")
+		}
+	})
+
+	t.Run("rejects empty required value", func(t *testing.T) {
+		t.Setenv("REQUIRED_HEADER", "")
+		parser := ConfigParser{}
+		_, err := parser.ParseConfig(ctx, []byte(`
+kind: source
+name: my-http-instance
+type: http
+baseUrl: https://example.com
+headers:
+  Required: ${REQUIRED_HEADER:?header is required}
+`))
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		want := `required environment variable is unset or empty: "REQUIRED_HEADER": header is required (line 7, column 13)`
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error mismatch: got %q, want substring %q", err, want)
+		}
+	})
 }
 
 func TestConvertConfig(t *testing.T) {

--- a/docs/en/documentation/configuration/_index.md
+++ b/docs/en/documentation/configuration/_index.md
@@ -12,18 +12,32 @@ tools.yaml` flag.
 
 ### Using Environment Variables
 
-To avoid hardcoding certain secret fields like passwords, usernames, API keys
-etc., you could use environment variables instead with the format `${ENV_NAME}`.
+To avoid hardcoding certain secret fields like passwords, usernames, API keys,
+etc., you can use environment variables. Toolbox supports these forms:
+
+| Syntax | Variable is unset | Variable is set to an empty string | Variable has a value |
+| --- | --- | --- | --- |
+| `${ENV_NAME}` | Error | Use the empty string | Use the value |
+| `${ENV_NAME:default}` | Use `default` | Use the empty string | Use the value |
+| `${ENV_NAME:-default}` | Use `default` | Use `default` | Use the value |
+| `${ENV_NAME:?message}` | Error | Error | Use the value |
+
+The message in `${ENV_NAME:?message}` is optional and is included in the
+startup error when provided.
 
 ```yaml
 user: ${USER_NAME}
 password: ${PASSWORD}
 ```
 
-A default value can be specified like `${ENV_NAME:default}`.
+A default value can be specified for an unset variable with
+`${ENV_NAME:default}`. Use `${ENV_NAME:-default}` when an empty value should
+also select the default.
 
 ```yaml
 port: ${DB_PORT:3306}
+host: ${DB_HOST:-localhost}
+password: ${PASSWORD:?database password is required}
 ```
 
 ### Sources


### PR DESCRIPTION
## Summary
- Add Compose/bash-style `${VAR:-default}` (use default when unset **or** empty) and `${VAR:?[message]}` (error when unset **or** empty).
- Keep legacy `${VAR}` and `${VAR:default}` semantics unchanged for back-compat (empty set values still interpolate).
- Expand table-driven `TestParseEnv` coverage across unset/empty/set for all forms; update configuration docs.

Fixes #3635.

## Test plan
- [x] `go test ./cmd/internal/ -run TestParseEnv -count=1`
- [x] `go test ./cmd/internal/ -count=1`