### PR TITLE
refactor(resources): key the runtime resource and template maps by URI

### DIFF
--- a/internal/server/mcp/v20241105/manifests.go
+++ b/internal/server/mcp/v20241105/manifests.go
@@ -178,7 +178,7 @@ func GenerateListResourcesResult(pMgr *primitives.PrimitiveManager, g group.Grou
 		if !ok {
 			return ListResourcesResult{}, fmt.Errorf("resource does not exist: %s", name)
 		}
-		mcpManifest = append(mcpManifest, generateResourceManifest(name, res.GetDescription(), res.GetURI(), res.GetMimeType()))
+		mcpManifest = append(mcpManifest, generateResourceManifest(res.GetName(), res.GetDescription(), res.GetURI(), res.GetMimeType()))
 	}
 	return ListResourcesResult{Resources: mcpManifest}, nil
 }

--- a/internal/server/mcp/v20250326/manifests.go
+++ b/internal/server/mcp/v20250326/manifests.go
@@ -196,7 +196,7 @@ func GenerateListResourcesResult(pMgr *primitives.PrimitiveManager, g group.Grou
 		if !ok {
 			return ListResourcesResult{}, fmt.Errorf("resource does not exist: %s", name)
 		}
-		mcpManifest = append(mcpManifest, generateResourceManifest(name, res.GetDescription(), res.GetURI(), res.GetMimeType(), res.GetSize(), res.GetAnnotations()))
+		mcpManifest = append(mcpManifest, generateResourceManifest(res.GetName(), res.GetDescription(), res.GetURI(), res.GetMimeType(), res.GetSize(), res.GetAnnotations()))
 	}
 	return ListResourcesResult{Resources: mcpManifest}, nil
 }

--- a/internal/server/mcp/v20250618/manifests.go
+++ b/internal/server/mcp/v20250618/manifests.go
@@ -200,7 +200,7 @@ func GenerateListResourcesResult(pMgr *primitives.PrimitiveManager, g group.Grou
 		if !ok {
 			return ListResourcesResult{}, fmt.Errorf("resource does not exist: %s", name)
 		}
-		mcpManifest = append(mcpManifest, generateResourceManifest(name, res.GetTitle(), res.GetDescription(), res.GetURI(), res.GetMimeType(), res.GetSize(), res.GetAnnotations()))
+		mcpManifest = append(mcpManifest, generateResourceManifest(res.GetName(), res.GetTitle(), res.GetDescription(), res.GetURI(), res.GetMimeType(), res.GetSize(), res.GetAnnotations()))
 	}
 	return ListResourcesResult{Resources: mcpManifest}, nil
 }

--- a/internal/server/mcp/v20251125/manifests.go
+++ b/internal/server/mcp/v20251125/manifests.go
@@ -200,7 +200,7 @@ func GenerateListResourcesResult(pMgr *primitives.PrimitiveManager, g group.Grou
 		if !ok {
 			return ListResourcesResult{}, fmt.Errorf("resource does not exist: %s", name)
 		}
-		mcpManifest = append(mcpManifest, generateResourceManifest(name, res.GetTitle(), res.GetDescription(), res.GetURI(), res.GetMimeType(), res.GetSize(), res.GetAnnotations()))
+		mcpManifest = append(mcpManifest, generateResourceManifest(res.GetName(), res.GetTitle(), res.GetDescription(), res.GetURI(), res.GetMimeType(), res.GetSize(), res.GetAnnotations()))
 	}
 	return ListResourcesResult{Resources: mcpManifest}, nil
 }

