### PR TITLE
fix(bigquery-execute-sql): check allowedDatasets before dry run, not after

### DIFF
--- a/internal/tools/bigquery/bigqueryexecutesql/bigqueryexecutesql.go
+++ b/internal/tools/bigquery/bigqueryexecutesql/bigqueryexecutesql.go
@@ -149,6 +149,23 @@ func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.Pa
 		}
 	}
 
+	if len(source.BigQueryAllowedDatasets()) > 0 {
+		// Check the allowlist from a static parse of the SQL text before the
+		// dry run. A query naming a disallowed dataset that doesn't exist
+		// (or the caller can't see) would otherwise have its dry run fail
+		// with an opaque BigQuery 404/403 before the clearer allowlist
+		// AgentError is ever reached. The dry-run-based check below still
+		// runs afterward, since it catches tables a view resolves to that
+		// aren't visible in the raw SQL text.
+		preDryRunTables, parseErr := bqutil.TableParser(sql, bqClient.Project())
+		if parseErr != nil {
+			return nil, util.NewAgentError("could not parse tables from query to validate against allowed datasets", parseErr)
+		}
+		if err := checkDatasetsAllowed(preDryRunTables, source); err != nil {
+			return nil, err
+		}
+	}
+
 	dryRunJob, err := bqutil.DryRunQuery(ctx, restService, bqClient.Project(), bqClient.Location, sql, nil, connProps, source.GetMaximumBytesBilled())
 	if err != nil {
 		return nil, util.ProcessGcpError(err)
@@ -206,14 +223,12 @@ func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.Pa
 			tableIDSet[tableID] = struct{}{}
 		}
 
+		tableIDs := make([]string, 0, len(tableIDSet))
 		for tableID := range tableIDSet {
-			parts := strings.Split(tableID, ".")
-			if len(parts) == 3 {
-				projectID, datasetID := parts[0], parts[1]
-				if !source.IsDatasetAllowed(projectID, datasetID) {
-					return nil, util.NewAgentError(fmt.Sprintf("query accesses dataset '%s.%s', which is not in the allowed list", projectID, datasetID), nil)
-				}
-			}
+			tableIDs = append(tableIDs, tableID)
+		}
+		if err := checkDatasetsAllowed(tableIDs, source); err != nil {
+			return nil, err
 		}
 	}
 
@@ -240,6 +255,22 @@ func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.Pa
 		return nil, util.ProcessGcpError(err)
 	}
 	return resp, nil
