### PR TITLE
fix(resources): normalize resource-template URI scheme to lowercase

### DIFF
--- a/internal/resources/resources.go
+++ b/internal/resources/resources.go
@@ -377,6 +377,14 @@ func (c *ResourceTemplateConfigBase) Validate() error {
 		return fmt.Errorf("missing required 'uriTemplate' field for resource template %q", c.Name)
 	}
 
+	// Normalize the scheme to lowercase for consistent comparison and usage.
+	// A url.Parse round trip is not used here (unlike ResourceConfigBase.Validate)
+	// because it corrupts RFC 6570 templates: it errors on "{" in the host for a
+	// template like "file://{path}", and percent-encodes "{"/"}" otherwise.
+	if i := strings.Index(c.URITemplate, "://"); i > 0 {
+		c.URITemplate = strings.ToLower(c.URITemplate[:i]) + c.URITemplate[i:]
+	}
+
 	// Validate RFC 6570 compliance
 	tmpl, err := uritemplate.New(c.URITemplate)
 	if err != nil {

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -198,6 +198,63 @@ annotations:
 	}
 }
 
+func TestResourceTemplateConfigBase_Validate_SchemeNormalization(t *testing.T) {
+	tests := []struct {
+		name        string
+		uriTemplate string
+		wantErr     bool
+		wantURI     string
+	}{
+		{
+			name:        "UppercaseScheme",
+			uriTemplate: "FILE://Queries/{path}",
+			wantURI:     "file://Queries/{path}",
+		},
+		{
+			name:        "MixedCaseScheme",
+			uriTemplate: "File://queries/{path}",
+			wantURI:     "file://queries/{path}",
+		},
+		{
+			name:        "AlreadyLowercase",
+			uriTemplate: "file://queries/{path}",
+			wantURI:     "file://queries/{path}",
+		},
+		{
+			name:        "NoVariable",
+			uriTemplate: "FILE://static/resource",
+			wantURI:     "file://static/resource",
+		},
+		{
+			name:        "MissingSchemeSeparator",
+			uriTemplate: "not-a-uri",
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := resources.ResourceTemplateConfigBase{
+				ConfigBase:  resources.ConfigBase{Name: "test", Type: "file"},
+				URITemplate: tt.uriTemplate,
+			}
+			err := cfg.Validate()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for URITemplate %q, got nil", tt.uriTemplate)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for URITemplate %q: %v", tt.uriTemplate, err)
+			}
+			if cfg.URITemplate != tt.wantURI {
+				t.Errorf("expected normalized URITemplate %q, got %q", tt.wantURI, cfg.URITemplate)
+			}
+		})
+	}
+}
+
 func TestStrictDecoding_Error(t *testing.T) {
 	raw := map[string]any{
 		"name":               "testResource",


### PR DESCRIPTION
## Description

`ResourceConfigBase.Validate` lowercases the scheme (and host) of a resource's `uri` and rewrites it back, but `ResourceTemplateConfigBase.Validate` never did the equivalent for `uriTemplate`. So a config like:

```yaml
uriTemplate: FILE://Queries/{path}
```

was stored exactly as written (uppercase scheme). This is minor in impact but real: the manifest advertises the uppercase scheme, and dedup on the raw template string (`internal/server/config.go`) treats `FILE://x/{path}` and `file://x/{path}` as two distinct templates instead of one.

The existing `url.Parse` round trip used by `ResourceConfigBase.Validate` can't be reused here because it corrupts RFC 6570 templates: `url.Parse("file://{path}")` errors on `{` in the host, and `url.Parse("FILE://Q/{path}")` percent-encodes `{`/`}`, breaking the `{path}` variable. This is why the existing template validation only checks a `dummy`-substituted copy and never writes it back.

Fix: lowercase only the scheme portion textually (up to the first `://`), leaving the rest of the template untouched.

## PR Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/googleapis/mcp-toolbox/blob/main/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (not required for this change)
- [ ] I ran `gofmt`/`goimports`, but this environment reports a false-positive on both touched files caused by Windows `core.autocrlf` (CRLF line endings show as a full-file diff under `gofmt -l`/`-d`, while `git diff` confirms the tracked content only has the intended lines changed)

Fixes #3992 🦕
