### PR TITLE
feat(source/bigquery): apply SQLCommenter labels to analyze-contribution model creation

### DIFF
--- a/docs/en/integrations/bigquery/source.md
+++ b/docs/en/integrations/bigquery/source.md
@@ -169,9 +169,8 @@ attaches the same attributes as native
 [job labels](https://cloud.google.com/bigquery/docs/adding-labels#job-label)
 on every query job executed through the source's SQL execution path — the
 `bigquery-execute-sql`, `bigquery-sql`, `bigquery-forecast`, and
-`bigquery-analyze-contribution` tools. (The internal model-creation
-statement of `bigquery-analyze-contribution` runs outside that path and
-carries only the `mcp-toolbox-tool` label.) Labels appear in
+`bigquery-analyze-contribution` tools, including the internal
+model-creation statement of `bigquery-analyze-contribution`. Labels appear in
 `INFORMATION_SCHEMA.JOBS`, the Jobs API, audit logs, and billing exports —
 no query text parsing is needed to recover them.
 

--- a/internal/sources/bigquery/bigquery.go
+++ b/internal/sources/bigquery/bigquery.go
@@ -606,6 +606,15 @@ func (s *Source) RetrieveClientAndService(accessToken tools.AccessToken) (*bigqu
 	return bqClient, restService, nil
 }
 
+// AppendJobLabels merges the SQLCommenter attributes into the given job
+// labels, honoring the source's sqlCommenter override. RunSQL applies it to
+// every query it executes; tools that build query jobs directly (e.g. the
+// model-creation statement in bigquery-analyze-contribution) call it to give
+// those jobs the same labels.
+func (s *Source) AppendJobLabels(ctx context.Context, labels map[string]string) map[string]string {
+	return sqlcommenter.AppendLabels(ctx, labels, SourceType, s.SQLCommenter)
+}
+
 func (s *Source) RunSQL(ctx context.Context, bqClient *bigqueryapi.Client, statement, statementType string, params []bigqueryapi.QueryParameter, connProps []*bigqueryapi.ConnectionProperty, labels map[string]string) (any, error) {
 	query := bqClient.Query(statement)
 	query.Location = bqClient.Location
@@ -618,7 +627,7 @@ func (s *Source) RunSQL(ctx context.Context, bqClient *bigqueryapi.Client, state
 	// BigQuery attaches SQLCommenter attributes as native job labels rather
 	// than SQL-text comments, so they surface in INFORMATION_SCHEMA.JOBS and
 	// billing exports without query text parsing.
-	labels = sqlcommenter.AppendLabels(ctx, labels, SourceType, s.SQLCommenter)
+	labels = s.AppendJobLabels(ctx, labels)
 	if labels != nil {
 		query.Labels = labels
 	}

--- a/internal/sources/bigquery/bigquery_test.go
+++ b/internal/sources/bigquery/bigquery_test.go
@@ -782,20 +782,25 @@ func TestInitialize_ReadOnlyAndWriteModeValidation(t *testing.T) {
 }
 
 func TestSource_AppendJobLabels(t *testing.T) {
-	ctx := util.WithSQLCommenterEnabled(context.Background(), false)
-	ctx = util.WithGenAIMetricAttrs(ctx, &util.GenAIMetricAttrs{ToolName: "analyze_contribution"})
 	explicit := map[string]string{"mcp-toolbox-tool": "bigquery-analyze-contribution"}
 
 	tcs := []struct {
 		desc                string
+		global              bool
 		sqlCommenter        *bool
 		wantCommenterLabels bool
 	}{
-		{desc: "override on adds commenter labels", sqlCommenter: testutils.BoolPtr(true), wantCommenterLabels: true},
-		{desc: "override off returns labels unchanged", sqlCommenter: testutils.BoolPtr(false), wantCommenterLabels: false},
+		{desc: "global off, override on", global: false, sqlCommenter: testutils.BoolPtr(true), wantCommenterLabels: true},
+		{desc: "global off, override off", global: false, sqlCommenter: testutils.BoolPtr(false), wantCommenterLabels: false},
+		{desc: "global off, override unset falls back to global", global: false, sqlCommenter: nil, wantCommenterLabels: false},
+		{desc: "global on, override unset falls back to global", global: true, sqlCommenter: nil, wantCommenterLabels: true},
+		{desc: "global on, override off wins", global: true, sqlCommenter: testutils.BoolPtr(false), wantCommenterLabels: false},
+		{desc: "global on, override on", global: true, sqlCommenter: testutils.BoolPtr(true), wantCommenterLabels: true},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
+			ctx := util.WithSQLCommenterEnabled(context.Background(), tc.global)
+			ctx = util.WithGenAIMetricAttrs(ctx, &util.GenAIMetricAttrs{ToolName: "analyze_contribution"})
 			s := &bigquery.Source{Config: bigquery.Config{SQLCommenter: tc.sqlCommenter}}
 			got := s.AppendJobLabels(ctx, explicit)
 			if got["mcp-toolbox-tool"] != "bigquery-analyze-contribution" {

--- a/internal/sources/bigquery/bigquery_test.go
+++ b/internal/sources/bigquery/bigquery_test.go
@@ -780,3 +780,30 @@ func TestInitialize_ReadOnlyAndWriteModeValidation(t *testing.T) {
 		})
 	}
 }
+
+func TestSource_AppendJobLabels(t *testing.T) {
+	ctx := util.WithSQLCommenterEnabled(context.Background(), false)
+	ctx = util.WithGenAIMetricAttrs(ctx, &util.GenAIMetricAttrs{ToolName: "analyze_contribution"})
+	explicit := map[string]string{"mcp-toolbox-tool": "bigquery-analyze-contribution"}
+
+	tcs := []struct {
+		desc                string
+		sqlCommenter        *bool
+		wantCommenterLabels bool
+	}{
+		{desc: "override on adds commenter labels", sqlCommenter: testutils.BoolPtr(true), wantCommenterLabels: true},
+		{desc: "override off returns labels unchanged", sqlCommenter: testutils.BoolPtr(false), wantCommenterLabels: false},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			s := &bigquery.Source{Config: bigquery.Config{SQLCommenter: tc.sqlCommenter}}
+			got := s.AppendJobLabels(ctx, explicit)
+			if got["mcp-toolbox-tool"] != "bigquery-analyze-contribution" {
+				t.Errorf("explicit label not preserved: %v", got)
+			}
+			if hasToolName := got["tool_name"] != ""; hasToolName != tc.wantCommenterLabels {
+				t.Errorf("tool_name present = %v, want %v (labels: %v)", hasToolName, tc.wantCommenterLabels, got)
+			}
+		})
+	}
+}

--- a/internal/tools/bigquery/bigqueryanalyzecontribution/bigqueryanalyzecontribution.go
+++ b/internal/tools/bigquery/bigqueryanalyzecontribution/bigqueryanalyzecontribution.go
@@ -58,6 +58,7 @@ type compatibleSource interface {
 	BigQuerySession() bigqueryds.BigQuerySessionProvider
 	RetrieveClientAndService(tools.AccessToken) (*bigqueryapi.Client, *bigqueryrestapi.Service, error)
 	RunSQL(context.Context, *bigqueryapi.Client, string, string, []bigqueryapi.QueryParameter, []*bigqueryapi.ConnectionProperty, map[string]string) (any, error)
+	AppendJobLabels(context.Context, map[string]string) map[string]string
 }
 
 type Config struct {
@@ -219,7 +220,7 @@ func (t Tool) Invoke(ctx context.Context, s sources.Source, params parameters.Pa
 	)
 
 	createModelQuery := bqClient.Query(createModelSQL)
-	createModelQuery.Labels = map[string]string{"mcp-toolbox-tool": resourceType}
+	createModelQuery.Labels = source.AppendJobLabels(ctx, map[string]string{"mcp-toolbox-tool": resourceType})
 
 	// Get session from provider if in protected mode.
 	// Otherwise, a new session will be created by the first query.

--- a/internal/tools/bigquery/bigquerycommon/mock_source.go
+++ b/internal/tools/bigquery/bigquerycommon/mock_source.go
@@ -87,3 +87,9 @@ func (m *MockSource) RunSQL(ctx context.Context, client *bigqueryapi.Client, sql
 	m.CalledSQL = sql
 	return m.RunSQLResult, m.RunSQLError
 }
+
+// AppendJobLabels returns the given labels unchanged; the mock does not
+// simulate SQLCommenter attributes.
+func (m *MockSource) AppendJobLabels(_ context.Context, labels map[string]string) map[string]string {
+	return labels
+}


### PR DESCRIPTION
## Description

Follow-up to #3843, as discussed in
[this review thread](https://github.com/googleapis/mcp-toolbox/pull/3843#discussion_r3968570438):
the `CREATE TEMP MODEL` statement in `bigquery-analyze-contribution` builds
its query job directly rather than through `RunSQL`, so it carried only the
`mcp-toolbox-tool` label while every other job from the tool carried the
full SQLCommenter attribute set.

- Expose the label merge as `Source.AppendJobLabels` (honoring the
  per-source `sqlCommenter` override); `RunSQL` now uses it internally.
- Require it on the tool's compatible-source interface and apply it to the
  model-creation job.
- Update the docs to drop the previous exception, and the shared BigQuery
  mock source accordingly.

Tests: unit test for `AppendJobLabels` covering override on/off and
explicit-label precedence; existing tool and source suites pass.
`go test -race ./internal/...` and `golangci-lint run` are green.

## PR Checklist

- [x] Make sure you reviewed
  [CONTRIBUTING.md](https://github.com/googleapis/mcp-toolbox/blob/main/CONTRIBUTING.md)
- [x] Make sure to open an issue as a
  [bug/issue](https://github.com/googleapis/mcp-toolbox/issues/new/choose)
  before writing your code! That way we can discuss the change, evaluate
  designs, and agree on the general idea (scoped and agreed in the #3843
  review thread linked above)
- [x] Ensure you have manually reviewed the entire diff before requesting a
  review
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
- [ ] Make sure to add `!` if this involve a breaking change
