### PR TITLE
feat(bigquery): add limit/prefix to list_dataset_ids and list_table_ids

### DIFF
--- a/internal/tools/bigquery/bigquerycommon/mock_source.go
+++ b/internal/tools/bigquery/bigquerycommon/mock_source.go
@@ -32,12 +32,17 @@ type MockSource struct {
 	Client          *bigqueryapi.Client
 	Service         *bigqueryrestapi.Service
 	AllowedDatasets []string
+	Project         string
 	RunSQLResult    any
 	RunSQLError     error
 }
 
 func (m *MockSource) BigQueryClient() *bigqueryapi.Client {
 	return m.Client
+}
+
+func (m *MockSource) BigQueryProject() string {
+	return m.Project
 }
 
 func (m *MockSource) UseClientAuthorization() bool {

--- a/internal/tools/bigquery/bigquerylistdatasetids/bigquerylistdatasetids.go
+++ b/internal/tools/bigquery/bigquerylistdatasetids/bigquerylistdatasetids.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	bigqueryapi "cloud.google.com/go/bigquery"
 	yaml "github.com/goccy/go-yaml"
@@ -31,6 +32,8 @@ import (
 
 const resourceType string = "bigquery-list-dataset-ids"
 const projectKey string = "project"
+const limitKey string = "limit"
+const prefixKey string = "prefix"
 
 func init() {
 	if !tools.Register(resourceType, newConfig) {
@@ -120,6 +123,11 @@ func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.Pa
 	if !ok {
 		return nil, util.NewAgentError(fmt.Sprintf("invalid or missing '%s' parameter; expected a string", projectKey), nil)
 	}
+	limit, _ := mapParams[limitKey].(int)
+	if limit < 0 {
+		return nil, util.NewAgentError(fmt.Sprintf("invalid '%s' parameter: %d must be >= 0 (use 0 for no limit)", limitKey, limit), nil)
+	}
+	prefix, _ := mapParams[prefixKey].(string)
 
 	bqClient, _, err := source.RetrieveClientAndService(accessToken)
 	if err != nil {
@@ -130,6 +138,9 @@ func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.Pa
 
 	var datasetIds []any
 	for {
+		if limit > 0 && len(datasetIds) >= limit {
+			break
+		}
 		dataset, err := datasetIterator.Next()
 		if err == iterator.Done {
 			break
@@ -142,6 +153,9 @@ func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.Pa
 		id := dataset.DatasetID
 		if len(id) >= 2 && id[0] == '"' && id[len(id)-1] == '"' {
 			id = id[1 : len(id)-1]
+		}
+		if prefix != "" && !strings.HasPrefix(id, prefix) {
+			continue
 		}
 		datasetIds = append(datasetIds, id)
 	}
@@ -173,7 +187,9 @@ func buildParams(allowedDatasets []string, defaultProject string) parameters.Par
 		projectParameterDescription = "This parameter will be ignored. The list of datasets is restricted to a pre-configured list; No need to provide a project ID."
 	}
 	projectParameter := parameters.NewStringParameter(projectKey, projectParameterDescription, parameters.WithStringDefault(defaultProject))
-	return parameters.Parameters{projectParameter}
+	limitParameter := parameters.NewIntParameter(limitKey, "Maximum number of dataset ids to return. A value of 0 (the default) returns every dataset id in the project.", parameters.WithIntDefault(0))
+	prefixParameter := parameters.NewStringParameter(prefixKey, "Only return dataset ids that start with this prefix (case-sensitive). Empty (the default) returns every dataset id.", parameters.WithStringDefault(""))
+	return parameters.Parameters{projectParameter, limitParameter, prefixParameter}
 }
 
 // resolveParams builds the tool's parameters using the source's allowed-dataset configuration.

--- a/internal/tools/bigquery/bigquerylistdatasetids/bigquerylistdatasetids_limit_test.go
+++ b/internal/tools/bigquery/bigquerylistdatasetids/bigquerylistdatasetids_limit_test.go
@@ -1,0 +1,173 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bigquerylistdatasetids_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	bigqueryapi "cloud.google.com/go/bigquery"
+	"github.com/googleapis/mcp-toolbox/internal/tools"
+	bqutil "github.com/googleapis/mcp-toolbox/internal/tools/bigquery/bigquerycommon"
+	"github.com/googleapis/mcp-toolbox/internal/tools/bigquery/bigquerylistdatasetids"
+	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
+	"google.golang.org/api/option"
+)
+
+// Covers https://github.com/googleapis/mcp-toolbox/issues/3975: list_dataset_ids
+// iterated (and returned) every dataset in the project with no way to bound
+// the response, which produced multi-megabyte results on large projects.
+func TestInvokeBoundsResultWithLimitAndPrefix(t *testing.T) {
+	allDatasetIDs := []string{"analytics_a", "analytics_b", "reporting_a", "reporting_b", "staging"}
+
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.HasSuffix(r.URL.Path, "/datasets") {
+			http.Error(w, "not implemented", http.StatusNotFound)
+			return
+		}
+		datasets := make([]map[string]any, 0, len(allDatasetIDs))
+		for _, id := range allDatasetIDs {
+			datasets = append(datasets, map[string]any{
+				"datasetReference": map[string]any{
+					"projectId": "test-project",
+					"datasetId": id,
+				},
+			})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"kind": "bigquery#datasetList", "datasets": datasets})
+	}))
+	defer mockServer.Close()
+
+	ctx := t.Context()
+	bqClient, err := bigqueryapi.NewClient(ctx, "test-project", option.WithEndpoint(mockServer.URL), option.WithoutAuthentication())
+	if err != nil {
+		t.Fatalf("failed to create mocked BigQuery client: %v", err)
+	}
+
+	testSrc := &bqutil.MockSource{Client: bqClient, Project: "test-project"}
+
+	cfg := bigquerylistdatasetids.Config{
+		ConfigBase: tools.ConfigBase{Name: "list_dataset_ids_tool", Description: "List dataset ids"},
+		Type:       "bigquery-list-dataset-ids",
+		Source:     "my-bq-source",
+	}
+	tool, err := cfg.Initialize(ctx)
+	if err != nil {
+		t.Fatalf("failed to initialize tool: %v", err)
+	}
+
+	tcs := []struct {
+		desc      string
+		extraArgs map[string]any
+		want      []string
+	}{
+		{
+			desc: "no limit or prefix returns every dataset, unchanged from today's behavior",
+			want: allDatasetIDs,
+		},
+		{
+			desc:      "limit truncates to the first N without fetching the rest",
+			extraArgs: map[string]any{"limit": 2},
+			want:      []string{"analytics_a", "analytics_b"},
+		},
+		{
+			desc:      "prefix filters regardless of limit",
+			extraArgs: map[string]any{"prefix": "reporting_"},
+			want:      []string{"reporting_a", "reporting_b"},
+		},
+		{
+			desc:      "limit and prefix combine: limit counts only prefix matches",
+			extraArgs: map[string]any{"prefix": "reporting_", "limit": 1},
+			want:      []string{"reporting_a"},
+		},
+		{
+			desc:      "prefix matching nothing returns an empty, not nil, result",
+			extraArgs: map[string]any{"prefix": "does-not-exist"},
+			want:      []string{},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			data := map[string]any{"project": "test-project"}
+			for k, v := range tc.extraArgs {
+				data[k] = v
+			}
+
+			params, err := tool.GetParameters(testSrc)
+			if err != nil {
+				t.Fatalf("failed to get parameters: %v", err)
+			}
+			paramVals, err := parameters.ParseParams(params, data, nil)
+			if err != nil {
+				t.Fatalf("unexpected error parsing parameters: %v", err)
+			}
+
+			got, toolErr := tool.Invoke(ctx, testSrc, paramVals, "")
+			if toolErr != nil {
+				t.Fatalf("unexpected error: %v", toolErr)
+			}
+
+			gotIDs := make([]string, 0)
+			for _, v := range got.([]any) {
+				gotIDs = append(gotIDs, v.(string))
+			}
+			if len(gotIDs) != len(tc.want) {
+				t.Fatalf("got %v, want %v", gotIDs, tc.want)
+			}
+			for i, id := range tc.want {
+				if gotIDs[i] != id {
+					t.Fatalf("got %v, want %v", gotIDs, tc.want)
+				}
+			}
+		})
+	}
+}
+
+func TestInvokeRejectsNegativeLimit(t *testing.T) {
+	ctx := t.Context()
+	testSrc := &bqutil.MockSource{Project: "test-project"}
+
+	cfg := bigquerylistdatasetids.Config{
+		ConfigBase: tools.ConfigBase{Name: "list_dataset_ids_tool", Description: "List dataset ids"},
+		Type:       "bigquery-list-dataset-ids",
+		Source:     "my-bq-source",
+	}
+	tool, err := cfg.Initialize(ctx)
+	if err != nil {
+		t.Fatalf("failed to initialize tool: %v", err)
+	}
+
+	params, err := tool.GetParameters(testSrc)
+	if err != nil {
+		t.Fatalf("failed to get parameters: %v", err)
+	}
+	paramVals, err := parameters.ParseParams(params, map[string]any{"project": "test-project", "limit": -1}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error parsing parameters: %v", err)
+	}
+
+	_, toolErr := tool.Invoke(ctx, testSrc, paramVals, "")
+	if toolErr == nil {
+		t.Fatalf("expected an error for a negative limit, got nil")
+	}
+	if !strings.Contains(toolErr.Error(), "must be >= 0") {
+		t.Fatalf("expected error to mention 'must be >= 0', got %v", toolErr)
+	}
+}