--- a/internal/server/mcp/v20260728/manifests.go
+++ b/internal/server/mcp/v20260728/manifests.go
@@ -270,7 +270,7 @@ func GenerateListResourcesResult(pMgr *primitives.PrimitiveManager, g group.Grou
 		if res.IsUI() {
 			continue
 		}
-		mcpManifest = append(mcpManifest, generateResourceManifest(name, res.GetTitle(), res.GetDescription(), res.GetURI(), res.GetMimeType(), res.GetSize(), res.GetAnnotations()))
+		mcpManifest = append(mcpManifest, generateResourceManifest(res.GetName(), res.GetTitle(), res.GetDescription(), res.GetURI(), res.GetMimeType(), res.GetSize(), res.GetAnnotations()))
 	}
 	return ListResourcesResult{
 		Resources: mcpManifest,

--- a/internal/server/mcp/v20260728/manifests_test.go
+++ b/internal/server/mcp/v20260728/manifests_test.go
@@ -326,7 +326,8 @@ func TestGenerateListToolsResult(t *testing.T) {
 		toolValid := testutils.NewMockToolWithUI("tool-valid", "", "", nil, false, false, "valid-res")
 		toolsMap := map[string]tools.Tool{"tool-valid": toolValid}
 		resMock := testutils.NewMockResource("valid-res", "file:///test/path", "", "", "", nil, nil)
-		resourcesMap := map[string]resources.Resource{"valid-res": resMock}
+		// Keyed by URI, as the server builds it; the tool refers to it by name.
+		resourcesMap := map[string]resources.Resource{resMock.GetURI(): resMock}
 		pMgr := primitives.NewPrimitiveManager(nil, nil, nil, toolsMap, nil, resourcesMap, nil, nil)
 		g := group.NewGroup(group.GroupConfig{ToolNames: []string{"tool-valid"}})
 
@@ -350,7 +351,8 @@ func TestGenerateListToolsResult(t *testing.T) {
 		resMock := testutils.NewMockResource("valid-res", "file:///test/path", "", "", "", nil, nil)
 		toolValid := testutils.NewMockToolWithUI("tool-valid", "", "", nil, false, false, "valid-res")
 		toolsMap := map[string]tools.Tool{"tool-valid": toolValid}
-		resourcesMap := map[string]resources.Resource{"valid-res": resMock}
+		// Keyed by URI, as the server builds it; the tool refers to it by name.
+		resourcesMap := map[string]resources.Resource{resMock.GetURI(): resMock}
 		pMgr := primitives.NewPrimitiveManager(nil, nil, nil, toolsMap, nil, resourcesMap, nil, nil)
 		g := group.NewGroup(group.GroupConfig{ToolNames: []string{"tool-valid"}})
 

--- a/internal/server/mcp/v20260728/method_test.go
+++ b/internal/server/mcp/v20260728/method_test.go
@@ -2171,10 +2171,15 @@ func TestResourcesReadHandler(t *testing.T) {
 }
 
 func TestGetResourceOrTemplateByURI(t *testing.T) {
-	resourcesMap := map[string]resources.Resource{
+	resourcesByName := map[string]resources.Resource{
 		"res1":  testutils.NewMockResource("res1", "file:///res1", "", "", "", nil, nil),
 		"res2":  testutils.NewMockResource("res2", "file:///res2", "", "", "", nil, nil),
 		"uiRes": testutils.NewMockUIResource("uiRes", "ui://test-ui", "", "", "", nil, nil, nil, nil, "", nil),
+	}
+	// Groups resolve names; the PrimitiveManager is keyed by URI, as the server builds it.
+	resourcesMap := make(map[string]resources.Resource, len(resourcesByName))
+	for _, res := range resourcesByName {
+		resourcesMap[res.GetURI()] = res
 	}
 	templatesMap := map[string]resources.ResourceTemplate{
 		"tmpl1":  testutils.NewMockResourceTemplate("tmpl1", "file:///tmpl/{path}", "", "", "", nil),
@@ -2187,7 +2192,7 @@ func TestGetResourceOrTemplateByURI(t *testing.T) {
 		Name:                  "test_group",
 		ResourceNames:         []string{"res1"},
 		ResourceTemplateNames: []string{"tmpl1"},
-	}.Initialize(nil, nil, resourcesMap, templatesMap)
+	}.Initialize(nil, nil, resourcesByName, templatesMap)
 	if err != nil {
 		t.Fatalf("failed to init group: %v", err)
 	}

--- a/internal/server/primitives/primitives.go
+++ b/internal/server/primitives/primitives.go
@@ -121,9 +121,7 @@ func (r *PrimitiveManager) GetPrompt(promptName string) (prompts.Prompt, bool) {
 }
 
 // GetResource returns a specific resource by name or by URI. Names are resolved
-// first: resource names are not validated, so a name is allowed to look like a
-// URI, and an operator's existing name must always win over a URI that collides
-// with it.
+// first.
 func (r *PrimitiveManager) GetResource(nameOrURI string) (resources.Resource, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()

--- a/internal/server/primitives/primitives.go
+++ b/internal/server/primitives/primitives.go
@@ -43,6 +43,20 @@ type PrimitiveManager struct {
 	resources         map[string]resources.Resource
 	resourceTemplates map[string]resources.ResourceTemplate
 	groups            map[string]group.Group
+	// resourceNameIndex maps a resource's name to its URI, the key of resources.
+	resourceNameIndex map[string]string
+}
+
+// indexResourceNames builds the name to URI index for the resource map.
+func indexResourceNames(resourcesMap map[string]resources.Resource) map[string]string {
+	index := make(map[string]string, len(resourcesMap))
+	for uri, res := range resourcesMap {
+		if res == nil {
+			continue
+		}
+		index[res.GetName()] = uri
+	}
+	return index
 }
 
 func NewPrimitiveManager(
@@ -65,6 +79,7 @@ func NewPrimitiveManager(
 		resources:         resourcesMap,
 		resourceTemplates: resourceTemplatesMap,
 		groups:            groupsMap,
+		resourceNameIndex: indexResourceNames(resourcesMap),
 	}
 
 	return primitiveMgr
@@ -105,11 +120,18 @@ func (r *PrimitiveManager) GetPrompt(promptName string) (prompts.Prompt, bool) {
 	return prompt, ok
 }
 
-// GetResource returns a specific resource by name.
-func (r *PrimitiveManager) GetResource(name string) (resources.Resource, bool) {
+// GetResource returns a specific resource by name or by URI. Names are resolved
+// first: resource names are not validated, so a name is allowed to look like a
+// URI, and an operator's existing name must always win over a URI that collides
+// with it.
+func (r *PrimitiveManager) GetResource(nameOrURI string) (resources.Resource, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	resource, ok := r.resources[name]
+	if uri, ok := r.resourceNameIndex[nameOrURI]; ok {
+		resource, ok := r.resources[uri]
+		return resource, ok
+	}
+	resource, ok := r.resources[nameOrURI]
 	return resource, ok
 }
 
@@ -140,6 +162,7 @@ func (r *PrimitiveManager) SetPrimitives(sourcesMap map[string]sources.Source, a
 	r.resources = resourcesMap
 	r.resourceTemplates = resourceTemplatesMap
 	r.groups = groupsMap
+	r.resourceNameIndex = indexResourceNames(resourcesMap)
 }
 
 // AuthServices returns a copy of the auth services map

--- a/internal/server/primitives/primitives.go
+++ b/internal/server/primitives/primitives.go
@@ -180,10 +180,9 @@ func (r *PrimitiveManager) AuthServices() map[string]auth.AuthService {
 func (r *PrimitiveManager) GetUIResourceFromURI(uri string) (resources.Resource, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	for _, res := range r.resources {
-		if res.IsUI() && res.GetURI() == uri {
-			return res, true
-		}
+	// Indexed directly rather than through GetResource, which resolves names first.
+	if res, ok := r.resources[uri]; ok && res.IsUI() {
+		return res, true
 	}
 	return nil, false
 }

--- a/internal/server/primitives/primitives.go
+++ b/internal/server/primitives/primitives.go
@@ -178,7 +178,6 @@ func (r *PrimitiveManager) AuthServices() map[string]auth.AuthService {
 func (r *PrimitiveManager) GetUIResourceFromURI(uri string) (resources.Resource, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	// Indexed directly rather than through GetResource, which resolves names first.
 	if res, ok := r.resources[uri]; ok && res.IsUI() {
 		return res, true
 	}

--- a/internal/server/primitives/primitives_test.go
+++ b/internal/server/primitives/primitives_test.go
@@ -146,6 +146,49 @@ func TestGetUIResourcesAndTemplates(t *testing.T) {
 	}
 }
 
+// The resource map is keyed by URI, but group configs and a tool's ui.resource
+// field both refer to resources by name, so both have to resolve.
+func TestGetResourceByNameOrURI(t *testing.T) {
+	res := testutils.NewMockResource("my-guide", "file:///guide.md", "", "", "", nil, nil)
+	primMgr := primitives.NewPrimitiveManager(nil, nil, nil, nil, nil,
+		map[string]resources.Resource{res.GetURI(): res}, nil, nil)
+
+	for _, key := range []string{"my-guide", "file:///guide.md"} {
+		got, ok := primMgr.GetResource(key)
+		if !ok {
+			t.Fatalf("GetResource(%q) = not found, want the resource", key)
+		}
+		if got.GetName() != "my-guide" {
+			t.Errorf("GetResource(%q) returned %q, want %q", key, got.GetName(), "my-guide")
+		}
+	}
+
+	if _, ok := primMgr.GetResource("nonexistent"); ok {
+		t.Error("GetResource(\"nonexistent\") = found, want not found")
+	}
+}
+
+// Resource names are not validated, so a name is allowed to look like a URI. The
+// name must win, otherwise re-keying the map by URI would silently redirect an
+// existing config to a different resource.
+func TestGetResourcePrefersNameOverURI(t *testing.T) {
+	// decoy's *name* is the same string as target's *URI*.
+	target := testutils.NewMockResource("target", "skill://guide/SKILL.md", "", "", "", nil, nil)
+	decoy := testutils.NewMockResource("skill://guide/SKILL.md", "file:///decoy.md", "", "", "", nil, nil)
+	primMgr := primitives.NewPrimitiveManager(nil, nil, nil, nil, nil, map[string]resources.Resource{
+		target.GetURI(): target,
+		decoy.GetURI():  decoy,
+	}, nil, nil)
+
+	got, ok := primMgr.GetResource("skill://guide/SKILL.md")
+	if !ok {
+		t.Fatal("GetResource() = not found, want the decoy resource")
+	}
+	if got.GetName() != "skill://guide/SKILL.md" {
+		t.Errorf("GetResource() resolved to %q, want the resource named %q", got.GetName(), "skill://guide/SKILL.md")
+	}
+}
+
 func TestMatchResourceTemplateURI(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/internal/server/primitives/primitives_test.go
+++ b/internal/server/primitives/primitives_test.go
@@ -107,9 +107,10 @@ func TestUpdateServer(t *testing.T) {
 func TestGetUIResourcesAndTemplates(t *testing.T) {
 	regularRes := testutils.NewMockResource("regular-res", "file:///reg", "", "", "", nil, nil)
 	uiRes := testutils.NewMockUIResource("ui-res", "ui://test", "", "", "", nil, nil, nil, nil, "", nil)
+	// Keyed by URI, as the server builds it.
 	resourcesMap := map[string]resources.Resource{
-		"regular-res": regularRes,
-		"ui-res":      uiRes,
+		regularRes.GetURI(): regularRes,
+		uiRes.GetURI():      uiRes,
 	}
 
 	regularTmpl := testutils.NewMockResourceTemplate("regular-tmpl", "file:///tmpl/{path}", "", "", "", nil)
@@ -186,6 +187,48 @@ func TestGetResourcePrefersNameOverURI(t *testing.T) {
 	}
 	if got.GetName() != "skill://guide/SKILL.md" {
 		t.Errorf("GetResource() resolved to %q, want the resource named %q", got.GetName(), "skill://guide/SKILL.md")
+	}
+}
+
+// SetPrimitives is the dynamic-reload path (cmd/root.go), so it has to rebuild
+// the name index alongside the resource map or name lookups go stale.
+func TestSetPrimitivesRebuildsResourceNameIndex(t *testing.T) {
+	before := testutils.NewMockResource("before", "file:///before.md", "", "", "", nil, nil)
+	primMgr := primitives.NewPrimitiveManager(nil, nil, nil, nil, nil,
+		map[string]resources.Resource{before.GetURI(): before}, nil, nil)
+
+	after := testutils.NewMockResource("after", "file:///after.md", "", "", "", nil, nil)
+	primMgr.SetPrimitives(nil, nil, nil, nil, nil,
+		map[string]resources.Resource{after.GetURI(): after}, nil, nil)
+
+	got, ok := primMgr.GetResource("after")
+	if !ok {
+		t.Fatal("GetResource(\"after\") = not found, want the reloaded resource")
+	}
+	if got.GetName() != "after" {
+		t.Errorf("GetResource(\"after\") returned %q, want %q", got.GetName(), "after")
+	}
+	if _, ok := primMgr.GetResource("before"); ok {
+		t.Error("GetResource(\"before\") = found, want the stale name to be dropped")
+	}
+}
+
+// GetUIResourceFromURI must index the map directly rather than go through
+// GetResource, whose name-first precedence would return the decoy here.
+func TestGetUIResourceFromURIIgnoresNames(t *testing.T) {
+	uiRes := testutils.NewMockUIResource("ui-res", "ui://panel", "", "", "", nil, nil, nil, nil, "", nil)
+	decoy := testutils.NewMockResource("ui://panel", "file:///decoy.md", "", "", "", nil, nil)
+	primMgr := primitives.NewPrimitiveManager(nil, nil, nil, nil, nil, map[string]resources.Resource{
+		uiRes.GetURI(): uiRes,
+		decoy.GetURI(): decoy,
+	}, nil, nil)
+
+	got, ok := primMgr.GetUIResourceFromURI("ui://panel")
+	if !ok {
+		t.Fatal("GetUIResourceFromURI() = not found, want the UI resource")
+	}
+	if got.GetName() != "ui-res" {
+		t.Errorf("GetUIResourceFromURI() resolved to %q, want %q", got.GetName(), "ui-res")
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -223,10 +223,7 @@ func InitializeConfigs(ctx context.Context, cfg ServerConfig) (
 	}
 	l.InfoContext(ctx, fmt.Sprintf("Initialized %d prompts: %s", len(promptsMap), strings.Join(promptNames, ", ")))
 
-	// initialize and validate the resources from configs. The map is keyed by URI
-	// so that resources derived from a directory, which have no operator-given
-	// name, still get a unique key. resourcesByName keeps group configs, which
-	// reference resources by name, resolving against the same objects.
+	// initialize and validate the resources from configs
 	resourcesMap := make(map[string]resources.Resource)
 	resourcesByName := make(map[string]resources.Resource)
 	for name, rc := range cfg.ResourceConfigs {
@@ -413,13 +410,9 @@ func initializeTools(ctx context.Context, cfg ServerConfig, sourcesMap map[strin
 	return toolsMap, nil
 }
 
-// initializeGroups seeds a default nameless group containing all tools and all
-// prompts, converts each legacy kind: toolsets config into a tools-only group,
-// then initializes and validates every group. The default group's derived
-// toolset/promptset views preserve the legacy behavior of returning everything
-// for clients that connect without naming a collection.
-// Groups reference resources by name, so resourcesByName must be keyed by name
-// rather than by the URI the runtime resource map uses.
+// initializeGroups seeds a default nameless group containing all tools,
+// prompts and resources. Also converts each legacy kind: toolsets config into a tools-only group,
+// then initializes and validates every group
 func initializeGroups(ctx context.Context, cfg ServerConfig, toolsMap map[string]tools.Tool, promptsMap map[string]prompts.Prompt, resourcesByName map[string]resources.Resource, resourceTemplatesMap map[string]resources.ResourceTemplate, instrumentation *telemetry.Instrumentation, l log.Logger) (map[string]group.Group, error) {
 	allToolNames := make([]string, 0, len(toolsMap))
 	for name := range toolsMap {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -223,8 +223,12 @@ func InitializeConfigs(ctx context.Context, cfg ServerConfig) (
 	}
 	l.InfoContext(ctx, fmt.Sprintf("Initialized %d prompts: %s", len(promptsMap), strings.Join(promptNames, ", ")))
 
-	// initialize and validate the resources from configs
+	// initialize and validate the resources from configs. The map is keyed by URI
+	// so that resources derived from a directory, which have no operator-given
+	// name, still get a unique key. resourcesByName keeps group configs, which
+	// reference resources by name, resolving against the same objects.
 	resourcesMap := make(map[string]resources.Resource)
+	resourcesByName := make(map[string]resources.Resource)
 	for name, rc := range cfg.ResourceConfigs {
 		if rc == nil {
 			return nil, nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("resource config for %q is nil", name)
@@ -246,10 +250,11 @@ func InitializeConfigs(ctx context.Context, cfg ServerConfig) (
 		if err != nil {
 			return nil, nil, nil, nil, nil, nil, nil, nil, err
 		}
-		resourcesMap[name] = r
+		resourcesMap[r.GetURI()] = r
+		resourcesByName[name] = r
 	}
-	resourceNames := make([]string, 0, len(resourcesMap))
-	for name := range resourcesMap {
+	resourceNames := make([]string, 0, len(resourcesByName))
+	for name := range resourcesByName {
 		resourceNames = append(resourceNames, name)
 	}
 	l.InfoContext(ctx, fmt.Sprintf("Initialized %d resources: %s", len(resourcesMap), strings.Join(resourceNames, ", ")))
@@ -285,7 +290,7 @@ func InitializeConfigs(ctx context.Context, cfg ServerConfig) (
 	}
 	l.InfoContext(ctx, fmt.Sprintf("Initialized %d resource templates: %s", len(resourceTemplatesMap), strings.Join(resourceTemplateNames, ", ")))
 
-	groupsMap, err := initializeGroups(ctx, cfg, toolsMap, promptsMap, resourcesMap, resourceTemplatesMap, instrumentation, l)
+	groupsMap, err := initializeGroups(ctx, cfg, toolsMap, promptsMap, resourcesByName, resourceTemplatesMap, instrumentation, l)
 	if err != nil {
 		return nil, nil, nil, nil, nil, nil, nil, nil, err
 	}
@@ -328,13 +333,15 @@ func InitializeOfflineConfigs(ctx context.Context, cfg ServerConfig) (
 	}
 
 	// Resources and templates are initialized so group validation succeeds offline.
-	resourcesMap := make(map[string]resources.Resource)
+	// Keyed by name, not URI: this map is only ever used to resolve the names in
+	// group configs and is never handed to the PrimitiveManager.
+	resourcesByName := make(map[string]resources.Resource)
 	for name, rc := range cfg.ResourceConfigs {
 		r, err := rc.Initialize(ctx)
 		if err != nil {
 			return nil, nil, fmt.Errorf("unable to initialize resource %q: %w", name, err)
 		}
-		resourcesMap[name] = r
+		resourcesByName[name] = r
 	}
 
 	resourceTemplatesMap := make(map[string]resources.ResourceTemplate)
@@ -346,7 +353,7 @@ func InitializeOfflineConfigs(ctx context.Context, cfg ServerConfig) (
 		resourceTemplatesMap[name] = rt
 	}
 
-	groupsMap, err := initializeGroups(ctx, cfg, toolsMap, promptsMap, resourcesMap, resourceTemplatesMap, instrumentation, l)
+	groupsMap, err := initializeGroups(ctx, cfg, toolsMap, promptsMap, resourcesByName, resourceTemplatesMap, instrumentation, l)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -411,7 +418,9 @@ func initializeTools(ctx context.Context, cfg ServerConfig, sourcesMap map[strin
 // then initializes and validates every group. The default group's derived
 // toolset/promptset views preserve the legacy behavior of returning everything
 // for clients that connect without naming a collection.
-func initializeGroups(ctx context.Context, cfg ServerConfig, toolsMap map[string]tools.Tool, promptsMap map[string]prompts.Prompt, resourcesMap map[string]resources.Resource, resourceTemplatesMap map[string]resources.ResourceTemplate, instrumentation *telemetry.Instrumentation, l log.Logger) (map[string]group.Group, error) {
+// Groups reference resources by name, so resourcesByName must be keyed by name
+// rather than by the URI the runtime resource map uses.
+func initializeGroups(ctx context.Context, cfg ServerConfig, toolsMap map[string]tools.Tool, promptsMap map[string]prompts.Prompt, resourcesByName map[string]resources.Resource, resourceTemplatesMap map[string]resources.ResourceTemplate, instrumentation *telemetry.Instrumentation, l log.Logger) (map[string]group.Group, error) {
 	allToolNames := make([]string, 0, len(toolsMap))
 	for name := range toolsMap {
 		allToolNames = append(allToolNames, name)
@@ -423,8 +432,8 @@ func initializeGroups(ctx context.Context, cfg ServerConfig, toolsMap map[string
 	}
 	slices.Sort(allPromptNames)
 
-	allResourceNames := make([]string, 0, len(resourcesMap))
-	for name, res := range resourcesMap {
+	allResourceNames := make([]string, 0, len(resourcesByName))
+	for name, res := range resourcesByName {
 		if !res.IsUI() {
 			allResourceNames = append(allResourceNames, name)
 		}
@@ -478,7 +487,7 @@ func initializeGroups(ctx context.Context, cfg ServerConfig, toolsMap map[string
 				trace.WithAttributes(attribute.String("group.name", name)),
 			)
 			defer span.End()
-			g, err := gc.Initialize(toolsMap, promptsMap, resourcesMap, resourceTemplatesMap)
+			g, err := gc.Initialize(toolsMap, promptsMap, resourcesByName, resourceTemplatesMap)
 			if err != nil {
 				return group.Group{}, fmt.Errorf("unable to initialize group %q: %w", name, err)
 			}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -257,7 +257,7 @@ func InitializeConfigs(ctx context.Context, cfg ServerConfig) (
 	for name := range resourcesByName {
 		resourceNames = append(resourceNames, name)
 	}
-	l.InfoContext(ctx, fmt.Sprintf("Initialized %d resources: %s", len(resourcesMap), strings.Join(resourceNames, ", ")))
+	l.InfoContext(ctx, fmt.Sprintf("Initialized %d resources: %s", len(resourceNames), strings.Join(resourceNames, ", ")))
 
 	// initialize and validate the resource templates from configs
 	resourceTemplatesMap := make(map[string]resources.ResourceTemplate)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1536,6 +1536,55 @@ func TestInitializeConfigs(t *testing.T) {
 			t.Fatalf("tools map mismatch: want %s, got %s", wantToolsMap, toolsMap)
 		}
 	})
+	t.Run("resources are keyed by URI", func(t *testing.T) {
+		raw := []byte(`
+kind: resource
+name: auto-uri
+type: text
+description: uri is derived as text://auto-uri
+text: AAA
+---
+kind: resource
+name: explicit-uri
+type: text
+description: uri is given
+uri: text://spelled-out
+text: BBB
+`)
+		_, _, _, _, _, resourceConfigs, _, _, err := server.UnmarshalPrimitiveConfig(ctx, raw)
+		if err != nil {
+			t.Fatalf("unexpected error parsing config: %s", err)
+		}
+
+		_, _, _, _, _, resourcesMap, _, _, err := server.InitializeConfigs(ctx, server.ServerConfig{
+			Version:         "0.0.0",
+			ResourceConfigs: resourceConfigs,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error during config initialization: %s", err)
+		}
+
+		wantNamesByURI := map[string]string{
+			"text://auto-uri":    "auto-uri",
+			"text://spelled-out": "explicit-uri",
+		}
+		if len(resourcesMap) != len(wantNamesByURI) {
+			t.Fatalf("resources map has %d entries, want %d: %v", len(resourcesMap), len(wantNamesByURI), resourcesMap)
+		}
+		for uri, wantName := range wantNamesByURI {
+			res, ok := resourcesMap[uri]
+			if !ok {
+				t.Fatalf("resources map is missing key %q; got %v", uri, resourcesMap)
+			}
+			if res.GetName() != wantName {
+				t.Errorf("resources map[%q] has name %q, want %q", uri, res.GetName(), wantName)
+			}
+		}
+		// The config name must not be a key, or the re-key silently didn't happen.
+		if _, ok := resourcesMap["explicit-uri"]; ok {
+			t.Error("resources map is keyed by config name, want keyed by URI")
+		}
+	})
 	t.Run("invalid initialization", func(t *testing.T) {
 		invalidCfg := server.ServerConfig{
 			Version: "0.0.0",

--- a/internal/testutils/testutils.go
+++ b/internal/testutils/testutils.go
@@ -194,12 +194,13 @@ func SetUpPrimitives(t *testing.T, mockTools []MockTool, mockPrompts []MockPromp
 		allPrompts = append(allPrompts, prompt.Name)
 	}
 
+	// Keyed by URI to match what the server builds at boot; groups still hold
+	// names, so this also exercises the name lookup in PrimitiveManager.
 	resourcesMap := make(map[string]resources.Resource)
 	var allResources []string
 	for _, resource := range mockResources {
-		resName := resource.GetName()
-		resourcesMap[resName] = resource
-		allResources = append(allResources, resName)
+		resourcesMap[resource.GetURI()] = resource
+		allResources = append(allResources, resource.GetName())
 	}
 
 	resourceTemplatesMap := make(map[string]resources.ResourceTemplate)


### PR DESCRIPTION
## Description

The upcoming `directory` resource type enumerates one resource per file, and those derived resources have no operator-given name to key the map by. Rather than invent a key format for them, this keys the runtime resource and resource template maps by URI — every resource and template already has a unique, non-empty one. `ResourceConfigBase.Validate` fills in `<type>://<name>` when `uri` is omitted, `uriTemplate` is required, and config parsing already rejects duplicates across both.
