### PR TITLE
fix(telemetry): circuit-break GCP trace export on persistent PermissionDenied

### DIFF
--- a/internal/telemetry/gcp_trace_exporter.go
+++ b/internal/telemetry/gcp_trace_exporter.go
@@ -1,0 +1,83 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telemetry
+
+import (
+	"context"
+	"log/slog"
+	"sync/atomic"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// gcpTracePermissionDeniedThreshold is the number of consecutive
+// PermissionDenied export failures after which the exporter disables itself
+// for the rest of the process lifetime. A PermissionDenied on trace export
+// means the service account is missing an IAM grant, which does not appear
+// spontaneously, unlike Unavailable/DeadlineExceeded which are genuinely
+// worth retrying.
+const gcpTracePermissionDeniedThreshold = 3
+
+// gcpTracePermissionDeniedRole is named in the one-time warning so an
+// operator does not have to read the raw error to find it.
+const gcpTracePermissionDeniedRole = "roles/cloudtrace.agent"
+
+// circuitBreakingTraceExporter wraps a Cloud Trace span exporter and stops
+// calling it after gcpTracePermissionDeniedThreshold consecutive
+// PermissionDenied failures, logging a single WARN instead of the
+// underlying exporter's own per-export error log (the batch span processor
+// otherwise retries on every export interval, ~5s by default, for the life
+// of the process).
+type circuitBreakingTraceExporter struct {
+	sdktrace.SpanExporter
+	consecutivePermissionDenied atomic.Int32
+	disabled                    atomic.Bool
+}
+
+// newCircuitBreakingTraceExporter wraps exp with the PermissionDenied
+// circuit breaker described above.
+func newCircuitBreakingTraceExporter(exp sdktrace.SpanExporter) sdktrace.SpanExporter {
+	return &circuitBreakingTraceExporter{SpanExporter: exp}
+}
+
+// ExportSpans implements sdktrace.SpanExporter.
+func (e *circuitBreakingTraceExporter) ExportSpans(ctx context.Context, spans []sdktrace.ReadOnlySpan) error {
+	if e.disabled.Load() {
+		return nil
+	}
+	err := e.SpanExporter.ExportSpans(ctx, spans)
+	if err == nil {
+		e.consecutivePermissionDenied.Store(0)
+		return nil
+	}
+	if status.Code(err) != codes.PermissionDenied {
+		e.consecutivePermissionDenied.Store(0)
+		return err
+	}
+	if e.consecutivePermissionDenied.Add(1) < gcpTracePermissionDeniedThreshold {
+		return err
+	}
+	if e.disabled.CompareAndSwap(false, true) {
+		slog.WarnContext(ctx,
+			"disabling Google Cloud Trace export after repeated PermissionDenied failures; grant the missing role to the service account to re-enable",
+			"consecutiveFailures", gcpTracePermissionDeniedThreshold,
+			"requiredRole", gcpTracePermissionDeniedRole,
+			"error", err.Error(),
+		)
+	}
+	return nil
+}

--- a/internal/telemetry/gcp_trace_exporter_test.go
+++ b/internal/telemetry/gcp_trace_exporter_test.go
@@ -1,0 +1,166 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telemetry
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// fakeSpanExporter is a minimal sdktrace.SpanExporter whose ExportSpans
+// result is scripted call-by-call, and which records how many times
+// ExportSpans and Shutdown were actually invoked.
+type fakeSpanExporter struct {
+	results       []error
+	exportCalls   int
+	shutdownCalls int
+}
+
+func (f *fakeSpanExporter) ExportSpans(_ context.Context, _ []sdktrace.ReadOnlySpan) error {
+	var err error
+	if f.exportCalls < len(f.results) {
+		err = f.results[f.exportCalls]
+	}
+	f.exportCalls++
+	return err
+}
+
+func (f *fakeSpanExporter) Shutdown(_ context.Context) error {
+	f.shutdownCalls++
+	return nil
+}
+
+func permissionDeniedErr() error {
+	return status.Error(codes.PermissionDenied, "denied")
+}
+
+func TestCircuitBreakingTraceExporter_SuccessPassesThrough(t *testing.T) {
+	fake := &fakeSpanExporter{results: []error{nil}}
+	exp := newCircuitBreakingTraceExporter(fake)
+
+	if err := exp.ExportSpans(context.Background(), nil); err != nil {
+		t.Fatalf("ExportSpans() = %v, want nil", err)
+	}
+	if fake.exportCalls != 1 {
+		t.Fatalf("underlying ExportSpans called %d times, want 1", fake.exportCalls)
+	}
+}
+
+func TestCircuitBreakingTraceExporter_NonPermissionDeniedAlwaysPassesThrough(t *testing.T) {
+	unavailable := status.Error(codes.Unavailable, "try again")
+	fake := &fakeSpanExporter{results: []error{unavailable, unavailable, unavailable, unavailable, unavailable}}
+	exp := newCircuitBreakingTraceExporter(fake)
+
+	for i := range 5 {
+		if err := exp.ExportSpans(context.Background(), nil); !errors.Is(err, unavailable) {
+			t.Fatalf("call %d: ExportSpans() = %v, want %v", i, err, unavailable)
+		}
+	}
+	if fake.exportCalls != 5 {
+		t.Fatalf("underlying ExportSpans called %d times, want 5 (never disabled)", fake.exportCalls)
+	}
+}
+
+func TestCircuitBreakingTraceExporter_DisablesAfterThresholdConsecutivePermissionDenied(t *testing.T) {
+	results := make([]error, 0, gcpTracePermissionDeniedThreshold+2)
+	for range gcpTracePermissionDeniedThreshold {
+		results = append(results, permissionDeniedErr())
+	}
+	fake := &fakeSpanExporter{results: results}
+	exp := newCircuitBreakingTraceExporter(fake)
+
+	for i := range gcpTracePermissionDeniedThreshold - 1 {
+		if err := exp.ExportSpans(context.Background(), nil); err == nil {
+			t.Fatalf("call %d: ExportSpans() = nil, want a PermissionDenied error (below threshold)", i)
+		}
+	}
+	// The threshold-th consecutive failure trips the breaker: the caller
+	// still sees a nil error (nothing left to usefully retry on).
+	if err := exp.ExportSpans(context.Background(), nil); err != nil {
+		t.Fatalf("threshold call: ExportSpans() = %v, want nil (circuit tripped)", err)
+	}
+	if fake.exportCalls != gcpTracePermissionDeniedThreshold {
+		t.Fatalf("underlying ExportSpans called %d times, want %d", fake.exportCalls, gcpTracePermissionDeniedThreshold)
+	}
+
+	// Further calls must not reach the underlying exporter at all.
+	for range 3 {
+		if err := exp.ExportSpans(context.Background(), nil); err != nil {
+			t.Fatalf("post-trip ExportSpans() = %v, want nil", err)
+		}
+	}
+	if fake.exportCalls != gcpTracePermissionDeniedThreshold {
+		t.Fatalf("underlying ExportSpans called %d times after trip, want still %d (breaker open)", fake.exportCalls, gcpTracePermissionDeniedThreshold)
+	}
+}
+
+func TestCircuitBreakingTraceExporter_SuccessResetsConsecutiveCount(t *testing.T) {
+	// One fewer than the threshold, then a success, then the threshold
+	// again: the breaker must not trip, because the streak was reset.
+	results := []error{}
+	for range gcpTracePermissionDeniedThreshold - 1 {
+		results = append(results, permissionDeniedErr())
+	}
+	results = append(results, nil)
+	for range gcpTracePermissionDeniedThreshold - 1 {
+		results = append(results, permissionDeniedErr())
+	}
+	fake := &fakeSpanExporter{results: results}
+	exp := newCircuitBreakingTraceExporter(fake)
+
+	for range results {
+		exp.ExportSpans(context.Background(), nil)
+	}
+	if fake.exportCalls != len(results) {
+		t.Fatalf("underlying ExportSpans called %d times, want %d (breaker never tripped)", fake.exportCalls, len(results))
+	}
+}
+
+func TestCircuitBreakingTraceExporter_OtherErrorResetsConsecutiveCount(t *testing.T) {
+	unavailable := status.Error(codes.Unavailable, "try again")
+	results := []error{}
+	for range gcpTracePermissionDeniedThreshold - 1 {
+		results = append(results, permissionDeniedErr())
+	}
+	results = append(results, unavailable)
+	for range gcpTracePermissionDeniedThreshold - 1 {
+		results = append(results, permissionDeniedErr())
+	}
+	fake := &fakeSpanExporter{results: results}
+	exp := newCircuitBreakingTraceExporter(fake)
+
+	for range results {
+		exp.ExportSpans(context.Background(), nil)
+	}
+	if fake.exportCalls != len(results) {
+		t.Fatalf("underlying ExportSpans called %d times, want %d (breaker never tripped)", fake.exportCalls, len(results))
+	}
+}
+
+func TestCircuitBreakingTraceExporter_ShutdownDelegates(t *testing.T) {
+	fake := &fakeSpanExporter{}
+	exp := newCircuitBreakingTraceExporter(fake)
+	if err := exp.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown() = %v, want nil", err)
+	}
+	if fake.shutdownCalls != 1 {
+		t.Fatalf("underlying Shutdown called %d times, want 1", fake.shutdownCalls)
+	}
+}

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -135,7 +135,7 @@ func newTracerProvider(ctx context.Context, r *resource.Resource, telemetryOTLP 
 		if err != nil {
 			return nil, wrapGCPProjectHint(err)
 		}
-		traceOpts = append(traceOpts, tracesdk.WithBatcher(gcpExporter))
+		traceOpts = append(traceOpts, tracesdk.WithBatcher(newCircuitBreakingTraceExporter(gcpExporter)))
 	}
 	traceOpts = append(traceOpts, tracesdk.WithResource(r))
 


