### PR TITLE
feat(resources): allow skill:// URIs on file resources

### DIFF
--- a/internal/resources/file/file.go
+++ b/internal/resources/file/file.go
@@ -117,9 +117,10 @@ func (c *Config) Validate() error {
 	if err := c.ResourceConfigBase.Validate(); err != nil {
 		return err
 	}
-	parsed, _ := url.Parse(c.URI)
-	if !c.UI && parsed.Scheme != "file" {
-		return fmt.Errorf("invalid scheme for file resource %q: must be 'file'", c.Name)
+	if !c.UI {
+		if err := resources.ValidateScheme(c.URI, resourceType); err != nil {
+			return fmt.Errorf("invalid scheme for file resource %q: %w", c.Name, err)
+		}
 	}
 
 	if c.MaxSize != nil {
@@ -446,9 +447,10 @@ func (c *TemplateConfig) Validate() error {
 	if err := c.ResourceTemplateConfigBase.Validate(); err != nil {
 		return err
 	}
-	parsed, _ := url.Parse(strings.ReplaceAll(c.URITemplate, "{path}", "path"))
-	if !c.UI && parsed.Scheme != "file" {
-		return fmt.Errorf("invalid scheme for file resource template %q: must be 'file'", c.Name)
+	if !c.UI {
+		if err := resources.ValidateScheme(strings.ReplaceAll(c.URITemplate, "{path}", "path"), resourceType); err != nil {
+			return fmt.Errorf("invalid scheme for file resource template %q: %w", c.Name, err)
+		}
 	}
 
 	if c.MaxSize != nil {

--- a/internal/resources/file/file_test.go
+++ b/internal/resources/file/file_test.go
@@ -105,6 +105,79 @@ func TestParseFromYamlFile(t *testing.T) {
 				},
 			},
 		},
+		{
+			// A file resource may also be addressed under skill://, which is
+			// what lets a skill's files be declared by hand.
+			desc: "skill scheme uri",
+			in: fmt.Sprintf(`
+			kind: resource
+			name: queries
+			type: file
+			uri: skill://analytics-guide/references/queries.md
+			path: %s
+			`, filepath.ToSlash(validPath)),
+			want: server.ResourceConfigs{
+				"queries": &file.Config{
+					ResourceConfigBase: resources.ResourceConfigBase{
+						ConfigBase: resources.ConfigBase{
+							Name:        "queries",
+							Type:        "file",
+							Annotations: &resources.ResourceAnnotations{Priority: func(f float64) *float64 { return &f }(1.0)},
+						},
+						URI: "skill://analytics-guide/references/queries.md",
+					},
+					Path: filepath.ToSlash(validPath),
+				},
+			},
+		},
+		{
+			// Schemes and hosts are case-insensitive per RFC 3986 §3.1 and §3.2.2,
+			// so both are normalized to lowercase on the way in. The path is not.
+			desc: "uppercase native scheme is normalized",
+			in: fmt.Sprintf(`
+			kind: resource
+			name: queries
+			type: file
+			uri: FILE://Queries
+			path: %s
+			`, filepath.ToSlash(validPath)),
+			want: server.ResourceConfigs{
+				"queries": &file.Config{
+					ResourceConfigBase: resources.ResourceConfigBase{
+						ConfigBase: resources.ConfigBase{
+							Name:        "queries",
+							Type:        "file",
+							Annotations: &resources.ResourceAnnotations{Priority: func(f float64) *float64 { return &f }(1.0)},
+						},
+						URI: "file://queries",
+					},
+					Path: filepath.ToSlash(validPath),
+				},
+			},
+		},
+		{
+			desc: "uppercase skill scheme is normalized",
+			in: fmt.Sprintf(`
+			kind: resource
+			name: queries
+			type: file
+			uri: SKILL://Analytics-Guide/references/queries.md
+			path: %s
+			`, filepath.ToSlash(validPath)),
+			want: server.ResourceConfigs{
+				"queries": &file.Config{
+					ResourceConfigBase: resources.ResourceConfigBase{
+						ConfigBase: resources.ConfigBase{
+							Name:        "queries",
+							Type:        "file",
+							Annotations: &resources.ResourceAnnotations{Priority: func(f float64) *float64 { return &f }(1.0)},
+						},
+						URI: "skill://analytics-guide/references/queries.md",
+					},
+					Path: filepath.ToSlash(validPath),
+				},
+			},
+		},
 	}
 
 	for _, tc := range tcs {
@@ -151,6 +224,39 @@ func TestFailParseFromYaml(t *testing.T) {
 			type: file
 			`,
 			err: "Field validation for 'Path' failed on the 'required' tag",
+		},
+		{
+			desc: "foreign scheme",
+			in: fmt.Sprintf(`
+			kind: resource
+			name: my-file
+			type: file
+			uri: query://my-file
+			path: %s
+			`, filepath.ToSlash(validPath)),
+			err: "must be 'file' or 'skill'",
+		},
+		{
+			desc: "text scheme",
+			in: fmt.Sprintf(`
+			kind: resource
+			name: my-file
+			type: file
+			uri: text://my-file
+			path: %s
+			`, filepath.ToSlash(validPath)),
+			err: "must be 'file' or 'skill'",
+		},
+		{
+			desc: "uppercase foreign scheme",
+			in: fmt.Sprintf(`
+			kind: resource
+			name: my-file
+			type: file
+			uri: QUERY://my-file
+			path: %s
+			`, filepath.ToSlash(validPath)),
+			err: "must be 'file' or 'skill'",
 		},
 		{
 			desc: "maxSize zero",

--- a/internal/resources/file/template_test.go
+++ b/internal/resources/file/template_test.go
@@ -357,6 +357,36 @@ func TestFileTemplate_Validation(t *testing.T) {
 			wantErrMsg: "failed on the 'required' tag",
 		},
 		{
+			name: "foreign scheme",
+			yamlStr: `
+			kind: resourceTemplate
+			name: my-template
+			type: file
+			uriTemplate: "query://{path}"
+			`,
+			wantErrMsg: "must be 'file' or 'skill'",
+		},
+		{
+			name: "text scheme",
+			yamlStr: `
+			kind: resourceTemplate
+			name: my-template
+			type: file
+			uriTemplate: "text://{path}"
+			`,
+			wantErrMsg: "must be 'file' or 'skill'",
+		},
+		{
+			name: "uppercase foreign scheme",
+			yamlStr: `
+			kind: resourceTemplate
+			name: my-template
+			type: file
+			uriTemplate: "QUERY://{path}"
+			`,
+			wantErrMsg: "must be 'file' or 'skill'",
+		},
+		{
 			name: "invalid maxSize negative",
 			yamlStr: `
 			kind: resourceTemplate
@@ -513,4 +543,37 @@ allowedPaths:
 			t.Fatalf("Expected error for ui scheme with ui: false, got %v", err)
 		}
 	})
+}
+
+// TestFileTemplate_AllowedSchemes is the accepting counterpart to the scheme
+// cases in TestFileTemplate_Validation. skill:// is what lets a skill declare
+// its directory of files as a single template.
+func TestFileTemplate_AllowedSchemes(t *testing.T) {
+	tests := []struct {
+		name        string
+		uriTemplate string
+	}{
+		{"native scheme", "file://{path}"},
+		{"skill scheme", "skill://analytics-guide/references/{path}"},
+		{"uppercase skill scheme", "SKILL://analytics-guide/references/{path}"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			yamlStr := fmt.Sprintf(`
+			kind: resourceTemplate
+			name: my-template
+			type: file
+			uriTemplate: %q
+			`, tt.uriTemplate)
+
+			_, _, _, _, _, _, got, _, err := server.UnmarshalPrimitiveConfig(context.Background(), testutils.FormatYaml(yamlStr))
+			if err != nil {
+				t.Fatalf("parsing %s: got %v, want nil", tt.uriTemplate, err)
+			}
+			if _, ok := got["my-template"]; !ok {
+				t.Fatalf("parsing %s: template not registered, got %v", tt.uriTemplate, got)
+			}
+		})
+	}
 }

