### PR TITLE
fix: watch tools.yaml for reload when config flag omitted

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -385,8 +385,10 @@ func resolveWatcherInputs(toolsFile string, toolsFiles []string, toolsFolder str
 		relevantFiles = toolsFiles
 	} else if toolsFolder != "" {
 		watchDirs[filepath.Clean(toolsFolder)] = true
-	} else {
+	} else if toolsFile != "" {
 		relevantFiles = []string{toolsFile}
+	} else {
+		relevantFiles = []string{"tools.yaml"}
 	}
 
 	// extract parent dir for relevant files and dedup

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -532,6 +532,14 @@ func TestResolveWatcherInputs(t *testing.T) {
 			wantWatchedFiles: map[string]bool{"tools.yaml": true},
 		},
 		{
+			description:      "no config specified (root dir)",
+			toolsFile:        "",
+			toolsFiles:       []string{},
+			toolsFolder:      "",
+			wantWatchDirs:    map[string]bool{".": true},
+			wantWatchedFiles: map[string]bool{"tools.yaml": true},
+		},
+		{
 			description:   "multiple files in different folders",
 			toolsFile:     "",
 			toolsFiles:    []string{"tools_folder/example_tools.yaml", "tools_folder2/example_tools.yaml"},


### PR DESCRIPTION
## Description

When starting Toolbox without specifying `--config`, the server correctly falls back to loading `tools.yaml`, but file modifications to `tools.yaml` don't trigger a reload. Only when `--config tools.yaml` is passed explicitly, the file changes are tracked and reloaded as expected.

## Fix

Updated `resolveWatcherInputs` in `cmd/root.go` to explicitly default `relevantFiles` to `[]string{"tools.yaml"}` when `toolsFile` is empty and no other configuration flags are set, allowing reloading to occur as expected when users run without the `--config` flag.


