### PR TITLE
feat(tasks): add task models, AsyncTask interface and tool async config

### DIFF
--- a/internal/tasks/interfaces.go
+++ b/internal/tasks/interfaces.go
@@ -1,0 +1,27 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tasks
+
+import (
+	"context"
+
+	"github.com/googleapis/mcp-toolbox/internal/sources"
+)
+
+// AsyncTask defines the stateless proxy interface for managing long-running tasks.
+type AsyncTask interface {
+	GetStatus(ctx context.Context, s sources.Source, nativeID string) (*TaskStatusResult, error)
+	Cancel(ctx context.Context, s sources.Source, nativeID string) error
+}

--- a/internal/tasks/types.go
+++ b/internal/tasks/types.go
@@ -1,0 +1,68 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tasks
+
+// TaskStatus represents the current state of a task.
+type TaskStatus string
+
+const (
+	TaskStatusWorking       TaskStatus = "working"
+	TaskStatusInputRequired TaskStatus = "input_required"
+	TaskStatusCompleted     TaskStatus = "completed"
+	TaskStatusFailed        TaskStatus = "failed"
+	TaskStatusCancelled     TaskStatus = "cancelled"
+)
+
+// TaskError represents an error that occurred during task execution.
+type TaskError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Data    any    `json:"data,omitempty"`
+}
+
+// Task represents the canonical task shape from the MCP specification.
+type Task struct {
+	TaskID         string         `json:"taskId"`
+	Status         TaskStatus     `json:"status"`
+	StatusMessage  string         `json:"statusMessage,omitempty"`
+	CreatedAt      string         `json:"createdAt"`
+	LastUpdatedAt  string         `json:"lastUpdatedAt"`
+	TTLMs          *int64         `json:"ttlMs"`
+	PollIntervalMs int64          `json:"pollIntervalMs,omitempty"`
+	InputRequests  map[string]any `json:"inputRequests,omitempty"`
+	Result         any            `json:"result,omitempty"`
+	Error          *TaskError     `json:"error,omitempty"`
+}
+
+// CreateTaskResult is the payload returned in response to an eligible task-augmented request.
+type CreateTaskResult struct {
+	ResultType string `json:"resultType"`
+	Task
+}
+
+// TaskProgress represents the internal progress of a task.
+type TaskProgress struct {
+	Total    float64 `json:"total,omitempty"`
+	Progress float64 `json:"progress,omitempty"`
+}
+
+// TaskStatusResult is returned by the AsyncTask backend interface when queried for status.
+type TaskStatusResult struct {
+	Status        TaskStatus    `json:"status"`
+	Progress      *TaskProgress `json:"progress,omitempty"`
+	StatusMessage string        `json:"statusMessage,omitempty"`
+	Result        any           `json:"result,omitempty"`
+	Error         *TaskError    `json:"error,omitempty"`
+}

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -140,6 +140,7 @@ type Tool interface {
 	GetScopesRequired() []string
 	ValidateSource(sources.Source) error
 	HasSecureParams() bool
+	GetAsyncSetting() (*AsyncConfig, bool)
 }
 
 // PrimitiveManagerI defines the minimal view of the primitives.PrimitiveManager
@@ -171,6 +172,12 @@ func IsAuthorized(authRequiredSources []string, verifiedAuthServices []string) b
 	return false
 }
 
