### PR TITLE
docs: add security-vulnerability check instruction for AI agents

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -153,6 +153,17 @@ A concise description of the changes (bug or feature), its impact, and a summary
 **3. Issue Reference**
 Use the format: `Fixes #<issue_number> 🦕`
 
+## Security
+
+Before proposing or making a change, check it for the vulnerability classes most relevant to this codebase:
+
+-   **SQL/query injection:** Never build a query by concatenating or `fmt.Sprintf`-ing a user-supplied tool parameter into a query string. Bind parameters using the source's parameterized-query API instead.
+-   **Credentials and secrets:** Never log, hardcode, or echo back a credential, API key, connection string, or token. Read secrets from config/environment, not from tool parameters.
+-   **Path/command injection:** Treat any user-supplied string used to build a file path or a shell/subprocess argument as untrusted; validate or reject it rather than passing it through unchecked.
+-   **Auth bypass:** A new or modified tool must still go through `BaseTool`'s `Authorized`/`authRequired`/`scopesRequired` handling — do not add a code path that skips it.
+
+If a change touches a `source` or `tool` implementation, call out the relevant point(s) above explicitly in the PR description rather than leaving them implicit.
+
 ## Adding New Features
 
 ### Adding a New Data Source


### PR DESCRIPTION
**1. Description**

`GEMINI.md` (symlinked as `CLAUDE.md`, `AGENTS.md`, and `.gemini/styleguide.md`) had no guidance directing an AI coding agent to check for common vulnerability classes before proposing or making a change. Added a `## Security` section listing the four classes most relevant to this codebase — SQL/query injection, credential/secret handling, path/command injection, and auth bypass around `BaseTool`'s `Authorized`/`authRequired`/`scopesRequired` handling — with a one-line pointer to call the relevant point(s) out in the PR description when a change touches a source or tool implementation.

Docs-only change; no source code touched.

**2. PR Checklist**
- [x] Make sure to open an issue as a bug/issue before writing your code!
- [x] Ensure you have manually reviewed the entire diff before requesting a review
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed) — N/A, docs only
- [x] Appropriate docs were updated (if necessary)
- [ ] Make sure to add `!` if this involves a breaking change — not applicable

**3. Issue Reference**

Fixes #3649 🦕