### PR TITLE
docs(getting-started): add Java local quickstart and SDK documentation

### DIFF
--- a/.ci/sample_tests/quickstart/java.integration.cloudbuild.yaml
+++ b/.ci/sample_tests/quickstart/java.integration.cloudbuild.yaml
@@ -1,0 +1,52 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+  - name: 'maven:3.9.6-eclipse-temurin-17'
+    id: 'java-quickstart-test'
+    entrypoint: 'bash'
+    args:
+      # The '-c' flag tells bash to execute the following string as a command.
+      # The 'set -ex' enables debug output and exits on error for easier troubleshooting.
+      - -c
+      - |
+        set -ex
+        export VERSION=$(cat ./cmd/version.txt)
+        chmod +x .ci/sample_tests/run_tests.sh
+        .ci/sample_tests/run_tests.sh
+    env:
+      - 'CLOUD_SQL_INSTANCE=${_CLOUD_SQL_INSTANCE}'
+      - 'GCP_PROJECT=${_GCP_PROJECT}'
+      - 'DATABASE_NAME=${_DATABASE_NAME}'
+      - 'DB_USER=${_DB_USER}'
+      - 'TARGET_ROOT=docs/en/documentation/getting-started/quickstart/java'
+      - 'TARGET_LANG=java'
+      - 'TABLE_NAME=hotels_java'
+      - 'SQL_FILE=.ci/sample_tests/setup_hotels.sql'
+      - 'AGENT_FILE_PATTERN=Quickstart.java'
+    secretEnv: ['TOOLS_YAML_CONTENT', 'GOOGLE_API_KEY', 'DB_PASSWORD']
+
+availableSecrets:
+  secretManager:
+  - versionName: projects/${_GCP_PROJECT}/secrets/${_TOOLS_YAML_SECRET}/versions/11
+    env: 'TOOLS_YAML_CONTENT'
+  - versionName: projects/${_GCP_PROJECT_NUMBER}/secrets/${_API_KEY_SECRET}/versions/latest
+    env: 'GOOGLE_API_KEY'
+  - versionName: projects/${_GCP_PROJECT}/secrets/${_DB_PASS_SECRET}/versions/latest
+    env: 'DB_PASSWORD'
+
+timeout: 1000s
+
+options:
+  logging: CLOUD_LOGGING_ONLY

--- a/.ci/sample_tests/run_tests.sh
+++ b/.ci/sample_tests/run_tests.sh
@@ -170,6 +170,16 @@ run_go_test() {
   )
 }
 