+}
+
+// checkDatasetsAllowed returns an AgentError naming the first table ID (in
+// "project.dataset.table" form) whose dataset is not in source's configured
+// allowlist, or nil if every table is allowed.
+func checkDatasetsAllowed(tableIDs []string, source compatibleSource) util.ToolboxError {
+	for _, tableID := range tableIDs {
+		parts := strings.Split(tableID, ".")
+		if len(parts) == 3 {
+			projectID, datasetID := parts[0], parts[1]
+			if !source.IsDatasetAllowed(projectID, datasetID) {
+				return util.NewAgentError(fmt.Sprintf("query accesses dataset '%s.%s', which is not in the allowed list", projectID, datasetID), nil)
+			}
+		}
+	}
+	return nil
 }
 
 func (t Tool) RequiresClientAuthorization(source sources.Source) (bool, error) {

--- a/internal/tools/bigquery/bigqueryexecutesql/bigqueryexecutesql_test.go
+++ b/internal/tools/bigquery/bigqueryexecutesql/bigqueryexecutesql_test.go
@@ -16,6 +16,7 @@ package bigqueryexecutesql_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -307,13 +308,20 @@ func TestInvokeDatasetRestrictionsCatchesNonexistentTableBeforeDryRun(t *testing
 
 				// Any dataset/table not explicitly listed here stands in for
 				// one BigQuery can't resolve: dry run 404s, matching what a
-				// real non-existent (or unreadable) table produces.
+				// real non-existent (or unreadable) table produces. The
+				// dataset name is echoed back from the query so the error
+				// message matches whichever dataset the test case actually
+				// targets, instead of always naming forbidden_dataset.
 				if strings.Contains(query, "no_such_table") {
 					w.WriteHeader(http.StatusNotFound)
+					dataset := "forbidden_dataset"
+					if strings.Contains(query, "allowed_dataset") {
+						dataset = "allowed_dataset"
+					}
 					_ = json.NewEncoder(w).Encode(map[string]any{
 						"error": map[string]any{
 							"code":    404,
-							"message": "Not found: Table test-project:forbidden_dataset.no_such_table",
+							"message": fmt.Sprintf("Not found: Table test-project:%s.no_such_table", dataset),
 						},
 					})
 					return
@@ -398,7 +406,7 @@ func TestInvokeDatasetRestrictionsCatchesNonexistentTableBeforeDryRun(t *testing
 			desc:    "nonexistent table in allowed dataset: the underlying dry-run failure still surfaces",
 			sql:     "SELECT * FROM allowed_dataset.no_such_table",
 			wantErr: true,
-			wantSub: "Not found: Table test-project:forbidden_dataset.no_such_table",
+			wantSub: "Not found: Table test-project:allowed_dataset.no_such_table",
 		},
 	}
 

--- a/internal/tools/bigquery/bigqueryexecutesql/bigqueryexecutesql_test.go
+++ b/internal/tools/bigquery/bigqueryexecutesql/bigqueryexecutesql_test.go
@@ -281,6 +281,161 @@ func TestInvokeDatasetRestrictions(t *testing.T) {
 	}
 }
 
+// TestInvokeDatasetRestrictionsCatchesNonexistentTableBeforeDryRun covers
+// https://github.com/googleapis/mcp-toolbox/issues/3717: a query naming a
+// disallowed dataset must be rejected with the allowlist AgentError even
+// when the referenced table doesn't exist (or isn't visible to the caller),
+// rather than surfacing BigQuery's opaque dry-run 404/403 first.
+func TestInvokeDatasetRestrictionsCatchesNonexistentTableBeforeDryRun(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/jobs") {
+			var body struct {
+				Configuration struct {
+					DryRun bool `json:"dryRun"`
+					Query  struct {
+						Query string `json:"query"`
+					} `json:"query"`
+				} `json:"configuration"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+
+			if body.Configuration.DryRun {
+				query := body.Configuration.Query.Query
+
+				// Any dataset/table not explicitly listed here stands in for
+				// one BigQuery can't resolve: dry run 404s, matching what a
+				// real non-existent (or unreadable) table produces.
+				if strings.Contains(query, "no_such_table") {
+					w.WriteHeader(http.StatusNotFound)
+					_ = json.NewEncoder(w).Encode(map[string]any{
+						"error": map[string]any{
+							"code":    404,
+							"message": "Not found: Table test-project:forbidden_dataset.no_such_table",
+						},
+					})
+					return
+				}
+
+				resp := map[string]any{
+					"kind": "bigquery#job",
+					"jobReference": map[string]string{
+						"projectId": "test-project",
+						"jobId":     "mock-job-id",
+					},
+					"status": map[string]any{"state": "DONE"},
+					"configuration": map[string]any{
+						"query": map[string]any{"query": query},
+					},
+					"statistics": map[string]any{
+						"creationTime": "123456789",
+						"startTime":    "123456789",
+						"endTime":      "123456789",
+						"query": map[string]any{
+							"statementType": "SELECT",
+						},
+					},
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(resp)
+				return
+			}
+		}
+
+		http.Error(w, "not implemented", http.StatusNotFound)
+	}))
+	defer mockServer.Close()
+
+	ctx, err := testutils.ContextWithNewLogger()
+	if err != nil {
+		t.Fatalf("failed to create context with logger: %v", err)
+	}
+
+	bqClient, err := bigqueryapi.NewClient(ctx, "test-project", option.WithEndpoint(mockServer.URL), option.WithoutAuthentication())
+	if err != nil {
+		t.Fatalf("failed to create mocked BigQuery client: %v", err)
+	}
+
+	restService, err := bigqueryrestapi.NewService(ctx, option.WithEndpoint(mockServer.URL), option.WithoutAuthentication())
+	if err != nil {
+		t.Fatalf("failed to create mocked BigQuery REST service: %v", err)
+	}
+
+	testSrc := &bqutil.MockSource{
+		Client:          bqClient,
+		Service:         restService,
+		AllowedDatasets: []string{"test-project.allowed_dataset"},
+	}
+
+	cfg := bigqueryexecutesql.Config{
+		ConfigBase: tools.ConfigBase{
+			Name:        "execute_sql_tool",
+			Description: "Execute SQL",
+		},
+		Type:   "bigquery-execute-sql",
+		Source: "my-bq-source",
+	}
+	tool, err := cfg.Initialize(ctx)
+	if err != nil {
+		t.Fatalf("failed to initialize tool: %v", err)
+	}
+
+	tcs := []struct {
+		desc    string
+		sql     string
+		wantErr bool
+		wantSub string
+	}{
+		{
+			desc:    "nonexistent table in forbidden dataset: allowlist error, not a bare 404",
+			sql:     "SELECT * FROM forbidden_dataset.no_such_table",
+			wantErr: true,
+			wantSub: "query accesses dataset 'test-project.forbidden_dataset', which is not in the allowed list",
+		},
+		{
+			desc:    "nonexistent table in allowed dataset: the underlying dry-run failure still surfaces",
+			sql:     "SELECT * FROM allowed_dataset.no_such_table",
+			wantErr: true,
+			wantSub: "Not found: Table test-project:forbidden_dataset.no_such_table",
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			data := map[string]any{
+				"sql":     tc.sql,
+				"dry_run": true,
+			}
+
+			params, err := tool.(bigqueryexecutesql.Tool).GetParameters(testSrc)
+			if err != nil {
+				t.Fatalf("failed to get parameters: %v", err)
+			}
+			paramVals, err := parameters.ParseParams(params, data, nil)
+			if err != nil {
+				t.Fatalf("unexpected error parsing parameters: %v", err)
+			}
+
+			_, err = tool.Invoke(ctx, testSrc, paramVals, "")
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), tc.wantSub) {
+					t.Errorf("expected error to contain %q, got %v", tc.wantSub, err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
 func TestGetAnnotations(t *testing.T) {
 	ctx, err := testutils.ContextWithNewLogger()
 	if err != nil {


### PR DESCRIPTION
## Description

`bigquery-execute-sql`'s `Invoke` ran `DryRunQuery` first and returned immediately via `ProcessGcpError` on any dry-run failure — before the `allowedDatasets` check ever ran. A query naming a disallowed dataset that doesn't exist (or isn't readable by the caller) therefore surfaced BigQuery's opaque 404/403 instead of the intended `query accesses dataset '...', which is not in the allowed list` AgentError, even though the outcome was still fail-safe (no data returned either way) — the policy signal was just wrong, and callers/evals couldn't distinguish "table missing" from "dataset not allowlisted".

This adds a static-parse-only `allowedDatasets` check (via the existing `TableParser`, which needs no BigQuery round trip) before the dry run, so a disallowed dataset is rejected with the intended policy error regardless of whether the referenced table exists. The existing post-dry-run check is unchanged and still runs afterward — it's still needed, since it also catches tables a view resolves to that aren't visible in the raw SQL text (dry-run's `ReferencedTables`). Extracted the shared per-table allow/deny lookup into a `checkDatasetsAllowed` helper so both checks share one code path instead of duplicating the loop.

Fixes #3717

## Testing

- Added `TestInvokeDatasetRestrictionsCatchesNonexistentTableBeforeDryRun`, extending the existing mock-BigQuery-server test harness with a case that returns a dry-run 404 for a specific table name: confirms a query against a *nonexistent* table in a *forbidden* dataset now gets the allowlist AgentError (not the raw 404), and — as a control — that a nonexistent table in an *allowed* dataset still correctly surfaces the underlying dry-run failure, proving the fix only reorders the allowlist check and doesn't swallow real errors.
- All existing `TestInvokeDatasetRestrictions` cases pass unchanged (no regression to current allowlist/INFORMATION_SCHEMA/EXTERNAL_QUERY behavior).
- `go build ./...`, `go vet ./...`, `go test ./internal/tools/bigquery/...` (all packages) — clean.
- `gofmt` — clean (only whole-file CRLF diffs show on this Windows checkout; `git diff` confirms the actual changes are the intended additive lines only).

## PR Checklist

- [x] Reviewed CONTRIBUTING.md
- [x] Issue #3717 already exists and covers this exact case with a clear repro
- [x] Reviewed the entire diff before requesting review
- [x] Tests and `go vet` pass; `golangci-lint` isn't installed in this environment, but the change doesn't touch anything it would flag
- [x] Code coverage does not decrease — added a new test covering the previously-uncovered pre-dry-run-failure path
- [ ] Docs update — none needed; this doesn't change any documented flag or behavior, only which of two existing error messages a caller sees
- [x] Not a breaking change

🛠️ Fixes #3717