+// AsyncConfig defines the asynchronous configuration for a tool.
+type AsyncConfig struct {
+	PollIntervalMs int64 `yaml:"pollIntervalMs" json:"pollIntervalMs"`
+	TTLMs          int64 `yaml:"ttlMs" json:"ttlMs"`
+}
+
 // ToolMeta is the read-only view BaseTool needs of any tool's Config. Tools
 // satisfy it for free by embedding ConfigBase.
 type ToolMeta interface {
@@ -178,6 +185,7 @@ type ToolMeta interface {
 	GetDescription() string
 	GetAuthRequired() []string
 	GetScopesRequired() []string
+	GetAsyncSetting() (*AsyncConfig, bool)
 }
 
 // ConfigBase owns the YAML fields that every tool's Config shares and that
@@ -186,16 +194,23 @@ type ToolMeta interface {
 // configs omit description: and rely on a canned per-tool string), so
 // post-Initialize ConfigBase.Description holds the resolved value.
 type ConfigBase struct {
-	Name           string   `yaml:"name"           validate:"required"`
-	Description    string   `yaml:"description"`
-	AuthRequired   []string `yaml:"authRequired"`
-	ScopesRequired []string `yaml:"scopesRequired"`
+	Name           string       `yaml:"name"           validate:"required"`
+	Description    string       `yaml:"description"`
+	AuthRequired   []string     `yaml:"authRequired"`
+	ScopesRequired []string     `yaml:"scopesRequired"`
+	EnableAsync    *AsyncConfig `yaml:"enableAsync,omitempty"`
 }
 
 func (c ConfigBase) GetName() string             { return c.Name }
 func (c ConfigBase) GetDescription() string      { return c.Description }
 func (c ConfigBase) GetAuthRequired() []string   { return c.AuthRequired }
 func (c ConfigBase) GetScopesRequired() []string { return c.ScopesRequired }
+func (c ConfigBase) GetAsyncSetting() (*AsyncConfig, bool) {
+	if c.EnableAsync == nil {
+		return nil, false
+	}
+	return c.EnableAsync, true
+}
 
 // BaseTool provides default implementations of various methods on the Tool
 // interface. Tools embed BaseTool to drop their boilerplate and override
@@ -234,6 +249,7 @@ func (b BaseTool[T]) GetAuthRequired() []string                        { return 
 func (b BaseTool[T]) HasSecureParams() bool                            { return b.hasSecureParams }
 func (b BaseTool[T]) GetScopesRequired() []string                      { return b.Cfg.GetScopesRequired() }
 func (b BaseTool[T]) GetAnnotations(_ sources.Source) *ToolAnnotations { return b.annotations }
+func (b BaseTool[T]) GetAsyncSetting() (*AsyncConfig, bool)            { return b.Cfg.GetAsyncSetting() }
 
 // Manifest returns the precomputed metadata. It and GetParameters stay trivial
 // and never call each other: embedded methods have no virtual dispatch, so a

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -174,8 +174,8 @@ func IsAuthorized(authRequiredSources []string, verifiedAuthServices []string) b
 
 // AsyncConfig defines the asynchronous configuration for a tool.
 type AsyncConfig struct {
-	PollIntervalMs int64 `yaml:"pollIntervalMs" json:"pollIntervalMs"`
-	TTLMs          int64 `yaml:"ttlMs" json:"ttlMs"`
+	PollIntervalMs int64 `yaml:"pollIntervalMs" json:"pollIntervalMs" validate:"required,gt=0"`
+	TTLMs          int64 `yaml:"ttlMs" json:"ttlMs" validate:"required,gt=0"`
 }
 
 // ToolMeta is the read-only view BaseTool needs of any tool's Config. Tools

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -18,6 +18,9 @@ import (
 	"context"
 	"testing"
 
+	"github.com/goccy/go-yaml"
+
+	"github.com/go-playground/validator/v10"
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/mcp-toolbox/internal/sources"
 	"github.com/googleapis/mcp-toolbox/internal/testutils"
@@ -220,6 +223,95 @@ func TestShouldSuppress(t *testing.T) {
 			}
 			if got := tools.ShouldSuppress(context.Background(), tool, tt.src); got != tt.want {
 				t.Errorf("ShouldSuppress() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConfigBaseYamlParsing_AsyncTask(t *testing.T) {
+	yamlData := `
+name: async-tool
+enableAsync:
+  pollIntervalMs: 5000
+  ttlMs: 3600000
+`
+	var cfg tools.ConfigBase
+	if err := yaml.Unmarshal([]byte(yamlData), &cfg); err != nil {
+		t.Fatalf("yaml.Unmarshal error: %v", err)
+	}
+
+	if cfg.Name != "async-tool" {
+		t.Errorf("cfg.Name = %v, want %v", cfg.Name, "async-tool")
+	}
+
+	asyncSettings, ok := cfg.GetAsyncSetting()
+	if !ok {
+		t.Fatalf("GetAsyncSetting() = false, want true")
+	}
+	if asyncSettings.PollIntervalMs != 5000 {
+		t.Errorf("PollIntervalMs = %v, want 5000", asyncSettings.PollIntervalMs)
+	}
+	if asyncSettings.TTLMs != 3600000 {
+		t.Errorf("TTLMs = %v, want 3600000", asyncSettings.TTLMs)
+	}
+}
+
+func TestConfigBaseYamlParsing_NoAsync(t *testing.T) {
+	yamlData := `
+name: sync-tool
+`
+	var cfg tools.ConfigBase
+	if err := yaml.Unmarshal([]byte(yamlData), &cfg); err != nil {
+		t.Fatalf("yaml.Unmarshal error: %v", err)
+	}
+
+	_, ok := cfg.GetAsyncSetting()
+	if ok {
+		t.Fatalf("GetAsyncSetting() = true, want false")
+	}
+}
+
+func TestConfigBaseYamlParsing_Async_Invalid(t *testing.T) {
+	testCases := []struct {
+		name     string
+		yamlData string
+	}{
+		{
+			name: "missing pollIntervalMs",
+			yamlData: `
+name: async-tool
+enableAsync:
+  ttlMs: 3600000
+`,
+		},
+		{
+			name: "negative pollIntervalMs",
+			yamlData: `
+name: async-tool
+enableAsync:
+  pollIntervalMs: -1
+  ttlMs: 3600000
+`,
+		},
+		{
+			name: "zero ttlMs",
+			yamlData: `
+name: async-tool
+enableAsync:
+  pollIntervalMs: 5000
+  ttlMs: 0
+`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var cfg tools.ConfigBase
+			// Note: we don't just call yaml.Unmarshal. The actual codebase uses util.UnmarshalYAML which uses the validator.
+			// However, in tools_test.go, we should test what util.UnmarshalYAML does or test the validator directly.
+			err := yaml.UnmarshalWithOptions([]byte(tc.yamlData), &cfg, yaml.Validator(validator.New()))
+			if err == nil {
+				t.Fatalf("expected validation error, got none")
 			}
 		})
 	}


### PR DESCRIPTION
- Added MCP `Task` and `CreateTaskResult` payload structures (`internal/tasks/types.go`).
- Defined the stateless `AsyncTask` interface for database sources to proxy LROs (`internal/tasks/interfaces.go`).
- Updated `tools.yaml` parsing to support the new `enableAsync` configuration block (`internal/tools/tools.go`).