--- a/internal/resources/resources.go
+++ b/internal/resources/resources.go
@@ -36,6 +36,22 @@ const UIMimeType = "text/html;profile=mcp-app"
 // BaseDirKey is the context key for storing the base directory path during config parsing.
 const BaseDirKey contextKey = "baseDir"
 
+// SkillScheme is how a resource belonging to an Agent Skill is addressed,
+// as skill://<skill-name>/<path>, whichever resource type backs it.
+const SkillScheme = "skill"
+
+// ValidateScheme checks uri against the schemes a resource may be addressed by:
+// nativeScheme, which is the resource's own type (eg. file), or SkillScheme. The
+// returned error names the accepted set, so callers need only prefix it with the
+// resource they were validating.
+func ValidateScheme(uri, nativeScheme string) error {
+	parsed, err := url.Parse(uri)
+	if err != nil || (parsed.Scheme != nativeScheme && parsed.Scheme != SkillScheme) {
+		return fmt.Errorf("must be '%s' or '%s'", nativeScheme, SkillScheme)
+	}
+	return nil
+}
+
 // GetBaseDirFromContext extracts the base directory path from the context.
 func GetBaseDirFromContext(ctx context.Context) string {
 	if ctx == nil {


### PR DESCRIPTION
## Description

A resource that belongs to an Agent Skill is addressed under `skill://` so resources have to accept that scheme alongside their own. Without this, a skill's files cannot be declared at all.