### PR DESCRIPTION
**1. Description**

`--telemetry-gcp`'s trace exporter (wrapped via `tracesdk.WithBatcher`) treats every export failure as transient and just retries on the next batch interval (~5s by default). A service account missing `roles/cloudtrace.agent` produces a `PermissionDenied` that will never clear on its own — IAM grants don't appear spontaneously — so the exporter spams the same `failed to export to Google Cloud Trace: rpc error: code = PermissionDenied ...` line roughly every 5 seconds for the life of the process. This is exactly the state a least-privilege deployment (metrics working, traces missing the separate role) lands in first, and it drowned out an unrelated `--log-level=DEBUG` investigation for the reporter.

Wrap the GCP trace exporter in a small circuit breaker (`circuitBreakingTraceExporter` in `internal/telemetry/gcp_trace_exporter.go`): after 3 consecutive `PermissionDenied` failures it logs one `WARN` naming the required IAM role and disables itself for the rest of the process lifetime, silently dropping further export attempts instead of calling through to the real exporter. Any other error code (`Unavailable`, `DeadlineExceeded`, etc.) always passes through unchanged and never counts toward the threshold, since those genuinely are worth retrying. A success resets the counter, so a transient blip doesn't accumulate toward tripping the breaker.

The IAM-roles documentation half of #3638 (the pair of roles required, and a callout for this exact partial-grant scenario) was already covered by #3824 — this PR addresses only the remaining "stop the noise" half (issue's suggested fix #1).

