### PR TITLE
ci(source/bigtable): parameterize coverage threshold for cheap test path

### DIFF
--- a/.ci/integration.cloudbuild.yaml
+++ b/.ci/integration.cloudbuild.yaml
@@ -285,7 +285,7 @@ steps:
             export RUN_EXPENSIVE_TESTS="true"
           fi
           if [ "$$RUN_EXPENSIVE_TESTS" != "true" ]; then
-            # Admin tool tests skipped; measured baseline is 42.6%.
+            # Admin tool tests are skipped here, so their packages go uncovered.
             export COVERAGE_THRESHOLD=40
           fi
           .ci/test_with_coverage.sh \

--- a/.ci/integration.cloudbuild.yaml
+++ b/.ci/integration.cloudbuild.yaml
@@ -283,8 +283,9 @@ steps:
           echo "Changes detected. Running Bigtable tests..."
           if grep -qE "(^|/)bigtable/" /workspace/changed_files.txt; then
             export RUN_EXPENSIVE_TESTS="true"
-          else
-            # Admin tool tests are skipped here, so their packages go uncovered.
+          fi
+          if [ "$$RUN_EXPENSIVE_TESTS" != "true" ]; then
+            # Admin tool tests skipped; measured baseline is 42.6%.
             export COVERAGE_THRESHOLD=40
           fi
           .ci/test_with_coverage.sh \

--- a/.ci/integration.cloudbuild.yaml
+++ b/.ci/integration.cloudbuild.yaml
@@ -283,6 +283,9 @@ steps:
           echo "Changes detected. Running Bigtable tests..."
           if grep -qE "(^|/)bigtable/" /workspace/changed_files.txt; then
             export RUN_EXPENSIVE_TESTS="true"
+          else
+            # Admin tool tests are skipped here, so their packages go uncovered.
+            export COVERAGE_THRESHOLD=40
           fi
           .ci/test_with_coverage.sh \
             "Bigtable" \

--- a/.ci/test_with_coverage.sh
+++ b/.ci/test_with_coverage.sh
@@ -6,6 +6,10 @@
 # $3, $4, ...: Tool package names for grep (e.g., postgressql), if the
 # integration test specifically check a separate package inside a folder, please
 # specify the full path instead (e.g., postgressql/postgresexecutesql)
+#
+# Environment:
+# COVERAGE_THRESHOLD: minimum coverage percentage (default 50)
+# EXTRA_TEST_ARGS: extra flags passed to the test binary
 
 DISPLAY_NAME="$1"
 SOURCE_PACKAGE_NAME="$2"
@@ -23,8 +27,6 @@ TOOL_PACKAGE_NAMES=("$@")
 COVERAGE_FILE="${TEST_BINARY%.test}_coverage.out"
 FILTERED_COVERAGE_FILE="${TEST_BINARY%.test}_filtered_coverage.out"
 
-# Shards that deliberately skip part of their suite (e.g. quota-bound tests)
-# lower this; everything else is held to 50%.
 COVERAGE_THRESHOLD="${COVERAGE_THRESHOLD:-50}"
 
 export path="github.com/googleapis/mcp-toolbox/internal/"

--- a/.ci/test_with_coverage.sh
+++ b/.ci/test_with_coverage.sh
@@ -23,6 +23,10 @@ TOOL_PACKAGE_NAMES=("$@")
 COVERAGE_FILE="${TEST_BINARY%.test}_coverage.out"
 FILTERED_COVERAGE_FILE="${TEST_BINARY%.test}_filtered_coverage.out"
 
+# Shards that deliberately skip part of their suite (e.g. quota-bound tests)
+# lower this; everything else is held to 50%.
+COVERAGE_THRESHOLD="${COVERAGE_THRESHOLD:-50}"
+
 export path="github.com/googleapis/mcp-toolbox/internal/"
 
 GREP_PATTERN="^mode:|${path}${SOURCE_PATH}"
@@ -54,8 +58,8 @@ echo "${DISPLAY_NAME} total coverage: $total_coverage"
 coverage_numeric=$(echo "$total_coverage" | sed 's/%//')
 
 # Check coverage threshold
-if awk -v coverage="$coverage_numeric" 'BEGIN {exit !(coverage < 50)}'; then
-    echo "Coverage failure: ${DISPLAY_NAME} total coverage($total_coverage) is below 50%."
+if awk -v coverage="$coverage_numeric" -v threshold="$COVERAGE_THRESHOLD" 'BEGIN {exit !(coverage < threshold)}'; then
+    echo "Coverage failure: ${DISPLAY_NAME} total coverage($total_coverage) is below ${COVERAGE_THRESHOLD}%."
     exit 1
 else
     echo "Coverage for ${DISPLAY_NAME} is sufficient."


### PR DESCRIPTION
## 1. Description

The Bigtable integration shard fails on any build that runs it without touching `bigtable/`. It is not a flake; retrying always fails the same way. This covers:

- **PRs changing shared code** — `.ci/`, `cmd/`, `go.mod`, `internal/server/`, etc.
- **Post-merge builds** — `detect-changes` falls back to writing `.ci/integration.cloudbuild.yaml` when the diff is empty, which matches `core_pattern` but not `bigtable/`.

**Cause.** #3908 gated the expensive Bigtable admin tool tests behind `RUN_EXPENSIVE_TESTS`, exported only when `bigtable/` files change. But the shard also runs on `core_pattern.txt` matches. On those runs the admin tool tests are skipped, the ~25 admin tool packages go uncovered, and coverage lands at 42.6% — below the 50% floor hardcoded in `.ci/test_with_coverage.sh`. The shard runs a reduced suite, then grades it against the full-suite standard.

**Fix.** Make the floor an env var defaulting to 50, matching `.ci/test_prompts_with_coverage.sh`, and lower it to 40 when `RUN_EXPENSIVE_TESTS` is not `true`.

The condition keys off the effective value of `RUN_EXPENSIVE_TESTS` rather than the diff, because the two can disagree: the `_RUN_EXPENSIVE_TESTS` substitution is the other input. Keying off the diff would hand a nightly running the full suite the relaxed 40% floor.

| Build | Suite | Threshold |
| --- | --- | --- |
| PR touching `bigtable/` | full | 50% |
| PR touching core only | reduced | 40% |
| Nightly (`_RUN_EXPENSIVE_TESTS=true`) | full | 50% |
| Post-merge (default) | reduced | 40% |
| All other shards | — | 50% (unchanged) |

**Verification.** Simulated all five paths against the rendered step script. Confirmed the `awk` threshold comparison is numeric in gawk, mawk, busybox awk, and `/usr/bin/awk` in `golang:1`.

**Follow-up.** 40% is tied to today's measurement and will drift as admin tool code grows. The durable fix is to drop the admin tool packages from the coverage calculation when their tests are skipped, so the number reflects only what ran. Out of scope here — this PR is limited to unblocking `main`.

## 2. PR Checklist

- [ ] Make sure to open an issue as a bug/issue before writing your code!
- [x] Ensure you have manually reviewed the entire diff before requesting a review
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
- [x] Make sure to add `!` if this involves a breaking change

## 3. Issue Reference

Regression from #3908 🦕