### PR TITLE
fix(ci): fail the Oracle integration step when go test fails

### DIFF
--- a/.ci/integration.cloudbuild.yaml
+++ b/.ci/integration.cloudbuild.yaml
@@ -1438,9 +1438,12 @@ steps:
           tar -C /usr/local -xzf go.tar.gz
           export PATH="/usr/local/go/bin:$$PATH"
 
-          go test -v ./tests/oracle/... \
+          if ! go test -v ./tests/oracle/... \
             -coverprofile=oracle_coverage.out \
-            -coverpkg=./internal/sources/oracle/...,./internal/tools/oracle/...
+            -coverpkg=./internal/sources/oracle/...,./internal/tools/oracle/...; then
+            echo "Error: Oracle tests failed. Exiting."
+            exit 1
+          fi
 
           # Coverage check
           total_coverage=$(go tool cover -func=oracle_coverage.out | grep "total:" | awk '{print $3}')

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -437,6 +437,20 @@ Evals for the prebuilt configs run separately from the test workflows, on their
 own Cloud Build config. See
 [Adding Prebuilt Config Evals](#adding-prebuilt-config-evals).
 
+### Propagating Test Failures in CI Scripts
+
+Most sources run their integration tests through the shared
+[`test_with_coverage.sh`](./.ci/test_with_coverage.sh) script, which checks
+the test binary's exit code with `if ! ...; then exit 1; fi` before computing
+coverage. A source whose CI step cannot use that shared script (for example,
+one needing extra system packages installed inline, like Oracle) must apply
+the same check by hand around its own `go test` invocation. A bare `go test
+...` on its own line lets a failing test fall through to the coverage
+calculation; if coverage still clears the threshold, Cloud Build reports the
+step as passing even though tests failed. Always wrap the test command so a
+non-zero exit fails the build immediately, and never rely on a downstream
+coverage or lint check to catch a test failure it wasn't designed to detect.
+
 ### Linting
 
 ### Code Linting


### PR DESCRIPTION
Fixes #3974.

## Problem

Every other source's Cloud Build integration step runs its compiled test binary through the shared `.ci/test_with_coverage.sh`, which checks the exit code (`if ! ./"${TEST_BINARY}" ...; then exit 1; fi`) before computing coverage. Oracle needs extra inline setup (installing `gcc`/`oracle-instantclient-devel` and Go itself inside the step), so it doesn't go through that script — but its inline replacement dropped the exit-code check, running `go test ./tests/oracle/...` as a bare statement. A failing test fell through straight to the coverage calculation, and if coverage still cleared the 55% threshold, Cloud Build reported the step green anyway. This is exactly what happened with PR #2323, per the postmortem in #3974.

## Fix

Wrap the Oracle `go test` invocation in the same `if ! ...; then echo "..."; exit 1; fi` pattern `test_with_coverage.sh` already uses for every other source, so a test failure fails the build immediately regardless of the coverage outcome. Also documented the pattern in `DEVELOPER.md` (new "Propagating Test Failures in CI Scripts" subsection under Testing) so a future inline, non-shared-script CI step doesn't repeat the mistake.

## Scope

This only touches the Oracle step — it's the only integration step in `integration.cloudbuild.yaml` that runs `go test` outside `test_with_coverage.sh` (verified by grepping the file). No behavior changes for any other source's tests.

## Tests

- `python3 -c "import yaml; yaml.safe_load(open('.ci/integration.cloudbuild.yaml'))"` — confirms the YAML still parses after the edit.
- Manually traced the new branch: a failing `go test` now exits the block via `exit 1` before reaching the coverage `awk` check, matching `test_with_coverage.sh`'s behavior. I don't have access to a live Oracle instance to run this Cloud Build step end-to-end; a maintainer with CI access may want to confirm on a real run.