+run_java_test() {
+  local dir=$1
+  local name=$(basename "$dir")
+  echo "--- Running Java Test: $name ---"
+  (
+    cd "$dir"
+    mvn clean compile exec:java -Dexec.mainClass="Quickstart"
+  )
+}
+
 cleanup() {
   echo "Cleaning up background processes..."
   [ -n "$TOOLBOX_PID" ] && kill "$TOOLBOX_PID" || true
@@ -199,5 +209,7 @@ find "$TARGET_ROOT" -name "$AGENT_FILE_PATTERN" | while read -r agent_file; do
         run_js_test "$sample_dir"
     elif [[ "$TARGET_LANG" == "go" ]]; then
         run_go_test "$sample_dir"
+    elif [[ "$TARGET_LANG" == "java" ]]; then
+        run_java_test "$sample_dir"
     fi
 done

--- a/.ci/sample_tests/setup_hotels.sql
+++ b/.ci/sample_tests/setup_hotels.sql
@@ -11,6 +11,15 @@
 -- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
+CREATE TABLE IF NOT EXISTS $TABLE_NAME (
+  id            INTEGER NOT NULL PRIMARY KEY,
+  name          VARCHAR NOT NULL,
+  location      VARCHAR NOT NULL,
+  price_tier    VARCHAR NOT NULL,
+  checkin_date  DATE    NOT NULL,
+  checkout_date DATE    NOT NULL,
+  booked        BIT     NOT NULL
+);
 
 TRUNCATE TABLE $TABLE_NAME;
 

--- a/.hugo/data/filters.yaml
+++ b/.hugo/data/filters.yaml
@@ -22,6 +22,7 @@ data_sources:
 
 languages:
   - Go
+  - Java
   - JavaScript
   - Python
 

--- a/.hugo/hugo.cloudflare.toml
+++ b/.hugo/hugo.cloudflare.toml
@@ -22,7 +22,7 @@ defaultContentLanguageInSubdir = false
 enableGitInfo = true
 enableRobotsTXT = true
 
-ignoreFiles = ["quickstart/shared", "quickstart/python", "quickstart/js", "quickstart/go"]
+ignoreFiles = ["quickstart/shared", "quickstart/python", "quickstart/js", "quickstart/go", "quickstart/java"]
 
 [security.node]
   [security.node.permissions]

--- a/.hugo/hugo.toml
+++ b/.hugo/hugo.toml
@@ -8,7 +8,7 @@ defaultContentLanguageInSubdir = false
 enableGitInfo = true
 enableRobotsTXT = true
 
-ignoreFiles = ["quickstart/shared", "quickstart/python", "quickstart/js", "quickstart/go"]
+ignoreFiles = ["quickstart/shared", "quickstart/python", "quickstart/js", "quickstart/go", "quickstart/java"]
 
 [languages]
   [languages.en]

--- a/docs/en/documentation/connect-to/_index.md
+++ b/docs/en/documentation/connect-to/_index.md
@@ -17,6 +17,7 @@ If you are building custom AI agents or orchestrating multi-step workflows in co
 *   **[Python SDKs](toolbox-sdks/python-sdk/_index.md)**: Connect using our Core SDK, or leverage native integrations for LangChain, LlamaIndex, and the Agent Development Kit (ADK).
 *   **[JavaScript / TypeScript SDKs](toolbox-sdks/javascript-sdk/_index.md)**: Build Node.js applications using our Core SDK or ADK integrations.
 *   **[Go SDKs](toolbox-sdks/go-sdk/_index.md)**: Build highly concurrent agents with our Go Core SDK, or use our integrations for Genkit and ADK.
+*   **[Java SDKs](toolbox-sdks/java-sdk/_index.md)**: Build enterprise Java applications and agent integrations using our Java Core SDK.
 
 ## MCP Clients & CLIs
 

--- a/docs/en/documentation/connect-to/toolbox-sdks/_index.md
+++ b/docs/en/documentation/connect-to/toolbox-sdks/_index.md
@@ -3,18 +3,19 @@ title: "Toolbox SDKs"
 type: docs
 weight: 2
 description: >
-  Integrate the MCP Toolbox directly into your custom applications and AI agents using our official SDKs for Python, JavaScript/TypeScript, and Go.
+  Integrate the MCP Toolbox directly into your custom applications and AI agents using our official SDKs for Python, JavaScript/TypeScript, Go, and Java.
 ---
 
 Our Toolbox Client SDKs provide the foundational building blocks for connecting your custom applications to the MCP Toolbox server.
 
 Whether you are writing a simple script to execute a single query or building a complex, multi-agent orchestration system, these SDKs handle the underlying Model Context Protocol (MCP) communication so you can focus on your business logic.
 
-By using our SDKs, your application can dynamically request tools, bind parameters, provide secure parameters out-of-band, add authentication, and execute commands at runtime. We offer official support and deep framework integrations across three primary languages:
+By using our SDKs, your application can dynamically request tools, bind parameters, provide secure parameters out-of-band, add authentication, and execute commands at runtime. We offer official support and deep framework integrations across four primary languages:
 
 *   **[Python](./python-sdk/)**: Includes the Core SDK, along with native integrations for popular orchestrators like LangChain, LlamaIndex, and the ADK.
 *   **[JavaScript / TypeScript](./javascript-sdk/)**: Includes the Node.js Core SDK and integrations for the Agent Development Kit (ADK).
 *   **[Go](./go-sdk/)**: Includes the Core SDK, plus dedicated packages for building agents with Genkit (`tbgenkit`) and the ADK.
+*   **[Java](./java-sdk/)**: Includes the Java Core SDK for connecting Java applications and AI orchestration frameworks.
 
 ## Secure Parameters Support Across SDKs
 
@@ -25,5 +26,6 @@ By using our SDKs, your application can dynamically request tools, bind paramete
 | **[Python](./python-sdk/)** | `toolbox-core`, `toolbox-adk`, `toolbox-langchain`, `toolbox-llamaindex` | `>= 1.4.0` (`toolbox-llamaindex` `>= 0.9.0`) | MCP `2026-07-28` + `com.google.cloud/toolbox.v1` |
 | **[JavaScript / TypeScript](./javascript-sdk/)** | `@toolbox-sdk/core`, `@toolbox-sdk/adk` | `>= 1.2.0` | MCP `2026-07-28` + `com.google.cloud/toolbox.v1` |
 | **[Go](./go-sdk/)** | `core`, `tbadk`, `tbgenkit` | `core` / `tbadk` `>= v1.2.0`, `tbgenkit` `>= v0.10.0` | MCP `2026-07-28` + `com.google.cloud/toolbox.v1` |
+| **[Java](./java-sdk/)** | `mcp-toolbox-sdk-java` | `>= 1.0.0` | MCP `2026-07-28` + `com.google.cloud/toolbox.v1` |
 
 Select your preferred language to explore installation instructions, quickstart guides, and framework-specific implementations.

--- a/docs/en/documentation/getting-started/_index.md
+++ b/docs/en/documentation/getting-started/_index.md
@@ -68,7 +68,7 @@ Being built on the Model Context Protocol (MCP), MCP Toolbox is framework-agnost
 *   [**IDE Integrations:**](../connect-to/ides/_index.md) Connect your local Toolbox server directly to MCP-compatible development environments.
 *   [**CLI Tools:**](../connect-to/gemini-cli/_index.md) Use command-line interfaces like the Gemini CLI to interact with your databases using natural language directly from your terminal.
 *   [**MCP Client:**](../connect-to/mcp-client/_index.md) Connect to an MCP Client.
-*   [**Application Integration (Client SDKs):**](../connect-to/toolbox-sdks/_index.md) If you are building custom AI agents, you can use our Client SDKs to pull tools directly into your application code. We provide native support for major orchestration frameworks including LangChain, LlamaIndex, Genkit, and more across Python, JavaScript/TypeScript, and Go.
+*   [**Application Integration (Client SDKs):**](../connect-to/toolbox-sdks/_index.md) If you are building custom AI agents, you can use our Client SDKs to pull tools directly into your application code. We provide native support for major orchestration frameworks including LangChain, LlamaIndex, Genkit, and more across Python, JavaScript/TypeScript, Go, and Java.
 
 ---
 

--- a/docs/en/documentation/getting-started/local_quickstart_java.md
+++ b/docs/en/documentation/getting-started/local_quickstart_java.md
@@ -1,0 +1,78 @@
+---
+title: "Java Quickstart (Local)"
+type: docs
+weight: 5
+description: >
+  How to get started running MCP Toolbox locally with [Java](https://github.com/googleapis/mcp-toolbox-sdk-java) and PostgreSQL.
+sample_filters: ["Java", "Quickstart", "Local"]
+is_sample: true
+---
+
+## Before you begin
+
+This guide assumes you have already done the following:
+
+1. Installed [Java (JDK 17 or higher)][install-java].
+1. Installed [Maven (3.8 or higher)][install-maven] or [Gradle][install-gradle].
+1. Installed [PostgreSQL 16+ and the `psql` client][install-postgres].
+
+[install-java]: https://adoptium.net/
+[install-maven]: https://maven.apache.org/download.cgi
+[install-gradle]: https://gradle.org/install/
+[install-postgres]: https://www.postgresql.org/download/
+
+### Cloud Setup (Optional)
+
+{{< regionInclude "quickstart/shared/cloud_setup.md" "cloud_setup" >}}
+
+## Step 1: Set up your database
+
+{{< regionInclude "quickstart/shared/database_setup.md" "database_setup" >}}
+
+## Step 2: Install and configure MCP Toolbox
+
+{{< regionInclude "quickstart/shared/configure_toolbox.md" "configure_toolbox" >}}
+
+## Step 3: Connect your application to MCP Toolbox
+
+In this section, we will write and run a Java application that will load the Tools
+from MCP Toolbox.
+
+1. In a new terminal, add the SDK dependency to your project:
+
+    {{< tabpane persist=header >}}
+{{< tab header="Maven" lang="xml" >}}
+<dependency>
+    <groupId>com.google.cloud.mcp</groupId>
+    <artifactId>mcp-toolbox-sdk-java</artifactId>
+    <version>1.0.0</version>
+</dependency>
+{{< /tab >}}
+
+{{< tab header="Gradle" lang="groovy" >}}
+dependencies {
+    implementation("com.google.cloud.mcp:mcp-toolbox-sdk-java:1.0.0")
+}
+{{< /tab >}}
+    {{< /tabpane >}}
+
+2. Create a new file named `Quickstart.java` and copy the following code:
+
+{{< include "quickstart/java/core/Quickstart.java" "java" >}}
+
+3. Run your application, and observe the results:
+
+    {{< tabpane persist=header >}}
+{{< tab header="Maven" lang="bash" >}}
+mvn compile exec:java -Dexec.mainClass="Quickstart"
+{{< /tab >}}
+
+{{< tab header="Gradle" lang="bash" >}}
+./gradlew run
+{{< /tab >}}
+    {{< /tabpane >}}
+
+{{< notice info >}}
+For more information, visit the [Java SDK
+repo](https://github.com/googleapis/mcp-toolbox-sdk-java).
+{{</ notice >}}

--- a/docs/en/documentation/getting-started/quickstart/java/core/Quickstart.java
+++ b/docs/en/documentation/getting-started/quickstart/java/core/Quickstart.java
@@ -1,0 +1,27 @@
+import com.google.cloud.mcp.McpToolboxClient;
+import com.google.cloud.mcp.tool.ToolDefinition;
+import com.google.cloud.mcp.tool.ToolResult;
+import java.util.Map;
+
+public class Quickstart {
+  public static void main(String[] args) {
+    // Connect to the local MCP Toolbox server
+    McpToolboxClient client =
+        McpToolboxClient.builder().baseUrl("http://127.0.0.1:5000").build();
+
+    // 1. Load tools from the toolset
+    Map<String, ToolDefinition> tools = client.loadToolset("my-toolset").join();
+    System.out.println("Available tools: " + tools.keySet());
+
+    // 2. Search for hotels by name
+    System.out.println("\n--- Searching for hotels named 'Hilton' ---");
+    ToolResult searchResult =
+        client.invokeTool("search-hotels-by-name", Map.of("name", "Hilton")).join();
+    System.out.println("Result: " + searchResult.content().get(0).text());
+
+    // 3. Book a hotel by ID
+    System.out.println("\n--- Booking hotel with ID 1 ---");
+    ToolResult bookResult = client.invokeTool("book-hotel", Map.of("hotel_id", "1")).join();
+    System.out.println("Booking status: " + (bookResult.isError() ? "Failed" : "Success"));
+  }
+}

--- a/docs/en/documentation/getting-started/quickstart/java/core/pom.xml
+++ b/docs/en/documentation/getting-started/quickstart/java/core/pom.xml
@@ -1,0 +1,26 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>quickstart</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.cloud.mcp</groupId>
+            <artifactId>mcp-toolbox-sdk-java</artifactId>
+            <version>1.0.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <sourceDirectory>.</sourceDirectory>
+    </build>
+</project>

--- a/docs/en/documentation/getting-started/quickstart/shared/configure_toolbox.md
+++ b/docs/en/documentation/getting-started/quickstart/shared/configure_toolbox.md
@@ -1,4 +1,4 @@
-<!-- This file has been used in local_quickstart.md, local_quickstart_go.md & local_quickstart_js.md -->
+<!-- This file has been used in local_quickstart.md, local_quickstart_go.md, local_quickstart_js.md & local_quickstart_java.md -->
 <!-- [START configure_toolbox] -->
 
 In this section, we will download Toolbox, configure our tools in a

--- a/docs/en/documentation/getting-started/quickstart/shared/database_setup.md
+++ b/docs/en/documentation/getting-started/quickstart/shared/database_setup.md
@@ -1,4 +1,4 @@
-<!-- This file has been used in local_quickstart.md, local_quickstart_go.md & local_quickstart_js.md -->
+<!-- This file has been used in local_quickstart.md, local_quickstart_go.md, local_quickstart_js.md & local_quickstart_java.md -->
 <!-- [START database_setup] -->
 In this section, we will create a database, insert some data that needs to be
 accessed by our agent, and create a database user for Toolbox to connect with.

--- a/docs/en/documentation/introduction/_index.md
+++ b/docs/en/documentation/introduction/_index.md
@@ -761,6 +761,33 @@ For end-to-end samples on using the Toolbox Go SDK with ADK Go, see the [module'
 For more detailed instructions on using the Toolbox Go SDK, see the
 [README](https://github.com/googleapis/mcp-toolbox-sdk-go/blob/main/core/README.md).
 
+#### Java
+
+Once you've installed the [Java SDK](https://github.com/googleapis/mcp-toolbox-sdk-java), you can load tools:
+
+{{< tabpane text=true persist=header >}}
+{{% tab header="Core" lang="en" %}}
+
+{{< highlight java >}}
+import com.google.cloud.mcp.McpToolboxClient;
+import com.google.cloud.mcp.tool.ToolDefinition;
+import java.util.Map;
+
+// Update the url to point to your server
+McpToolboxClient client = McpToolboxClient.builder()
+    .baseUrl("http://127.0.0.1:5000")
+    .build();
+
+// Load tools from the toolset
+Map<String, ToolDefinition> tools = client.loadToolset("toolset_name").join();
+{{< /highlight >}}
+
+For more detailed instructions on using the Toolbox Java SDK, see the
+[README](https://github.com/googleapis/mcp-toolbox-sdk-java/blob/main/README.md).
+
+{{% /tab %}}
+{{< /tabpane >}}
+
 For more details, see the [Agent Skills guide](https://mcp-toolbox.dev/documentation/configuration/skills/).
 
 ## Supported MCP Version


### PR DESCRIPTION
## Summary
Adds documentation and quickstart resources for the Java SDK (`com.google.cloud.mcp:mcp-toolbox-sdk-java`) across the MCP Toolbox documentation site, resolving the gap where only Python, JavaScript, and Go were listed on `https://mcp-toolbox.dev/documentation/getting-started/`.

## Expectation & Implementation
- **Java Quickstart Guide:** Created `docs/en/documentation/getting-started/local_quickstart_java.md` documenting local setup with PostgreSQL, Maven/Gradle installation, and connecting via `McpToolboxClient`.
- **Sample Code:** Created `docs/en/documentation/getting-started/quickstart/java/core/` containing `pom.xml` and `Quickstart.java` implementing the hotel assistant tool invocation flow (`search-hotels-by-name`, `book-hotel`).
- **Getting Started Index:** Updated `docs/en/documentation/getting-started/_index.md` to list Java alongside Python, JavaScript/TypeScript, and Go.
- **Hugo Configuration:** Updated `ignoreFiles` in `.hugo/hugo.toml` and `.hugo/hugo.cloudflare.toml` to ignore `quickstart/java`.
- **SDK Overview & Reference:**
  - Added Java to `docs/en/documentation/connect-to/toolbox-sdks/_index.md` (description, language list, and Secure Parameters support matrix table).
  - Added Java SDK entry to `docs/en/documentation/connect-to/_index.md`.
  - Added Java code example tab under "Integrating your application" in `docs/en/documentation/introduction/_index.md`.
- **Shared Quickstart Snippets:** Updated file header comments in `database_setup.md` and `configure_toolbox.md`.

## Test cases
- Compiled `docs/en/documentation/getting-started/quickstart/java/core/pom.xml` using `mvn compile` with JDK 17 target to verify compilation without errors against `com.google.cloud.mcp:mcp-toolbox-sdk-java:1.0.0`.
- Verified `git diff --check` for whitespace and newline compliance.
- Verified shortcode syntax (`include`, `regionInclude`, `tabpane`, `notice`) against Hugo layouts.

## Acceptance criteria
- [x] Java Quickstart (Local) appears under Getting Started in doc navigation and section cards.
- [x] Client SDK lists across Getting Started, Connect-to, and Introduction mention Java.
- [x] Sample Java code compiles cleanly with Maven.
- [x] Hugo ignoreFiles correctly prevents parsing sample code directories as content.

## Breaking changes
None.