--- a/internal/tools/bigquery/bigquerylisttableids/bigquerylisttableids.go
+++ b/internal/tools/bigquery/bigquerylisttableids/bigquerylisttableids.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	bigqueryapi "cloud.google.com/go/bigquery"
 	yaml "github.com/goccy/go-yaml"
@@ -33,6 +34,8 @@ import (
 const resourceType string = "bigquery-list-table-ids"
 const projectKey string = "project"
 const datasetKey string = "dataset"
+const limitKey string = "limit"
+const prefixKey string = "prefix"
 
 func init() {
 	if !tools.Register(resourceType, newConfig) {
@@ -129,6 +132,11 @@ func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.Pa
 	if !source.IsDatasetAllowed(projectId, datasetId) {
 		return nil, util.NewAgentError(fmt.Sprintf("access denied to dataset '%s' because it is not in the configured list of allowed datasets for project '%s'", datasetId, projectId), nil)
 	}
+	limit, _ := mapParams[limitKey].(int)
+	if limit < 0 {
+		return nil, util.NewAgentError(fmt.Sprintf("invalid '%s' parameter: %d must be >= 0 (use 0 for no limit)", limitKey, limit), nil)
+	}
+	prefix, _ := mapParams[prefixKey].(string)
 
 	bqClient, _, err := source.RetrieveClientAndService(accessToken)
 	if err != nil {
@@ -140,6 +148,9 @@ func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.Pa
 	var tableIds []any
 	tableIterator := dsHandle.Tables(ctx)
 	for {
+		if limit > 0 && len(tableIds) >= limit {
+			break
+		}
 		table, err := tableIterator.Next()
 		if err == iterator.Done {
 			break
@@ -152,6 +163,9 @@ func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.Pa
 		id := table.TableID
 		if len(id) >= 2 && id[0] == '"' && id[len(id)-1] == '"' {
 			id = id[1 : len(id)-1]
+		}
+		if prefix != "" && !strings.HasPrefix(id, prefix) {
+			continue
 		}
 		tableIds = append(tableIds, id)
 	}
@@ -181,7 +195,9 @@ func buildParams(allowedDatasets []string, defaultProject string) parameters.Par
 	projectDescription := "The Google Cloud project ID containing the dataset."
 	datasetDescription := "The dataset to list table ids."
 	projectParameter, datasetParameter := bqutil.InitializeDatasetParameters(allowedDatasets, defaultProject, projectKey, datasetKey, projectDescription, datasetDescription)
-	return parameters.Parameters{projectParameter, datasetParameter}
+	limitParameter := parameters.NewIntParameter(limitKey, "Maximum number of table ids to return. A value of 0 (the default) returns every table id in the dataset.", parameters.WithIntDefault(0))
+	prefixParameter := parameters.NewStringParameter(prefixKey, "Only return table ids that start with this prefix (case-sensitive). Empty (the default) returns every table id.", parameters.WithStringDefault(""))
+	return parameters.Parameters{projectParameter, datasetParameter, limitParameter, prefixParameter}
 }
 
 // resolveParams builds the tool's parameters using the source's allowed-dataset configuration.

--- a/internal/tools/bigquery/bigquerylisttableids/bigquerylisttableids_limit_test.go
+++ b/internal/tools/bigquery/bigquerylisttableids/bigquerylisttableids_limit_test.go
@@ -1,0 +1,168 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bigquerylisttableids_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	bigqueryapi "cloud.google.com/go/bigquery"
+	"github.com/googleapis/mcp-toolbox/internal/tools"
+	bqutil "github.com/googleapis/mcp-toolbox/internal/tools/bigquery/bigquerycommon"
+	"github.com/googleapis/mcp-toolbox/internal/tools/bigquery/bigquerylisttableids"
+	"github.com/googleapis/mcp-toolbox/internal/util/parameters"
+	"google.golang.org/api/option"
+)
+
+// Covers the list_table_ids half of https://github.com/googleapis/mcp-toolbox/issues/3975:
+// same unbounded-iterator shape as list_dataset_ids, on a dataset with many tables.
+func TestInvokeBoundsResultWithLimitAndPrefix(t *testing.T) {
+	allTableIDs := []string{"events_a", "events_b", "users_a", "users_b", "staging"}
+
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.HasSuffix(r.URL.Path, "/tables") {
+			http.Error(w, "not implemented", http.StatusNotFound)
+			return
+		}
+		tables := make([]map[string]any, 0, len(allTableIDs))
+		for _, id := range allTableIDs {
+			tables = append(tables, map[string]any{
+				"tableReference": map[string]any{
+					"projectId": "test-project",
+					"datasetId": "test-dataset",
+					"tableId":   id,
+				},
+			})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"kind": "bigquery#tableList", "tables": tables})
+	}))
+	defer mockServer.Close()
+
+	ctx := t.Context()
+	bqClient, err := bigqueryapi.NewClient(ctx, "test-project", option.WithEndpoint(mockServer.URL), option.WithoutAuthentication())
+	if err != nil {
+		t.Fatalf("failed to create mocked BigQuery client: %v", err)
+	}
+
+	testSrc := &bqutil.MockSource{Client: bqClient, Project: "test-project"}
+
+	cfg := bigquerylisttableids.Config{
+		ConfigBase: tools.ConfigBase{Name: "list_table_ids_tool", Description: "List table ids"},
+		Type:       "bigquery-list-table-ids",
+		Source:     "my-bq-source",
+	}
+	tool, err := cfg.Initialize(ctx)
+	if err != nil {
+		t.Fatalf("failed to initialize tool: %v", err)
+	}
+
+	tcs := []struct {
+		desc      string
+		extraArgs map[string]any
+		want      []string
+	}{
+		{
+			desc: "no limit or prefix returns every table, unchanged from today's behavior",
+			want: allTableIDs,
+		},
+		{
+			desc:      "limit truncates to the first N without fetching the rest",
+			extraArgs: map[string]any{"limit": 2},
+			want:      []string{"events_a", "events_b"},
+		},
+		{
+			desc:      "prefix filters regardless of limit",
+			extraArgs: map[string]any{"prefix": "users_"},
+			want:      []string{"users_a", "users_b"},
+		},
+		{
+			desc:      "limit and prefix combine: limit counts only prefix matches",
+			extraArgs: map[string]any{"prefix": "users_", "limit": 1},
+			want:      []string{"users_a"},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			data := map[string]any{"project": "test-project", "dataset": "test-dataset"}
+			for k, v := range tc.extraArgs {
+				data[k] = v
+			}
+
+			params, err := tool.GetParameters(testSrc)
+			if err != nil {
+				t.Fatalf("failed to get parameters: %v", err)
+			}
+			paramVals, err := parameters.ParseParams(params, data, nil)
+			if err != nil {
+				t.Fatalf("unexpected error parsing parameters: %v", err)
+			}
+
+			got, toolErr := tool.Invoke(ctx, testSrc, paramVals, "")
+			if toolErr != nil {
+				t.Fatalf("unexpected error: %v", toolErr)
+			}
+
+			gotIDs := make([]string, 0)
+			for _, v := range got.([]any) {
+				gotIDs = append(gotIDs, v.(string))
+			}
+			if len(gotIDs) != len(tc.want) {
+				t.Fatalf("got %v, want %v", gotIDs, tc.want)
+			}
+			for i, id := range tc.want {
+				if gotIDs[i] != id {
+					t.Fatalf("got %v, want %v", gotIDs, tc.want)
+				}
+			}
+		})
+	}
+}
+
+func TestInvokeRejectsNegativeLimit(t *testing.T) {
+	ctx := t.Context()
+	testSrc := &bqutil.MockSource{Project: "test-project"}
+
+	cfg := bigquerylisttableids.Config{
+		ConfigBase: tools.ConfigBase{Name: "list_table_ids_tool", Description: "List table ids"},
+		Type:       "bigquery-list-table-ids",
+		Source:     "my-bq-source",
+	}
+	tool, err := cfg.Initialize(ctx)
+	if err != nil {
+		t.Fatalf("failed to initialize tool: %v", err)
+	}
+
+	params, err := tool.GetParameters(testSrc)
+	if err != nil {
+		t.Fatalf("failed to get parameters: %v", err)
+	}
+	paramVals, err := parameters.ParseParams(params, map[string]any{"project": "test-project", "dataset": "test-dataset", "limit": -1}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error parsing parameters: %v", err)
+	}
+
+	_, toolErr := tool.Invoke(ctx, testSrc, paramVals, "")
+	if toolErr == nil {
+		t.Fatalf("expected an error for a negative limit, got nil")
+	}
+	if !strings.Contains(toolErr.Error(), "must be >= 0") {
+		t.Fatalf("expected error to mention 'must be >= 0', got %v", toolErr)
+	}
+}