**2. PR Checklist**
- [x] Make sure to open an issue as a bug/issue before writing your code!
- [x] Ensure you have manually reviewed the entire diff before requesting a review
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary) — N/A, the docs half is already merged in #3824
- [ ] Make sure to add `!` if this involves a breaking change — not applicable

**3. Issue Reference**

Fixes #3638 🦕

## Test plan

- `go test -race ./internal/telemetry/...` — new file `gcp_trace_exporter_test.go` covers: a success passing through and resetting the counter; a non-`PermissionDenied` error always passing through without ever tripping the breaker; the breaker tripping on exactly the 3rd consecutive `PermissionDenied` and returning `nil` from then on without calling the underlying exporter again; a success or a different error code resetting the consecutive-failure count so a later `PermissionDenied` streak starts over; `Shutdown` delegating to the wrapped exporter.
- `go build ./...` and `go test ./cmd/... ./internal/...` — full build and test suite pass, no regressions.
- `go vet ./internal/telemetry/...` — clean.

## Caveats

- The one-time warning is logged via the standard `log/slog` default logger rather than this project's own `internal/log.Logger`, since threading a logger into `telemetry.SetupOTel`/`newTracerProvider` would require an import of `internal/log` at that call depth and (via `internal/util`, which already imports `internal/telemetry`) risks an import cycle if wired through the existing context-based logger accessor. Given the very narrow scope (one WARN, once, ever, only on the `--telemetry-gcp` + missing-role path), I judged the plumbing not worth the added surface — happy to revisit if a maintainer prefers it routed through the app's structured logger.
- Chose "disable permanently after 3 consecutive failures" per the issue's own suggested fix #1, rather than the "once-per-hour re-probe" alternative it also mentions — simpler, and correct for the common case (a missing IAM grant doesn't get fixed without a restart anyway, since it's read at exporter construction time).