### PR DESCRIPTION
## Description

`bigquery-list-dataset-ids` and `bigquery-list-table-ids` page through every dataset/table id in the iterator with no way to bound the response. On a project with ~10k datasets, `list_dataset_ids` returns over 1M characters in a single tool result — the linked issue's evals had the client spill the response to a file and shell out to `jq` to read it, turning a listing into a ~75s multi-step detour. `list_table_ids` has the identical unbounded-iterator shape and would hit the same wall on a dataset with many tables.

Adds optional `limit` (default `0`, no limit) and `prefix` (default `""`, no filter) parameters to both tools, mirroring the existing `cloud-storage-list-objects` tool's `prefix`/`max_results` shape rather than inventing a new one. The loop now stops as soon as `limit` matches are found — for a caller who supplies a `prefix` or a small `limit`, this also means fewer pages fetched from the API, not just a smaller response truncated after a full fetch.

Fixes #3975

## Testing

- New table-driven tests in both packages (`*_limit_test.go`), against a mocked BigQuery REST server (same `httptest`/`option.WithEndpoint` pattern already used by `bigqueryexecutesql_test.go`): no `limit`/`prefix` returns everything unchanged from today; `limit` alone truncates; `prefix` alone filters; `limit`+`prefix` together apply the limit *after* filtering; a `prefix` matching nothing returns an empty result; a negative `limit` is rejected with a clear error.
- Added `BigQueryProject()` to the shared `bigquerycommon.MockSource` test helper — both tools' `compatibleSource` interface needs it and no existing bigquery tool test exercised that path, so this is a small, additive, backward-compatible extension to a fixture other bigquery tool tests already use.
- `go build ./...`, `go vet ./internal/tools/bigquery/...`, `go test ./internal/tools/bigquery/...` (whole package tree, not just the two changed packages) — all clean.
- `gofmt` clean (only whole-file CRLF diffs show on this Windows checkout for the two modified source files; `git diff` confirms the actual changes are the intended additive lines only — the two new test files are already LF and show no gofmt diff at all).

## PR Checklist

- [x] Reviewed CONTRIBUTING.md
- [x] Issue #3975 already exists with a clear repro and proposed shape
- [x] Reviewed the entire diff before requesting review
- [x] Tests and `go vet` pass; `golangci-lint` isn't installed in this environment, but the change doesn't touch anything it would flag
- [x] Code coverage does not decrease — both tools go from schema-parse-only coverage to real `Invoke` coverage via the new mocked-server tests
- [ ] Docs update — none needed; this only adds two optional parameters with self-describing schema text, no existing documented behavior changes
- [x] Not a breaking change — both new parameters default to today's exact behavior (no limit, no filter)

🛠️ Fixes #3975